### PR TITLE
refactor(vscode): use lsp folding ranges

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -11,7 +11,7 @@ This extension provides basic VS Code support for Downstage scripts.
 - Context-aware character cue completions from the Go LSP
 - Structural heading completions from the Go LSP
 - Snippets for play skeletons, acts, scenes, cues, stage directions, and songs
-- Improved folding for title pages, headed sections, songs, and block comments
+- Folding for title pages, sections, songs, and block comments via the Go LSP
 - Automatic cue suggestion on a fresh line after a blank separator
 - Commands to render the current script in standard or compact PDF styles
 - Commands to preview the generated PDF inside VS Code

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -46,21 +46,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 			await renderCurrentScript("condensed", "internal");
 		},
 	);
-	const foldingProvider = vscode.languages.registerFoldingRangeProvider(
-		{ language: "downstage" },
-		{
-			provideFoldingRanges(document) {
-				return provideDownstageFoldingRanges(document);
-			},
-		},
-	);
 
 	context.subscriptions.push(restartCommand);
 	context.subscriptions.push(renderCommand);
 	context.subscriptions.push(renderCompactCommand);
 	context.subscriptions.push(previewCommand);
 	context.subscriptions.push(previewCompactCommand);
-	context.subscriptions.push(foldingProvider);
 	context.subscriptions.push(renderDiagnostics);
 	context.subscriptions.push(
 		vscode.workspace.onDidChangeConfiguration(async (event) => {
@@ -260,141 +251,6 @@ function isCueSuggestionLine(document: vscode.TextDocument, line: number): boole
 
 	const previousLine = document.lineAt(line - 1).text;
 	return previousLine.trim() === "";
-}
-
-function provideDownstageFoldingRanges(document: vscode.TextDocument): vscode.FoldingRange[] {
-	const ranges: vscode.FoldingRange[] = [];
-
-	addTitlePageFoldingRanges(document, ranges);
-	addHeadingFoldingRanges(document, ranges);
-	addSongFoldingRanges(document, ranges);
-	addBlockCommentFoldingRanges(document, ranges);
-
-	return ranges;
-}
-
-function addTitlePageFoldingRanges(
-	document: vscode.TextDocument,
-	ranges: vscode.FoldingRange[],
-): void {
-	let lastTitleLine = -1;
-
-	for (let line = 0; line < document.lineCount; line++) {
-		const text = document.lineAt(line).text;
-		if (text.trim() === "") {
-			if (lastTitleLine >= 0) {
-				lastTitleLine = line;
-			}
-			continue;
-		}
-
-		if (isTitlePageLine(text)) {
-			lastTitleLine = line;
-			continue;
-		}
-		break;
-	}
-
-	if (lastTitleLine > 0) {
-		ranges.push(new vscode.FoldingRange(0, lastTitleLine, vscode.FoldingRangeKind.Region));
-	}
-}
-
-function addHeadingFoldingRanges(
-	document: vscode.TextDocument,
-	ranges: vscode.FoldingRange[],
-): void {
-	const stack: Array<{ line: number; level: number }> = [];
-
-	for (let line = 0; line < document.lineCount; line++) {
-		const level = headingLevel(document.lineAt(line).text);
-		if (level === 0) {
-			continue;
-		}
-
-		while (stack.length > 0 && stack[stack.length - 1].level >= level) {
-			const current = stack.pop();
-			if (!current) {
-				continue;
-			}
-			const endLine = line - 1;
-			if (endLine > current.line) {
-				ranges.push(new vscode.FoldingRange(current.line, endLine, vscode.FoldingRangeKind.Region));
-			}
-		}
-
-		stack.push({ line, level });
-	}
-
-	while (stack.length > 0) {
-		const current = stack.pop();
-		if (!current) {
-			continue;
-		}
-		const endLine = document.lineCount - 1;
-		if (endLine > current.line) {
-			ranges.push(new vscode.FoldingRange(current.line, endLine, vscode.FoldingRangeKind.Region));
-		}
-	}
-}
-
-function addSongFoldingRanges(
-	document: vscode.TextDocument,
-	ranges: vscode.FoldingRange[],
-): void {
-	let songStart = -1;
-
-	for (let line = 0; line < document.lineCount; line++) {
-		const text = document.lineAt(line).text.trim();
-		if (songStart < 0 && isSongStartLine(text)) {
-			songStart = line;
-			continue;
-		}
-
-		if (songStart >= 0 && text === "SONG END") {
-			if (line > songStart) {
-				ranges.push(new vscode.FoldingRange(songStart, line, vscode.FoldingRangeKind.Region));
-			}
-			songStart = -1;
-		}
-	}
-}
-
-function addBlockCommentFoldingRanges(
-	document: vscode.TextDocument,
-	ranges: vscode.FoldingRange[],
-): void {
-	let commentStart = -1;
-
-	for (let line = 0; line < document.lineCount; line++) {
-		const text = document.lineAt(line).text;
-		if (commentStart < 0 && text.includes("/*")) {
-			if (!text.includes("*/") || text.indexOf("/*") < text.indexOf("*/")) {
-				commentStart = line;
-			}
-			continue;
-		}
-
-		if (commentStart >= 0 && text.includes("*/")) {
-			if (line > commentStart) {
-				ranges.push(new vscode.FoldingRange(commentStart, line, vscode.FoldingRangeKind.Comment));
-			}
-			commentStart = -1;
-		}
-	}
-}
-
-function isTitlePageLine(text: string): boolean {
-	return /^[A-Za-z][A-Za-z ]*:\s*.*$/.test(text) || /^[ \t].+$/.test(text);
-}
-
-function headingLevel(text: string): number {
-	const match = /^(#{1,3})\s+/.exec(text);
-	return match ? match[1].length : 0;
-}
-
-function isSongStartLine(text: string): boolean {
-	return text === "SONG" || text.startsWith("SONG ") || text.startsWith("SONG:");
 }
 
 type RenderOpenMode = "config" | "internal";

--- a/internal/lsp/folding.go
+++ b/internal/lsp/folding.go
@@ -1,0 +1,87 @@
+package lsp
+
+import (
+	"strings"
+
+	"github.com/jscaltreto/downstage/internal/ast"
+	"github.com/jscaltreto/downstage/internal/parser"
+	"github.com/jscaltreto/downstage/internal/token"
+	"go.lsp.dev/protocol"
+)
+
+func computeFoldingRanges(doc *ast.Document, _ []*parser.ParseError, content string) []protocol.FoldingRange {
+	if doc == nil {
+		return nil
+	}
+
+	lineCount := strings.Count(content, "\n") + 1
+	var ranges []protocol.FoldingRange
+
+	if doc.TitlePage != nil {
+		if folding, ok := buildFoldingRange(doc.TitlePage.Range, lineCount, protocol.RegionFoldingRange); ok {
+			ranges = append(ranges, folding)
+		}
+	}
+
+	for _, node := range doc.Body {
+		ranges = append(ranges, foldingRangesForNode(node, lineCount)...)
+	}
+
+	return ranges
+}
+
+func foldingRangesForNode(node ast.Node, lineCount int) []protocol.FoldingRange {
+	var ranges []protocol.FoldingRange
+
+	switch v := node.(type) {
+	case *ast.Section:
+		if folding, ok := buildFoldingRange(v.Range, lineCount, protocol.RegionFoldingRange); ok {
+			ranges = append(ranges, folding)
+		}
+		for _, child := range v.Children {
+			ranges = append(ranges, foldingRangesForNode(child, lineCount)...)
+		}
+	case *ast.Song:
+		if folding, ok := buildFoldingRange(v.Range, lineCount, protocol.RegionFoldingRange); ok {
+			ranges = append(ranges, folding)
+		}
+		for _, child := range v.Content {
+			ranges = append(ranges, foldingRangesForNode(child, lineCount)...)
+		}
+	case *ast.Comment:
+		if !v.Block {
+			return nil
+		}
+		if folding, ok := buildFoldingRange(v.Range, lineCount, protocol.CommentFoldingRange); ok {
+			ranges = append(ranges, folding)
+		}
+	}
+
+	return ranges
+}
+
+func buildFoldingRange(r token.Range, lineCount int, kind protocol.FoldingRangeKind) (protocol.FoldingRange, bool) {
+	startLine := r.Start.Line
+	endLine := foldEndLine(r, lineCount)
+	if startLine < 0 || endLine <= startLine {
+		return protocol.FoldingRange{}, false
+	}
+
+	return protocol.FoldingRange{
+		StartLine:      uint32(startLine),
+		StartCharacter: uint32(r.Start.Column),
+		EndLine:        uint32(endLine),
+		Kind:           kind,
+	}, true
+}
+
+func foldEndLine(r token.Range, lineCount int) int {
+	endLine := r.End.Line
+	if endLine >= lineCount {
+		endLine = lineCount - 1
+	}
+	if r.End.Column == 0 && endLine > r.Start.Line {
+		endLine--
+	}
+	return endLine
+}

--- a/internal/lsp/folding_test.go
+++ b/internal/lsp/folding_test.go
@@ -1,0 +1,86 @@
+package lsp
+
+import (
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/parser"
+	"go.lsp.dev/protocol"
+)
+
+func TestComputeFoldingRanges_NilDocument(t *testing.T) {
+	ranges := computeFoldingRanges(nil, nil, "")
+	if ranges != nil {
+		t.Fatalf("expected nil ranges for nil doc, got %#v", ranges)
+	}
+}
+
+func TestComputeFoldingRanges_TitlePageSectionsSongAndBlockComment(t *testing.T) {
+	content := `Title: Play
+Author: Example
+
+# Play
+
+## ACT I
+
+### SCENE 1
+
+SONG: Ballad
+Line one
+SONG END
+
+/*
+block
+comment
+*/`
+
+	doc, errs := parser.Parse([]byte(content))
+	if len(errs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", errs)
+	}
+
+	ranges := computeFoldingRanges(doc, errs, content)
+	if len(ranges) != 6 {
+		t.Fatalf("expected 6 folding ranges, got %d", len(ranges))
+	}
+
+	assertFoldingRange(t, ranges[0], 0, 1, protocol.RegionFoldingRange)
+	assertFoldingRange(t, ranges[1], 3, 16, protocol.RegionFoldingRange)
+	assertFoldingRange(t, ranges[2], 5, 16, protocol.RegionFoldingRange)
+	assertFoldingRange(t, ranges[3], 7, 16, protocol.RegionFoldingRange)
+	assertFoldingRange(t, ranges[4], 9, 11, protocol.RegionFoldingRange)
+	assertFoldingRange(t, ranges[5], 13, 16, protocol.CommentFoldingRange)
+}
+
+func TestComputeFoldingRanges_SkipsSingleLineNodes(t *testing.T) {
+	content := `# Play
+### SCENE`
+
+	doc, errs := parser.Parse([]byte(content))
+	if len(errs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", errs)
+	}
+
+	ranges := computeFoldingRanges(doc, errs, content)
+	if len(ranges) != 1 {
+		t.Fatalf("expected 1 folding range, got %d", len(ranges))
+	}
+
+	assertFoldingRange(t, ranges[0], 0, 1, protocol.RegionFoldingRange)
+}
+
+func assertFoldingRange(
+	t *testing.T,
+	got protocol.FoldingRange,
+	startLine int,
+	endLine int,
+	kind protocol.FoldingRangeKind,
+) {
+	t.Helper()
+
+	if int(got.StartLine) != startLine || int(got.EndLine) != endLine {
+		t.Fatalf("unexpected folding range lines: got %d-%d want %d-%d", got.StartLine, got.EndLine, startLine, endLine)
+	}
+	if got.Kind != kind {
+		t.Fatalf("unexpected folding kind: got %q want %q", got.Kind, kind)
+	}
+}

--- a/internal/lsp/handler.go
+++ b/internal/lsp/handler.go
@@ -55,6 +55,8 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, req jsonrp
 		return h.handleCompletion(ctx, reply, req)
 	case protocol.MethodTextDocumentCodeAction:
 		return h.handleCodeAction(ctx, reply, req)
+	case protocol.MethodTextDocumentFoldingRange:
+		return h.handleFoldingRange(ctx, reply, req)
 	default:
 		return reply(ctx, nil, jsonrpc2.NewError(jsonrpc2.MethodNotFound, "method not found: "+method))
 	}
@@ -85,6 +87,7 @@ func (h *handler) handleInitialize(ctx context.Context, reply jsonrpc2.Replier, 
 			HoverProvider:          true,
 			DefinitionProvider:     true,
 			CodeActionProvider:     true,
+			FoldingRangeProvider:   true,
 			CompletionProvider: &protocol.CompletionOptions{
 				TriggerCharacters: []string{"@", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"},
 			},
@@ -241,6 +244,24 @@ func (h *handler) handleCodeAction(ctx context.Context, reply jsonrpc2.Replier, 
 	}
 
 	result := computeCodeActions(doc.doc, doc.content, params.TextDocument.URI, params.Context.Diagnostics, doc.diagnostics)
+	return reply(ctx, result, nil)
+}
+
+func (h *handler) handleFoldingRange(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+	var params protocol.FoldingRangeParams
+	if err := json.Unmarshal(req.Params(), &params); err != nil {
+		return reply(ctx, []protocol.FoldingRange{}, nil)
+	}
+
+	doc := h.dm.Get(params.TextDocument.URI)
+	if doc == nil {
+		return reply(ctx, []protocol.FoldingRange{}, nil)
+	}
+
+	result := computeFoldingRanges(doc.doc, doc.errors, doc.content)
+	if result == nil {
+		result = []protocol.FoldingRange{}
+	}
 	return reply(ctx, result, nil)
 }
 

--- a/internal/lsp/handler_test.go
+++ b/internal/lsp/handler_test.go
@@ -1,0 +1,93 @@
+package lsp
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/parser"
+	"go.lsp.dev/jsonrpc2"
+	"go.lsp.dev/protocol"
+)
+
+func TestHandleInitialize_AdvertisesFoldingRangeProvider(t *testing.T) {
+	h := newHandler(newDocumentManager(parserFunc(parser.Parse)), slog.Default())
+	req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), protocol.MethodInitialize, protocol.InitializeParams{})
+	if err != nil {
+		t.Fatalf("new call: %v", err)
+	}
+
+	var got protocol.InitializeResult
+	reply := func(_ context.Context, result interface{}, err error) error {
+		if err != nil {
+			t.Fatalf("unexpected reply error: %v", err)
+		}
+		typed, ok := result.(protocol.InitializeResult)
+		if !ok {
+			t.Fatalf("unexpected result type: %T", result)
+		}
+		got = typed
+		return nil
+	}
+
+	if err := h.handleInitialize(context.Background(), reply, req); err != nil {
+		t.Fatalf("handleInitialize: %v", err)
+	}
+
+	if got.Capabilities.FoldingRangeProvider != true {
+		t.Fatalf("expected folding range provider to be advertised, got %#v", got.Capabilities.FoldingRangeProvider)
+	}
+}
+
+func TestHandleFoldingRange_ReturnsComputedRanges(t *testing.T) {
+	dm := newDocumentManager(parserFunc(parser.Parse))
+	h := newHandler(dm, slog.Default())
+	uri := protocol.DocumentURI("file:///test.ds")
+	content := `Title: Play
+Author: Example
+
+# Play
+
+## ACT I
+
+### SCENE 1
+
+SONG: Ballad
+Line one
+SONG END`
+
+	dm.Open(uri, content)
+
+	req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(2), protocol.MethodTextDocumentFoldingRange, protocol.FoldingRangeParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		},
+	})
+	if err != nil {
+		t.Fatalf("new call: %v", err)
+	}
+
+	var got []protocol.FoldingRange
+	reply := func(_ context.Context, result interface{}, err error) error {
+		if err != nil {
+			t.Fatalf("unexpected reply error: %v", err)
+		}
+		typed, ok := result.([]protocol.FoldingRange)
+		if !ok {
+			t.Fatalf("unexpected result type: %T", result)
+		}
+		got = typed
+		return nil
+	}
+
+	if err := h.handleFoldingRange(context.Background(), reply, req); err != nil {
+		t.Fatalf("handleFoldingRange: %v", err)
+	}
+
+	if len(got) == 0 {
+		t.Fatal("expected folding ranges")
+	}
+	if got[0].StartLine != 0 || got[0].EndLine != 1 {
+		t.Fatalf("unexpected title page folding range: %+v", got[0])
+	}
+}


### PR DESCRIPTION
## Summary
- move folding ranges into the Go LSP and advertise the folding capability
- remove the VS Code extension's local folding grammar heuristics
- add helper-level and handler-level LSP folding tests

## Test Plan
- env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go test ./...
- npm run lint
- npm run compile
- git diff --check

## Related Issues
- Closes #19
