### PR TITLE
fix(render): render parentheticals on separate line in HTML

### DIFF
--- a/internal/render/html/css.go
+++ b/internal/render/html/css.go
@@ -122,7 +122,10 @@ body {
   margin-bottom: 0;
 }
 .downstage-parenthetical {
+  text-align: center;
   font-style: italic;
+  font-weight: normal;
+  margin-bottom: 0;
 }
 .downstage-line {
   margin: 0 8%;
@@ -332,6 +335,7 @@ body {
 .downstage-character::after { content: ". "; }
 .downstage-parenthetical {
   font-style: italic;
+  display: inline;
 }
 .downstage-line {
   display: inline;

--- a/internal/render/html/html.go
+++ b/internal/render/html/html.go
@@ -306,16 +306,15 @@ func (r *htmlRenderer) EndDualDialogue(_ *ast.DualDialogue) error {
 func (r *htmlRenderer) BeginDialogue(d *ast.Dialogue) error {
 	r.beginBlock()
 	fmt.Fprintf(&r.buf, "<div class=\"downstage-dialogue\"%s>\n", r.sourceAttr(d.NodeRange()))
-	fmt.Fprintf(&r.buf, "<p class=\"downstage-character\">%s", html.EscapeString(strings.ToUpper(d.Character)))
+	fmt.Fprintf(&r.buf, "<p class=\"downstage-character\">%s</p>\n", html.EscapeString(strings.ToUpper(d.Character)))
 	if d.Parenthetical != "" {
 		paren := d.Parenthetical
 		if len(paren) == 0 || paren[0] != '(' {
 			paren = "(" + paren + ")"
 		}
-		fmt.Fprintf(&r.buf, " <span class=\"downstage-parenthetical\">%s</span>",
+		fmt.Fprintf(&r.buf, "<p class=\"downstage-parenthetical\">%s</p>\n",
 			html.EscapeString(paren))
 	}
-	r.buf.WriteString("</p>\n")
 	return nil
 }
 

--- a/internal/render/html/html_test.go
+++ b/internal/render/html/html_test.go
@@ -88,8 +88,8 @@ func TestRender_DialogueWithFormatting(t *testing.T) {
 	out := renderHTML(t, doc)
 
 	assert.Contains(t, out, "<div class=\"downstage-dialogue\">")
-	assert.Contains(t, out, "<p class=\"downstage-character\">HAMLET")
-	assert.Contains(t, out, "<span class=\"downstage-parenthetical\">(aside)</span>")
+	assert.Contains(t, out, "<p class=\"downstage-character\">HAMLET</p>")
+	assert.Contains(t, out, "<p class=\"downstage-parenthetical\">(aside)</p>")
 	assert.Contains(t, out, "<p class=\"downstage-line\">")
 	assert.Contains(t, out, "To be, or <strong>not</strong> to be.")
 	assert.Contains(t, out, "</div>")


### PR DESCRIPTION
## Summary
- Parentheticals were rendered as an inline `<span>` inside the character name `<p>`, causing output like "BOB (cheerily)" on one line
- Changed to render as a separate `<p class="downstage-parenthetical">` element, matching PDF renderer behavior
- Updated standard CSS (centered block) and condensed CSS (`display: inline` to preserve condensed layout)

## Test plan
- [x] All 24 HTML renderer tests pass
- [ ] Verify standard HTML output shows parenthetical on its own centered line below the character name
- [ ] Verify condensed HTML output keeps parenthetical inline as expected