### PR TITLE
feat: diagnose misnumbered act and scene sequences

### DIFF
--- a/internal/lsp/code_actions.go
+++ b/internal/lsp/code_actions.go
@@ -25,6 +25,7 @@ func computeCodeActions(
 	allSceneEdits := make([]protocol.TextEdit, 0)
 	seenActEdits := make(map[string]struct{})
 	seenSceneEdits := make(map[string]struct{})
+	var hasMisnumberedAct, hasMisnumberedScene bool
 
 	var (
 		dp      = ast.FindDramatisPersonae(doc.Body)
@@ -68,25 +69,32 @@ func computeCodeActions(
 					},
 				},
 			})
-		case diagnosticCodeUnnumberedAct, diagnosticCodeUnnumberedScene:
+		case diagnosticCodeUnnumberedAct, diagnosticCodeUnnumberedScene,
+			diagnosticCodeMisnumberedAct, diagnosticCodeMisnumberedScene:
 			textEdit := numberingEdit(diagnostic)
 			if textEdit == nil {
 				continue
 			}
 
 			switch diagnostic.Code {
-			case diagnosticCodeUnnumberedAct:
+			case diagnosticCodeUnnumberedAct, diagnosticCodeMisnumberedAct:
+				if diagnostic.Code == diagnosticCodeMisnumberedAct {
+					hasMisnumberedAct = true
+				}
 				if registerEdit(seenActEdits, *textEdit) {
 					allActEdits = append(allActEdits, *textEdit)
 				}
-			case diagnosticCodeUnnumberedScene:
+			case diagnosticCodeUnnumberedScene, diagnosticCodeMisnumberedScene:
+				if diagnostic.Code == diagnosticCodeMisnumberedScene {
+					hasMisnumberedScene = true
+				}
 				if registerEdit(seenSceneEdits, *textEdit) {
 					allSceneEdits = append(allSceneEdits, *textEdit)
 				}
 			}
 
 			actions = append(actions, protocol.CodeAction{
-				Title:       fmt.Sprintf("Number heading as %s", textEdit.NewText),
+				Title:       numberingActionTitle(diagnostic.Code, textEdit.NewText),
 				Kind:        protocol.QuickFix,
 				Diagnostics: []protocol.Diagnostic{diagnostic},
 				IsPreferred: true,
@@ -102,13 +110,19 @@ func computeCodeActions(
 	// Collect bulk edits from remaining diagnostics not in the context set.
 	for _, diagnostic := range allDiagnostics {
 		switch diagnostic.Code {
-		case diagnosticCodeUnnumberedAct:
+		case diagnosticCodeUnnumberedAct, diagnosticCodeMisnumberedAct:
+			if diagnostic.Code == diagnosticCodeMisnumberedAct {
+				hasMisnumberedAct = true
+			}
 			if edit := numberingEdit(diagnostic); edit != nil {
 				if registerEdit(seenActEdits, *edit) {
 					allActEdits = append(allActEdits, *edit)
 				}
 			}
-		case diagnosticCodeUnnumberedScene:
+		case diagnosticCodeUnnumberedScene, diagnosticCodeMisnumberedScene:
+			if diagnostic.Code == diagnosticCodeMisnumberedScene {
+				hasMisnumberedScene = true
+			}
 			if edit := numberingEdit(diagnostic); edit != nil {
 				if registerEdit(seenSceneEdits, *edit) {
 					allSceneEdits = append(allSceneEdits, *edit)
@@ -118,8 +132,12 @@ func computeCodeActions(
 	}
 
 	if len(allActEdits) > 1 {
+		title := "Number all acts in document"
+		if hasMisnumberedAct {
+			title = "Normalize all acts in document"
+		}
 		actions = append(actions, protocol.CodeAction{
-			Title: "Number all acts in document",
+			Title: title,
 			Kind:  protocol.QuickFix,
 			Edit: &protocol.WorkspaceEdit{
 				Changes: map[protocol.DocumentURI][]protocol.TextEdit{
@@ -130,8 +148,12 @@ func computeCodeActions(
 	}
 
 	if len(allSceneEdits) > 1 {
+		title := "Number all scenes in document"
+		if hasMisnumberedScene {
+			title = "Normalize all scenes in document"
+		}
 		actions = append(actions, protocol.CodeAction{
-			Title: "Number all scenes in document",
+			Title: title,
 			Kind:  protocol.QuickFix,
 			Edit: &protocol.WorkspaceEdit{
 				Changes: map[protocol.DocumentURI][]protocol.TextEdit{
@@ -142,6 +164,15 @@ func computeCodeActions(
 	}
 
 	return actions
+}
+
+func numberingActionTitle(code interface{}, replacement string) string {
+	switch code {
+	case diagnosticCodeMisnumberedAct, diagnosticCodeMisnumberedScene:
+		return fmt.Sprintf("Renumber heading as %s", replacement)
+	default:
+		return fmt.Sprintf("Number heading as %s", replacement)
+	}
 }
 
 func registerEdit(seen map[string]struct{}, edit protocol.TextEdit) bool {

--- a/internal/lsp/code_actions_test.go
+++ b/internal/lsp/code_actions_test.go
@@ -357,3 +357,128 @@ func TestComputeCodeActions_BareActHeadingNoTitle(t *testing.T) {
 		t.Fatalf("unexpected replacement text: %q", edits[0].NewText)
 	}
 }
+
+func TestComputeCodeActions_RenumberMisnumberedActHeading(t *testing.T) {
+	content := `# Play
+
+## ACT I
+
+## ACT I: Duplicate
+
+## ACT V: Finale`
+
+	doc, errs := parser.Parse([]byte(content))
+	if len(errs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", errs)
+	}
+
+	diagnostics := buildDiagnostics(doc, errs)
+	actions := computeCodeActions(doc, content, protocol.DocumentURI("file:///test.ds"), diagnostics, diagnostics)
+
+	var singleAction, bulkAction *protocol.CodeAction
+	for i := range actions {
+		switch actions[i].Title {
+		case "Renumber heading as ## ACT II: Duplicate":
+			singleAction = &actions[i]
+		case "Normalize all acts in document":
+			bulkAction = &actions[i]
+		}
+	}
+	if singleAction == nil {
+		t.Fatal("expected single act renumber action")
+	}
+	if bulkAction == nil {
+		t.Fatal("expected bulk act normalization action")
+	}
+
+	edits := singleAction.Edit.Changes[protocol.DocumentURI("file:///test.ds")]
+	if edits[0].NewText != "## ACT II: Duplicate" {
+		t.Fatalf("unexpected replacement text: %q", edits[0].NewText)
+	}
+
+	bulkEdits := bulkAction.Edit.Changes[protocol.DocumentURI("file:///test.ds")]
+	if len(bulkEdits) != 2 {
+		t.Fatalf("expected 2 bulk act edits, got %d", len(bulkEdits))
+	}
+}
+
+func TestComputeCodeActions_RenumberMisnumberedSceneHeading(t *testing.T) {
+	content := `# Play
+
+## ACT I
+
+### SCENE 1
+
+### SCENE 4: Garden
+
+### SCENE 7: Finale`
+
+	doc, errs := parser.Parse([]byte(content))
+	if len(errs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", errs)
+	}
+
+	diagnostics := buildDiagnostics(doc, errs)
+	actions := computeCodeActions(doc, content, protocol.DocumentURI("file:///test.ds"), diagnostics, diagnostics)
+
+	var singleAction, bulkAction *protocol.CodeAction
+	for i := range actions {
+		switch actions[i].Title {
+		case "Renumber heading as ### SCENE 2: Garden":
+			singleAction = &actions[i]
+		case "Normalize all scenes in document":
+			bulkAction = &actions[i]
+		}
+	}
+	if singleAction == nil {
+		t.Fatal("expected single scene renumber action")
+	}
+	if bulkAction == nil {
+		t.Fatal("expected bulk scene normalization action")
+	}
+
+	edits := singleAction.Edit.Changes[protocol.DocumentURI("file:///test.ds")]
+	if edits[0].NewText != "### SCENE 2: Garden" {
+		t.Fatalf("unexpected replacement text: %q", edits[0].NewText)
+	}
+
+	bulkEdits := bulkAction.Edit.Changes[protocol.DocumentURI("file:///test.ds")]
+	if len(bulkEdits) != 2 {
+		t.Fatalf("expected 2 bulk scene edits, got %d", len(bulkEdits))
+	}
+}
+
+func TestComputeCodeActions_RenumberMisnumberedSceneOutsideActs(t *testing.T) {
+	content := `# Play
+
+## SCENE 1
+
+## SCENE 3: Out of Order`
+
+	doc, errs := parser.Parse([]byte(content))
+	if len(errs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", errs)
+	}
+
+	diagnostics := buildDiagnostics(doc, errs)
+	actions := computeCodeActions(doc, content, protocol.DocumentURI("file:///test.ds"), diagnostics, diagnostics)
+
+	var singleAction *protocol.CodeAction
+	for i := range actions {
+		if actions[i].Title == "Renumber heading as ## SCENE 2: Out of Order" {
+			singleAction = &actions[i]
+			break
+		}
+	}
+	if singleAction == nil {
+		t.Fatal("expected scene renumber action outside acts")
+	}
+
+	edits := singleAction.Edit.Changes[protocol.DocumentURI("file:///test.ds")]
+	if len(edits) != 1 {
+		t.Fatalf("expected 1 text edit, got %d", len(edits))
+	}
+	if edits[0].NewText != "## SCENE 2: Out of Order" {
+		t.Fatalf("unexpected replacement text: %q", edits[0].NewText)
+	}
+}

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -14,6 +15,8 @@ const (
 	diagnosticCodeUnknownCharacter = "unknown-character"
 	diagnosticCodeUnnumberedAct    = "unnumbered-act"
 	diagnosticCodeUnnumberedScene  = "unnumbered-scene"
+	diagnosticCodeMisnumberedAct   = "misnumbered-act"
+	diagnosticCodeMisnumberedScene = "misnumbered-scene"
 )
 
 // collectiveCues are conventional ensemble cue names that should not
@@ -152,12 +155,20 @@ func checkUnnumberedSections(index *documentIndex) []protocol.Diagnostic {
 	for actNumber, act := range index.acts {
 		if d := unnumberedActDiagnostic(act, actNumber+1); d != nil {
 			diags = append(diags, *d)
+			continue
+		}
+		if d := misnumberedActDiagnostic(act, actNumber+1); d != nil {
+			diags = append(diags, *d)
 		}
 	}
 
 	for _, scene := range index.scenes {
 		number := index.sceneNumbers[scene]
 		if d := unnumberedSceneDiagnostic(scene, number); d != nil {
+			diags = append(diags, *d)
+			continue
+		}
+		if d := misnumberedSceneDiagnostic(scene, number); d != nil {
 			diags = append(diags, *d)
 		}
 	}
@@ -183,6 +194,25 @@ func unnumberedActDiagnostic(section *ast.Section, actNumber int) *protocol.Diag
 	}
 }
 
+func misnumberedActDiagnostic(section *ast.Section, expected int) *protocol.Diagnostic {
+	actual, ok := parseRomanNumeral(section.Number)
+	if ok && actual == expected {
+		return nil
+	}
+
+	replacement := formatSectionHeading(section, romanNumeral(expected))
+	return &protocol.Diagnostic{
+		Range:    toLSPRange(section.HeadingRange()),
+		Severity: protocol.DiagnosticSeverityWarning,
+		Code:     diagnosticCodeMisnumberedAct,
+		Source:   "downstage",
+		Message:  fmt.Sprintf("act heading should be ACT %s in document order", romanNumeral(expected)),
+		Data: map[string]string{
+			"replacement": replacement,
+		},
+	}
+}
+
 func unnumberedSceneDiagnostic(section *ast.Section, sceneNumber int) *protocol.Diagnostic {
 	if strings.TrimSpace(section.Number) != "" {
 		return nil
@@ -201,6 +231,25 @@ func unnumberedSceneDiagnostic(section *ast.Section, sceneNumber int) *protocol.
 	}
 }
 
+func misnumberedSceneDiagnostic(section *ast.Section, expected int) *protocol.Diagnostic {
+	actual, ok := parseSceneNumber(section.Number)
+	if ok && actual == expected {
+		return nil
+	}
+
+	replacement := formatSectionHeading(section, strconv.Itoa(expected))
+	return &protocol.Diagnostic{
+		Range:    toLSPRange(section.HeadingRange()),
+		Severity: protocol.DiagnosticSeverityWarning,
+		Code:     diagnosticCodeMisnumberedScene,
+		Source:   "downstage",
+		Message:  fmt.Sprintf("scene heading should be SCENE %d in sequence", expected),
+		Data: map[string]string{
+			"replacement": replacement,
+		},
+	}
+}
+
 func formatSectionHeading(section *ast.Section, number string) string {
 	marker := strings.Repeat("#", section.Level)
 	title := strings.TrimSpace(section.Title)
@@ -213,6 +262,59 @@ func formatSectionHeading(section *ast.Section, number string) string {
 	default:
 		return marker + " " + title
 	}
+}
+
+func parseSceneNumber(raw string) (int, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, false
+	}
+
+	number, err := strconv.Atoi(raw)
+	if err != nil || number <= 0 {
+		return 0, false
+	}
+
+	return number, true
+}
+
+func parseRomanNumeral(raw string) (int, bool) {
+	raw = strings.ToUpper(strings.TrimSpace(raw))
+	if raw == "" {
+		return 0, false
+	}
+
+	values := map[byte]int{
+		'I': 1,
+		'V': 5,
+		'X': 10,
+		'L': 50,
+		'C': 100,
+		'D': 500,
+		'M': 1000,
+	}
+
+	total := 0
+	for i := 0; i < len(raw); i++ {
+		value, ok := values[raw[i]]
+		if !ok {
+			return 0, false
+		}
+		if i+1 < len(raw) {
+			nextValue := values[raw[i+1]]
+			if value < nextValue {
+				total -= value
+				continue
+			}
+		}
+		total += value
+	}
+
+	if total <= 0 || romanNumeral(total) != raw {
+		return 0, false
+	}
+
+	return total, true
 }
 
 func toLSPRange(r token.Range) protocol.Range {

--- a/internal/lsp/diagnostics_test.go
+++ b/internal/lsp/diagnostics_test.go
@@ -398,3 +398,166 @@ func TestBuildDiagnostics_EarnestFixtureWarnsOnUnnumberedScenes(t *testing.T) {
 		t.Fatalf("expected 3 unnumbered scene warnings, got %d", sceneWarnings)
 	}
 }
+
+func TestBuildDiagnostics_MisnumberedActsWarn(t *testing.T) {
+	content := `# Play
+
+## ACT I
+
+## ACT I: Duplicate
+
+## ACT IV: Finale`
+
+	doc, errs := parser.Parse([]byte(content))
+	if len(errs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", errs)
+	}
+
+	diags := buildDiagnostics(doc, errs)
+
+	var replacements []string
+	for _, diag := range diags {
+		if diag.Code != diagnosticCodeMisnumberedAct {
+			continue
+		}
+		if diag.Severity != protocol.DiagnosticSeverityWarning {
+			t.Fatalf("expected warning severity, got %v", diag.Severity)
+		}
+		if diag.Range.Start.Line != diag.Range.End.Line {
+			t.Fatalf("expected heading-only diagnostic range, got %+v", diag.Range)
+		}
+		data, ok := diag.Data.(map[string]string)
+		if !ok {
+			t.Fatalf("unexpected diagnostic data: %#v", diag.Data)
+		}
+		replacements = append(replacements, data["replacement"])
+	}
+
+	if len(replacements) != 2 {
+		t.Fatalf("expected 2 misnumbered act diagnostics, got %d", len(replacements))
+	}
+	if replacements[0] != "## ACT II: Duplicate" {
+		t.Fatalf("unexpected duplicate-act replacement: %q", replacements[0])
+	}
+	if replacements[1] != "## ACT III: Finale" {
+		t.Fatalf("unexpected skipped-act replacement: %q", replacements[1])
+	}
+}
+
+func TestBuildDiagnostics_MisnumberedScenesWarnAndResetByAct(t *testing.T) {
+	content := `# Play
+
+## ACT I
+
+### SCENE 1
+
+### SCENE 1: Duplicate
+
+### SCENE 4: Skipped
+
+## ACT II
+
+### SCENE 4: Should Reset`
+
+	doc, errs := parser.Parse([]byte(content))
+	if len(errs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", errs)
+	}
+
+	diags := buildDiagnostics(doc, errs)
+
+	var replacements []string
+	for _, diag := range diags {
+		if diag.Code != diagnosticCodeMisnumberedScene {
+			continue
+		}
+		data, ok := diag.Data.(map[string]string)
+		if !ok {
+			t.Fatalf("unexpected diagnostic data: %#v", diag.Data)
+		}
+		replacements = append(replacements, data["replacement"])
+	}
+
+	if len(replacements) != 3 {
+		t.Fatalf("expected 3 misnumbered scene diagnostics, got %d", len(replacements))
+	}
+	if replacements[0] != "### SCENE 2: Duplicate" {
+		t.Fatalf("unexpected duplicate-scene replacement: %q", replacements[0])
+	}
+	if replacements[1] != "### SCENE 3: Skipped" {
+		t.Fatalf("unexpected skipped-scene replacement: %q", replacements[1])
+	}
+	if replacements[2] != "### SCENE 1: Should Reset" {
+		t.Fatalf("unexpected reset-scene replacement: %q", replacements[2])
+	}
+}
+
+func TestBuildDiagnostics_MisnumberedScenesOutsideActsUseDocumentOrder(t *testing.T) {
+	content := `# Play
+
+## SCENE 1
+
+## SCENE 3: Out of Order`
+
+	doc, errs := parser.Parse([]byte(content))
+	if len(errs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", errs)
+	}
+
+	diags := buildDiagnostics(doc, errs)
+
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+	if diags[0].Code != diagnosticCodeMisnumberedScene {
+		t.Fatalf("expected misnumbered scene diagnostic, got %#v", diags[0].Code)
+	}
+	data, ok := diags[0].Data.(map[string]string)
+	if !ok {
+		t.Fatalf("unexpected diagnostic data: %#v", diags[0].Data)
+	}
+	if data["replacement"] != "## SCENE 2: Out of Order" {
+		t.Fatalf("unexpected scene replacement: %q", data["replacement"])
+	}
+}
+
+func TestBuildDiagnostics_MisnumberedScenesWarnOnBackwardOrderWithinAct(t *testing.T) {
+	content := `# Play
+
+## ACT I
+
+### SCENE 1
+
+### SCENE 3
+
+### SCENE 2: Backward`
+
+	doc, errs := parser.Parse([]byte(content))
+	if len(errs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", errs)
+	}
+
+	diags := buildDiagnostics(doc, errs)
+
+	var replacements []string
+	for _, diag := range diags {
+		if diag.Code != diagnosticCodeMisnumberedScene {
+			continue
+		}
+		data, ok := diag.Data.(map[string]string)
+		if !ok {
+			t.Fatalf("unexpected diagnostic data: %#v", diag.Data)
+		}
+		replacements = append(replacements, data["replacement"])
+	}
+
+	if len(replacements) != 2 {
+		t.Fatalf("expected 2 misnumbered scene diagnostics, got %d", len(replacements))
+	}
+	if replacements[0] != "### SCENE 2" {
+		t.Fatalf("unexpected forward-gap replacement: %q", replacements[0])
+	}
+	if replacements[1] != "### SCENE 3: Backward" {
+		t.Fatalf("unexpected backward-order replacement: %q", replacements[1])
+	}
+}


### PR DESCRIPTION
## Summary
- add LSP warnings for duplicate, skipped, out-of-order, and reset-broken act/scene numbering
- add single-heading renumber fixes and bulk normalization actions for misnumbered sequences
- cover diagnostics and code actions with focused LSP tests

## Test Plan
- env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go test ./...

## Related Issues
Closes #26