### PR TITLE
feat(lsp): relax unknown-character warnings for collective and conjunction cues

### DIFF
--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -16,6 +16,60 @@ const (
 	diagnosticCodeUnnumberedScene  = "unnumbered-scene"
 )
 
+// collectiveCues are conventional ensemble cue names that should not
+// produce unknown-character warnings even if absent from Dramatis Personae.
+// Keys must be uppercase.
+var collectiveCues = map[string]bool{
+	"ALL":      true,
+	"CHORUS":   true,
+	"ENSEMBLE": true,
+}
+
+// conjunctionSeps are the delimiters used to split multi-speaker cues.
+// Surrounding spaces prevent matching substrings like "SANDY".
+var conjunctionSeps = []string{" AND ", " & "}
+
+// splitConjunctionCue splits a cue like "BOB AND JANE" or "BOB & JANE"
+// into individual names. Returns nil if no conjunction is found.
+func splitConjunctionCue(name string) []string {
+	upper := strings.ToUpper(name)
+
+	var parts []string
+	offset := 0
+	for offset < len(upper) {
+		bestIdx := -1
+		bestLen := 0
+		for _, sep := range conjunctionSeps {
+			if idx := strings.Index(upper[offset:], sep); idx >= 0 && (bestIdx < 0 || idx < bestIdx) {
+				bestIdx = idx
+				bestLen = len(sep)
+			}
+		}
+		if bestIdx < 0 {
+			parts = append(parts, strings.TrimSpace(name[offset:]))
+			break
+		}
+		parts = append(parts, strings.TrimSpace(name[offset:offset+bestIdx]))
+		offset += bestIdx + bestLen
+	}
+
+	if len(parts) <= 1 {
+		return nil
+	}
+	return parts
+}
+
+func unknownCharacterDiag(r token.Range, name string) protocol.Diagnostic {
+	return protocol.Diagnostic{
+		Range:    toLSPRange(r),
+		Severity: protocol.DiagnosticSeverityWarning,
+		Code:     diagnosticCodeUnknownCharacter,
+		Source:   "downstage",
+		Message:  "unknown character: " + name + " (add to Dramatis Personae)",
+		Data:     map[string]string{"character": name},
+	}
+}
+
 // buildDiagnostics converts parser errors and additional warnings into LSP diagnostics.
 func buildDiagnostics(doc *ast.Document, errors []*parser.ParseError) []protocol.Diagnostic {
 	return buildDiagnosticsWithIndex(doc, errors, newDocumentIndex(doc))
@@ -69,16 +123,25 @@ func checkUnknownCharacters(index *documentIndex) []protocol.Diagnostic {
 		if _, ok := index.knownCharacters[name]; ok {
 			continue
 		}
-		diags = append(diags, protocol.Diagnostic{
-			Range:    toLSPRange(ref.dialogue.NameRange()),
-			Severity: protocol.DiagnosticSeverityWarning,
-			Code:     diagnosticCodeUnknownCharacter,
-			Source:   "downstage",
-			Message:  "unknown character: " + ref.dialogue.Character + " (add to Dramatis Personae)",
-			Data: map[string]string{
-				"character": ref.dialogue.Character,
-			},
-		})
+		if collectiveCues[name] {
+			continue
+		}
+
+		if parts := splitConjunctionCue(ref.dialogue.Character); parts != nil {
+			for _, part := range parts {
+				up := strings.ToUpper(part)
+				if up == "" || collectiveCues[up] {
+					continue
+				}
+				if _, ok := index.knownCharacters[up]; ok {
+					continue
+				}
+				diags = append(diags, unknownCharacterDiag(ref.dialogue.NameRange(), part))
+			}
+			continue
+		}
+
+		diags = append(diags, unknownCharacterDiag(ref.dialogue.NameRange(), ref.dialogue.Character))
 	}
 	return diags
 }

--- a/internal/lsp/diagnostics_test.go
+++ b/internal/lsp/diagnostics_test.go
@@ -243,6 +243,136 @@ func TestBuildDiagnostics_UnnumberedSceneInActResetsNumbering(t *testing.T) {
 	}
 }
 
