### PR TITLE
docs(readme): add docs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Downstage
 
+[![Docs](https://img.shields.io/badge/docs-pages-firebrick)](https://jscaltreto.github.io/downstage/)
+
 A plaintext markup language for stage plays.
 
 ## What is Downstage?


### PR DESCRIPTION
## Summary
- add a Docs badge near the top of the README
- link the badge to the live GitHub Pages syntax guide

## Test Plan
- inspect README.md
- verify the badge target is https://jscaltreto.github.io/downstage/