+func testDocWithCharactersAndDialogue(knownNames []string, dialogueCharacter string) *ast.Document {
+	chars := make([]ast.Character, len(knownNames))
+	for i, name := range knownNames {
+		chars[i] = ast.Character{Name: name}
+	}
+	return &ast.Document{
+		Body: []ast.Node{
+			&ast.Section{
+				Kind:       ast.SectionDramatisPersonae,
+				Characters: chars,
+			},
+			&ast.Dialogue{
+				Character: dialogueCharacter,
+				Range: token.Range{
+					Start: token.Position{Line: 10, Column: 0},
+					End:   token.Position{Line: 12, Column: 0},
+				},
+			},
+		},
+	}
+}
+
+func TestBuildDiagnostics_CollectiveCueAll(t *testing.T) {
+	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "ALL")
+	diags := buildDiagnostics(doc, nil)
+	if len(diags) != 0 {
+		t.Errorf("expected 0 diagnostics for ALL, got %d", len(diags))
+	}
+}
+
+func TestBuildDiagnostics_CollectiveCueChorus(t *testing.T) {
+	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "CHORUS")
+	diags := buildDiagnostics(doc, nil)
+	if len(diags) != 0 {
+		t.Errorf("expected 0 diagnostics for CHORUS, got %d", len(diags))
+	}
+}
+
+func TestBuildDiagnostics_CollectiveCueEnsemble(t *testing.T) {
+	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "ENSEMBLE")
+	diags := buildDiagnostics(doc, nil)
+	if len(diags) != 0 {
+		t.Errorf("expected 0 diagnostics for ENSEMBLE, got %d", len(diags))
+	}
+}
+
+func TestBuildDiagnostics_CollectiveCueCaseInsensitive(t *testing.T) {
+	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "All")
+	diags := buildDiagnostics(doc, nil)
+	if len(diags) != 0 {
+		t.Errorf("expected 0 diagnostics for mixed-case All, got %d", len(diags))
+	}
+}
+
+func TestBuildDiagnostics_ConjunctionBothKnown(t *testing.T) {
+	doc := testDocWithCharactersAndDialogue([]string{"BOB", "JANE"}, "BOB AND JANE")
+	diags := buildDiagnostics(doc, nil)
+	if len(diags) != 0 {
+		t.Errorf("expected 0 diagnostics for conjunction of known characters, got %d", len(diags))
+	}
+}
+
+func TestBuildDiagnostics_ConjunctionAmpersandBothKnown(t *testing.T) {
+	doc := testDocWithCharactersAndDialogue([]string{"BOB", "JANE"}, "BOB & JANE")
+	diags := buildDiagnostics(doc, nil)
+	if len(diags) != 0 {
+		t.Errorf("expected 0 diagnostics for ampersand conjunction of known characters, got %d", len(diags))
+	}
+}
+
+func TestBuildDiagnostics_ConjunctionOneUnknown(t *testing.T) {
+	doc := testDocWithCharactersAndDialogue([]string{"BOB"}, "BOB AND JANE")
+	diags := buildDiagnostics(doc, nil)
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic for one unknown in conjunction, got %d", len(diags))
+	}
+	if diags[0].Message != "unknown character: JANE (add to Dramatis Personae)" {
+		t.Errorf("unexpected message: %s", diags[0].Message)
+	}
+}
+
+func TestBuildDiagnostics_ConjunctionBothUnknown(t *testing.T) {
+	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "BOB & JANE")
+	diags := buildDiagnostics(doc, nil)
+	if len(diags) != 2 {
+		t.Fatalf("expected 2 diagnostics for both unknown in conjunction, got %d", len(diags))
+	}
+}
+
+func TestBuildDiagnostics_ConjunctionWithCollective(t *testing.T) {
+	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "BOB AND ALL")
+	diags := buildDiagnostics(doc, nil)
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic (BOB only), got %d", len(diags))
+	}
+	if diags[0].Message != "unknown character: BOB (add to Dramatis Personae)" {
+		t.Errorf("unexpected message: %s", diags[0].Message)
+	}
+}
+
+func TestBuildDiagnostics_AllCollectiveConjunction(t *testing.T) {
+	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "ALL AND CHORUS")
+	diags := buildDiagnostics(doc, nil)
+	if len(diags) != 0 {
+		t.Errorf("expected 0 diagnostics for conjunction of collective cues, got %d", len(diags))
+	}
+}
+
+func TestBuildDiagnostics_MultiConjunction(t *testing.T) {
+	doc := testDocWithCharactersAndDialogue([]string{"BOB", "JANE"}, "BOB & JANE & STEVE")
+	diags := buildDiagnostics(doc, nil)
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic for STEVE, got %d", len(diags))
+	}
+	if diags[0].Message != "unknown character: STEVE (add to Dramatis Personae)" {
+		t.Errorf("unexpected message: %s", diags[0].Message)
+	}
+}
+
+func TestBuildDiagnostics_NameContainingAnd(t *testing.T) {
+	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "SANDY")
+	diags := buildDiagnostics(doc, nil)
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic for SANDY (no split), got %d", len(diags))
+	}
+	if diags[0].Message != "unknown character: SANDY (add to Dramatis Personae)" {
+		t.Errorf("unexpected message: %s", diags[0].Message)
+	}
+}
+
 func TestBuildDiagnostics_EarnestFixtureWarnsOnUnnumberedScenes(t *testing.T) {
 	content, err := os.ReadFile("../../testdata/importance_of_being_earnest.ds")
 	if err != nil {


### PR DESCRIPTION
## Summary
- Skip unknown-character warnings for conventional collective cues (ALL, CHORUS, ENSEMBLE)
- Split conjunction cues (`BOB AND JANE`, `BOB & JANE`) and validate each name individually
- Emit per-unknown diagnostics so code actions correctly offer to add only the unknown name(s)
- Existing "Add to Dramatis Personae" quick fix works without changes

## Test Plan
- [x] Collective cues (ALL, CHORUS, ENSEMBLE) produce no warning
- [x] Case-insensitive collective cue matching
- [x] Conjunction cues with all known names produce no warning (AND and &)
- [x] Conjunction with one unknown emits diagnostic for only the unknown name
- [x] Conjunction with all unknown emits one diagnostic per name
- [x] Mixed conjunction with collective cue (e.g., `BOB AND ALL`) only warns for BOB
- [x] Multi-way conjunction (`BOB & JANE & STEVE`) works correctly
- [x] Names containing "AND" substring (e.g., SANDY) are not incorrectly split
- [x] `go test ./internal/lsp/...` passes
- [x] `go vet ./internal/lsp/...` clean

Closes #28