### PR TITLE
test(core): add coverage for issue 23

### DIFF
--- a/internal/ast/walk_test.go
+++ b/internal/ast/walk_test.go
@@ -1,0 +1,107 @@
+package ast
+
+import "testing"
+
+type recordingVisitor struct {
+	visited []string
+	stopAt  map[string]bool
+}
+
+func (v *recordingVisitor) Visit(node Node) Visitor {
+	v.visited = append(v.visited, node.nodeType())
+	if v.stopAt[node.nodeType()] {
+		return nil
+	}
+	return v
+}
+
+func TestWalk_VisitsNodesDepthFirst(t *testing.T) {
+	doc := &Document{
+		TitlePage: &TitlePage{},
+		Body: []Node{
+			&Section{
+				Children: []Node{
+					&Dialogue{
+						Lines: []DialogueLine{
+							{
+								Content: []Inline{
+									&TextNode{Value: "plain"},
+									&BoldNode{Content: []Inline{&TextNode{Value: "bold"}}},
+								},
+							},
+						},
+					},
+				},
+				Lines: []SectionLine{
+					{Content: []Inline{&InlineDirectionNode{Content: []Inline{&TextNode{Value: "aside"}}}}},
+				},
+				order: []sectionItemRef{
+					{kind: SectionItemLine, index: 0},
+					{kind: SectionItemNode, index: 0},
+				},
+			},
+		},
+	}
+
+	visitor := &recordingVisitor{}
+	Walk(visitor, doc)
+
+	expected := []string{
+		"Document",
+		"TitlePage",
+		"Section",
+		"InlineDirectionNode",
+		"TextNode",
+		"Dialogue",
+		"TextNode",
+		"BoldNode",
+		"TextNode",
+	}
+
+	if len(visitor.visited) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, visitor.visited)
+	}
+	for i := range expected {
+		if visitor.visited[i] != expected[i] {
+			t.Fatalf("expected %v, got %v", expected, visitor.visited)
+		}
+	}
+}
+
+func TestWalk_StopVisitorPreventsChildTraversal(t *testing.T) {
+	doc := &Document{
+		Body: []Node{
+			&Section{
+				Children: []Node{
+					&Dialogue{
+						Lines: []DialogueLine{
+							{Content: []Inline{&TextNode{Value: "hidden"}}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	visitor := &recordingVisitor{stopAt: map[string]bool{"Section": true}}
+	Walk(visitor, doc)
+
+	expected := []string{"Document", "Section"}
+	if len(visitor.visited) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, visitor.visited)
+	}
+	for i := range expected {
+		if visitor.visited[i] != expected[i] {
+			t.Fatalf("expected %v, got %v", expected, visitor.visited)
+		}
+	}
+}
+
+func TestWalk_NilNodeDoesNothing(t *testing.T) {
+	visitor := &recordingVisitor{}
+	Walk(visitor, nil)
+
+	if len(visitor.visited) != 0 {
+		t.Fatalf("expected no visits, got %v", visitor.visited)
+	}
+}

--- a/internal/lsp/handler_test.go
+++ b/internal/lsp/handler_test.go
@@ -2,6 +2,7 @@ package lsp
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"testing"
 
@@ -10,12 +11,73 @@ import (
 	"go.lsp.dev/protocol"
 )
 
-func TestHandleInitialize_AdvertisesFoldingRangeProvider(t *testing.T) {
-	h := newHandler(newDocumentManager(parserFunc(parser.Parse)), slog.Default())
-	req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), protocol.MethodInitialize, protocol.InitializeParams{})
+type recordingConn struct {
+	methods []string
+	params  []interface{}
+}
+
+func (c *recordingConn) Call(context.Context, string, interface{}, interface{}) (jsonrpc2.ID, error) {
+	return jsonrpc2.NewNumberID(0), nil
+}
+
+func (c *recordingConn) Notify(_ context.Context, method string, params interface{}) error {
+	c.methods = append(c.methods, method)
+	c.params = append(c.params, params)
+	return nil
+}
+
+func (c *recordingConn) Go(context.Context, jsonrpc2.Handler) {}
+func (c *recordingConn) Close() error                         { return nil }
+func (c *recordingConn) Done() <-chan struct{}                { return nil }
+func (c *recordingConn) Err() error                           { return nil }
+
+type replyRecorder struct {
+	result interface{}
+	err    error
+}
+
+func (r *replyRecorder) replier(_ context.Context, result interface{}, err error) error {
+	r.result = result
+	r.err = err
+	return nil
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newTestHandler() (*handler, *recordingConn) {
+	dm := newDocumentManager(parserFunc(parser.Parse))
+	conn := &recordingConn{}
+	h := newHandler(dm, testLogger())
+	h.conn = conn
+	h.cancel = func() {}
+	return h, conn
+}
+
+func newCall(t *testing.T, id int, method string, params interface{}) jsonrpc2.Request {
+	t.Helper()
+
+	req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(int32(id)), method, params)
 	if err != nil {
 		t.Fatalf("new call: %v", err)
 	}
+	return req
+}
+
+func newNotification(t *testing.T, method string, params interface{}) jsonrpc2.Request {
+	t.Helper()
+
+	req, err := jsonrpc2.NewNotification(method, params)
+	if err != nil {
+		t.Fatalf("new notification: %v", err)
+	}
+	return req
+}
+
+func TestHandleInitialize_AdvertisesFoldingRangeProvider(t *testing.T) {
+	h, _ := newTestHandler()
+	req := newCall(t, 1, protocol.MethodInitialize, protocol.InitializeParams{})
 
 	var got protocol.InitializeResult
 	reply := func(_ context.Context, result interface{}, err error) error {
@@ -39,9 +101,289 @@ func TestHandleInitialize_AdvertisesFoldingRangeProvider(t *testing.T) {
 	}
 }
 
+func TestHandle_UnknownMethodReturnsMethodNotFound(t *testing.T) {
+	h, _ := newTestHandler()
+	req := newNotification(t, "$/downstage-unknown", map[string]string{"noop": "true"})
+	var reply replyRecorder
+
+	if err := h.Handle(context.Background(), reply.replier, req); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	if reply.result != nil {
+		t.Fatalf("expected nil result, got %#v", reply.result)
+	}
+	rpcErr, ok := reply.err.(*jsonrpc2.Error)
+	if !ok {
+		t.Fatalf("expected jsonrpc2 error, got %T", reply.err)
+	}
+	if rpcErr == nil {
+		t.Fatal("expected method not found error")
+	}
+	if rpcErr.Code != jsonrpc2.MethodNotFound {
+		t.Fatalf("expected method not found code, got %d", rpcErr.Code)
+	}
+}
+
+func TestHandleDidOpenDidChangeAndDidCloseManageDocumentLifecycle(t *testing.T) {
+	h, conn := newTestHandler()
+	uri := protocol.DocumentURI("file:///test.ds")
+	reply := &replyRecorder{}
+
+	openReq := newNotification(t, protocol.MethodTextDocumentDidOpen, protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{
+			URI:  uri,
+			Text: "# Play\n\nHAMLET\nHello.",
+		},
+	})
+	if err := h.handleDidOpen(context.Background(), reply.replier, openReq); err != nil {
+		t.Fatalf("handleDidOpen: %v", err)
+	}
+
+	doc := h.dm.Get(uri)
+	if doc == nil {
+		t.Fatal("expected open document to be tracked")
+	}
+	if doc.content != "# Play\n\nHAMLET\nHello." {
+		t.Fatalf("unexpected open content: %q", doc.content)
+	}
+	if len(conn.methods) != 1 || conn.methods[0] != protocol.MethodTextDocumentPublishDiagnostics {
+		t.Fatalf("expected one diagnostics publish, got %v", conn.methods)
+	}
+
+	changeReq := newNotification(t, protocol.MethodTextDocumentDidChange, protocol.DidChangeTextDocumentParams{
+		TextDocument: protocol.VersionedTextDocumentIdentifier{TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: uri}},
+		ContentChanges: []protocol.TextDocumentContentChangeEvent{
+			{Text: "# Play\n\nHAMLET\nUpdated."},
+		},
+	})
+	if err := h.handleDidChange(context.Background(), reply.replier, changeReq); err != nil {
+		t.Fatalf("handleDidChange: %v", err)
+	}
+
+	doc = h.dm.Get(uri)
+	if doc == nil {
+		t.Fatal("expected changed document to remain tracked")
+	}
+	if doc.content != "# Play\n\nHAMLET\nUpdated." {
+		t.Fatalf("unexpected changed content: %q", doc.content)
+	}
+	if len(conn.methods) != 2 {
+		t.Fatalf("expected two diagnostics publishes after change, got %d", len(conn.methods))
+	}
+
+	closeReq := newNotification(t, protocol.MethodTextDocumentDidClose, protocol.DidCloseTextDocumentParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+	})
+	if err := h.handleDidClose(context.Background(), reply.replier, closeReq); err != nil {
+		t.Fatalf("handleDidClose: %v", err)
+	}
+
+	if got := h.dm.Get(uri); got != nil {
+		t.Fatal("expected close to remove the document")
+	}
+	if len(conn.methods) != 3 {
+		t.Fatalf("expected three diagnostics publishes after close, got %d", len(conn.methods))
+	}
+
+	lastParams, ok := conn.params[2].(protocol.PublishDiagnosticsParams)
+	if !ok {
+		t.Fatalf("unexpected diagnostics params type: %T", conn.params[2])
+	}
+	if len(lastParams.Diagnostics) != 0 {
+		t.Fatalf("expected close to clear diagnostics, got %#v", lastParams.Diagnostics)
+	}
+}
+
+func TestHandleSemanticTokensFull_ReturnsEmptyTokensWhenDocumentMissing(t *testing.T) {
+	h, _ := newTestHandler()
+	req := newCall(t, 2, protocol.MethodSemanticTokensFull, protocol.SemanticTokensParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentURI("file:///missing.ds")},
+	})
+	var reply replyRecorder
+
+	if err := h.handleSemanticTokensFull(context.Background(), reply.replier, req); err != nil {
+		t.Fatalf("handleSemanticTokensFull: %v", err)
+	}
+
+	tokens, ok := reply.result.(*protocol.SemanticTokens)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", reply.result)
+	}
+	if len(tokens.Data) != 0 {
+		t.Fatalf("expected no semantic tokens, got %#v", tokens.Data)
+	}
+}
+
+func TestHandleDocumentRoutes_ReturnEmptyResultsWhenDocumentMissing(t *testing.T) {
+	h, _ := newTestHandler()
+	tests := []struct {
+		name   string
+		method string
+		req    jsonrpc2.Request
+		check  func(*testing.T, interface{})
+	}{
+		{
+			name:   "document symbols",
+			method: protocol.MethodTextDocumentDocumentSymbol,
+			req: newCall(t, 3, protocol.MethodTextDocumentDocumentSymbol, protocol.DocumentSymbolParams{
+				TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentURI("file:///missing.ds")},
+			}),
+			check: func(t *testing.T, result interface{}) {
+				t.Helper()
+				symbols, ok := result.([]protocol.DocumentSymbol)
+				if !ok {
+					t.Fatalf("unexpected result type: %T", result)
+				}
+				if len(symbols) != 0 {
+					t.Fatalf("expected no symbols, got %#v", symbols)
+				}
+			},
+		},
+		{
+			name:   "hover",
+			method: protocol.MethodTextDocumentHover,
+			req: newCall(t, 4, protocol.MethodTextDocumentHover, protocol.HoverParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentURI("file:///missing.ds")},
+				},
+			}),
+			check: func(t *testing.T, result interface{}) {
+				t.Helper()
+				if result != nil {
+					t.Fatalf("expected nil hover, got %#v", result)
+				}
+			},
+		},
+		{
+			name:   "definition",
+			method: protocol.MethodTextDocumentDefinition,
+			req: newCall(t, 5, protocol.MethodTextDocumentDefinition, protocol.DefinitionParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentURI("file:///missing.ds")},
+				},
+			}),
+			check: func(t *testing.T, result interface{}) {
+				t.Helper()
+				if result != nil {
+					t.Fatalf("expected nil definition, got %#v", result)
+				}
+			},
+		},
+		{
+			name:   "completion",
+			method: protocol.MethodTextDocumentCompletion,
+			req: newCall(t, 6, protocol.MethodTextDocumentCompletion, protocol.CompletionParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentURI("file:///missing.ds")},
+				},
+			}),
+			check: func(t *testing.T, result interface{}) {
+				t.Helper()
+				list, ok := result.(*protocol.CompletionList)
+				if !ok {
+					t.Fatalf("unexpected result type: %T", result)
+				}
+				if len(list.Items) != 0 {
+					t.Fatalf("expected no completion items, got %#v", list.Items)
+				}
+			},
+		},
+		{
+			name:   "code action",
+			method: protocol.MethodTextDocumentCodeAction,
+			req: newCall(t, 7, protocol.MethodTextDocumentCodeAction, protocol.CodeActionParams{
+				TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentURI("file:///missing.ds")},
+			}),
+			check: func(t *testing.T, result interface{}) {
+				t.Helper()
+				actions, ok := result.([]protocol.CodeAction)
+				if !ok {
+					t.Fatalf("unexpected result type: %T", result)
+				}
+				if len(actions) != 0 {
+					t.Fatalf("expected no code actions, got %#v", actions)
+				}
+			},
+		},
+		{
+			name:   "folding range",
+			method: protocol.MethodTextDocumentFoldingRange,
+			req: newCall(t, 8, protocol.MethodTextDocumentFoldingRange, protocol.FoldingRangeParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentURI("file:///missing.ds")},
+				},
+			}),
+			check: func(t *testing.T, result interface{}) {
+				t.Helper()
+				ranges, ok := result.([]protocol.FoldingRange)
+				if !ok {
+					t.Fatalf("unexpected result type: %T", result)
+				}
+				if len(ranges) != 0 {
+					t.Fatalf("expected no folding ranges, got %#v", ranges)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var reply replyRecorder
+
+			switch tt.method {
+			case protocol.MethodTextDocumentDocumentSymbol:
+				if err := h.handleDocumentSymbol(context.Background(), reply.replier, tt.req); err != nil {
+					t.Fatalf("handleDocumentSymbol: %v", err)
+				}
+			case protocol.MethodTextDocumentHover:
+				if err := h.handleHover(context.Background(), reply.replier, tt.req); err != nil {
+					t.Fatalf("handleHover: %v", err)
+				}
+			case protocol.MethodTextDocumentDefinition:
+				if err := h.handleDefinition(context.Background(), reply.replier, tt.req); err != nil {
+					t.Fatalf("handleDefinition: %v", err)
+				}
+			case protocol.MethodTextDocumentCompletion:
+				if err := h.handleCompletion(context.Background(), reply.replier, tt.req); err != nil {
+					t.Fatalf("handleCompletion: %v", err)
+				}
+			case protocol.MethodTextDocumentCodeAction:
+				if err := h.handleCodeAction(context.Background(), reply.replier, tt.req); err != nil {
+					t.Fatalf("handleCodeAction: %v", err)
+				}
+			case protocol.MethodTextDocumentFoldingRange:
+				if err := h.handleFoldingRange(context.Background(), reply.replier, tt.req); err != nil {
+					t.Fatalf("handleFoldingRange: %v", err)
+				}
+			}
+
+			tt.check(t, reply.result)
+		})
+	}
+}
+
+func TestHandleCompletion_BadParamsReturnEmptyCompletionList(t *testing.T) {
+	h, _ := newTestHandler()
+	req := newNotification(t, protocol.MethodTextDocumentCompletion, []string{"bad"})
+	var reply replyRecorder
+
+	if err := h.handleCompletion(context.Background(), reply.replier, req); err != nil {
+		t.Fatalf("handleCompletion: %v", err)
+	}
+
+	list, ok := reply.result.(*protocol.CompletionList)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", reply.result)
+	}
+	if len(list.Items) != 0 {
+		t.Fatalf("expected no completion items, got %#v", list.Items)
+	}
+}
+
 func TestHandleFoldingRange_ReturnsComputedRanges(t *testing.T) {
 	dm := newDocumentManager(parserFunc(parser.Parse))
-	h := newHandler(dm, slog.Default())
+	h := newHandler(dm, testLogger())
 	uri := protocol.DocumentURI("file:///test.ds")
 	content := `Title: Play
 Author: Example
@@ -58,14 +400,11 @@ SONG END`
 
 	dm.Open(uri, content)
 
-	req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(2), protocol.MethodTextDocumentFoldingRange, protocol.FoldingRangeParams{
+	req := newCall(t, 9, protocol.MethodTextDocumentFoldingRange, protocol.FoldingRangeParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 		},
 	})
-	if err != nil {
-		t.Fatalf("new call: %v", err)
-	}
 
 	var got []protocol.FoldingRange
 	reply := func(_ context.Context, result interface{}, err error) error {
@@ -89,5 +428,139 @@ SONG END`
 	}
 	if got[0].StartLine != 0 || got[0].EndLine != 1 {
 		t.Fatalf("unexpected title page folding range: %+v", got[0])
+	}
+}
+
+func TestPublishDiagnostics_NormalizesNilDiagnosticSlice(t *testing.T) {
+	h, conn := newTestHandler()
+	uri := protocol.DocumentURI("file:///test.ds")
+
+	if err := h.publishDiagnostics(context.Background(), uri, nil); err != nil {
+		t.Fatalf("publishDiagnostics: %v", err)
+	}
+
+	params, ok := conn.params[0].(protocol.PublishDiagnosticsParams)
+	if !ok {
+		t.Fatalf("unexpected params type: %T", conn.params[0])
+	}
+	if params.Diagnostics == nil {
+		t.Fatal("expected diagnostics slice to be normalized to empty")
+	}
+}
+
+func TestHandleDispatchesInitializeThroughTopLevelHandle(t *testing.T) {
+	h, _ := newTestHandler()
+	req := newCall(t, 10, protocol.MethodInitialize, protocol.InitializeParams{})
+	var reply replyRecorder
+
+	if err := h.Handle(context.Background(), reply.replier, req); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	result, ok := reply.result.(protocol.InitializeResult)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", reply.result)
+	}
+	if result.ServerInfo == nil || result.ServerInfo.Name != "downstage-lsp" {
+		t.Fatalf("unexpected server info: %#v", result.ServerInfo)
+	}
+}
+
+func TestHandleDidOpen_BadParamsDoNotPublishDiagnostics(t *testing.T) {
+	h, conn := newTestHandler()
+	req := newNotification(t, protocol.MethodTextDocumentDidOpen, []string{"bad"})
+	var reply replyRecorder
+
+	if err := h.handleDidOpen(context.Background(), reply.replier, req); err != nil {
+		t.Fatalf("handleDidOpen: %v", err)
+	}
+
+	if reply.result != nil {
+		t.Fatalf("expected nil result, got %#v", reply.result)
+	}
+	if len(conn.methods) != 0 {
+		t.Fatalf("expected no diagnostics publish for invalid didOpen params, got %v", conn.methods)
+	}
+}
+
+func TestHandleFoldingRange_BadParamsReturnEmptySlice(t *testing.T) {
+	h, _ := newTestHandler()
+	req := newNotification(t, protocol.MethodTextDocumentFoldingRange, []string{"bad"})
+	var reply replyRecorder
+
+	if err := h.handleFoldingRange(context.Background(), reply.replier, req); err != nil {
+		t.Fatalf("handleFoldingRange: %v", err)
+	}
+
+	ranges, ok := reply.result.([]protocol.FoldingRange)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", reply.result)
+	}
+	if len(ranges) != 0 {
+		t.Fatalf("expected no folding ranges, got %#v", ranges)
+	}
+}
+
+func TestHandleDocumentSymbol_WithDocumentReturnsSymbols(t *testing.T) {
+	h, _ := newTestHandler()
+	uri := protocol.DocumentURI("file:///test.ds")
+	h.dm.Open(uri, "# Play\n\n## ACT I")
+	req := newCall(t, 11, protocol.MethodTextDocumentDocumentSymbol, protocol.DocumentSymbolParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+	})
+	var reply replyRecorder
+
+	if err := h.handleDocumentSymbol(context.Background(), reply.replier, req); err != nil {
+		t.Fatalf("handleDocumentSymbol: %v", err)
+	}
+
+	symbols, ok := reply.result.([]protocol.DocumentSymbol)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", reply.result)
+	}
+	if len(symbols) == 0 {
+		t.Fatal("expected symbols for populated document")
+	}
+}
+
+func TestHandleDidChange_IgnoresEmptyContentChanges(t *testing.T) {
+	h, conn := newTestHandler()
+	uri := protocol.DocumentURI("file:///test.ds")
+	h.dm.Open(uri, "# Play\n\nHAMLET\nHello.")
+	req := newNotification(t, protocol.MethodTextDocumentDidChange, protocol.DidChangeTextDocumentParams{
+		TextDocument:   protocol.VersionedTextDocumentIdentifier{TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: uri}},
+		ContentChanges: nil,
+	})
+	var reply replyRecorder
+
+	if err := h.handleDidChange(context.Background(), reply.replier, req); err != nil {
+		t.Fatalf("handleDidChange: %v", err)
+	}
+
+	if len(conn.methods) != 0 {
+		t.Fatalf("expected no diagnostics publish for empty change set, got %v", conn.methods)
+	}
+	if got := h.dm.Get(uri); got == nil || got.content != "# Play\n\nHAMLET\nHello." {
+		t.Fatalf("expected document state to remain unchanged, got %#v", got)
+	}
+}
+
+func TestHandleHover_WithDocumentButNoMatchReturnsNil(t *testing.T) {
+	h, _ := newTestHandler()
+	uri := protocol.DocumentURI("file:///test.ds")
+	h.dm.Open(uri, "# Play\n\nHAMLET\nHello.")
+	req := newCall(t, 12, protocol.MethodTextDocumentHover, protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+			Position:     protocol.Position{Line: 0, Character: 0},
+		},
+	})
+	var reply replyRecorder
+
+	if err := h.handleHover(context.Background(), reply.replier, req); err != nil {
+		t.Fatalf("handleHover: %v", err)
+	}
+	if reply.result != nil {
+		t.Fatalf("expected nil hover, got %#v", reply.result)
 	}
 }

--- a/internal/parser/errors_test.go
+++ b/internal/parser/errors_test.go
@@ -1,0 +1,20 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/token"
+)
+
+func TestParseError_Error(t *testing.T) {
+	err := &ParseError{
+		Message: "unexpected token",
+		Range: token.Range{
+			Start: token.Position{Line: 2, Column: 4},
+		},
+	}
+
+	if got := err.Error(); got != "line 3, col 5: unexpected token" {
+		t.Fatalf("unexpected error string: %q", got)
+	}
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -508,6 +508,33 @@ La la la.`
 	assert.NotEmpty(t, errs, "expected at least one error for unterminated SONG")
 }
 
+func TestErrorRecovery_UnclosedBlockComment(t *testing.T) {
+	input := `# Play
+
+/*
+comment that never ends
+
+HAMLET
+Still here.`
+
+	doc, errs := Parse([]byte(input))
+	assert.NotNil(t, doc, "document should not be nil even with errors")
+	assert.NotEmpty(t, errs, "expected parse errors for unclosed block comment")
+}
+
+func TestErrorRecovery_CharacterAliasWithoutCharacterEntry(t *testing.T) {
+	input := `# Dramatis Personae
+[HAMLET/PRINCE]
+HAMLET — Prince of Denmark`
+
+	doc, errs := Parse([]byte(input))
+	assert.NotNil(t, doc, "document should not be nil even with errors")
+	assert.NotEmpty(t, errs, "expected parse errors for orphaned character alias")
+	dp := ast.FindDramatisPersonae(doc.Body)
+	require.NotNil(t, dp, "expected dramatis personae section to survive recovery")
+	assert.Len(t, dp.Characters, 1, "expected parser to recover and keep subsequent character entries")
+}
+
 func TestNoTitlePage(t *testing.T) {
 	input := `# Act One
 

--- a/internal/render/config_test.go
+++ b/internal/render/config_test.go
@@ -1,0 +1,90 @@
+package render
+
+import "testing"
+
+func TestParseStyle(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Style
+		wantErr bool
+	}{
+		{name: "standard", input: "standard", want: StyleStandard},
+		{name: "condensed", input: "condensed", want: StyleCondensed},
+		{name: "unsupported", input: "wide", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseStyle(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseStyle: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestParsePageSize(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    PageSize
+		wantErr bool
+	}{
+		{name: "letter lowercase", input: "letter", want: PageLetter},
+		{name: "letter title case", input: "Letter", want: PageLetter},
+		{name: "a4 lowercase", input: "a4", want: PageA4},
+		{name: "a4 upper", input: "A4", want: PageA4},
+		{name: "unsupported", input: "legal", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePageSize(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParsePageSize: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	got := DefaultConfig()
+
+	if got.PageSize != PageLetter {
+		t.Fatalf("expected default page size %q, got %q", PageLetter, got.PageSize)
+	}
+	if got.Style != StyleStandard {
+		t.Fatalf("expected default style %q, got %q", StyleStandard, got.Style)
+	}
+	if got.FontFamily != "Courier" {
+		t.Fatalf("expected Courier font family, got %q", got.FontFamily)
+	}
+	if got.FontSize != 12 {
+		t.Fatalf("expected 12 point font, got %v", got.FontSize)
+	}
+	if got.MarginTop != 72 || got.MarginBottom != 72 || got.MarginLeft != 72 || got.MarginRight != 72 {
+		t.Fatalf("unexpected default margins: %#v", got)
+	}
+	if got.SourceAnchors {
+		t.Fatal("expected source anchors to be disabled by default")
+	}
+}

--- a/internal/render/inline_test.go
+++ b/internal/render/inline_test.go
@@ -1,0 +1,36 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/ast"
+)
+
+func TestPlainText_StripsFormattingAndPreservesInlineDirections(t *testing.T) {
+	inlines := []ast.Inline{
+		&ast.TextNode{Value: "Hello "},
+		&ast.BoldNode{Content: []ast.Inline{&ast.TextNode{Value: "bold"}}},
+		&ast.TextNode{Value: " "},
+		&ast.ItalicNode{Content: []ast.Inline{&ast.TextNode{Value: "italic"}}},
+		&ast.TextNode{Value: " "},
+		&ast.BoldItalicNode{Content: []ast.Inline{&ast.TextNode{Value: "both"}}},
+		&ast.TextNode{Value: " "},
+		&ast.UnderlineNode{Content: []ast.Inline{&ast.TextNode{Value: "under"}}},
+		&ast.TextNode{Value: " "},
+		&ast.StrikethroughNode{Content: []ast.Inline{&ast.TextNode{Value: "strike"}}},
+		&ast.TextNode{Value: " "},
+		&ast.InlineDirectionNode{Content: []ast.Inline{&ast.TextNode{Value: "aside"}}},
+	}
+
+	got := PlainText(inlines)
+
+	if got != "Hello bold italic both under strike (aside)" {
+		t.Fatalf("unexpected plain text: %q", got)
+	}
+}
+
+func TestPlainText_EmptyInput(t *testing.T) {
+	if got := PlainText(nil); got != "" {
+		t.Fatalf("expected empty plain text, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- expand LSP handler glue coverage for dispatch, lifecycle, and malformed request paths
- add focused tests for render config, plain text extraction, AST walking, and parser error formatting
- strengthen parser recovery coverage with additional malformed input cases

## Test Plan
- env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go test ./internal/lsp ./internal/render ./internal/ast ./internal/parser
- env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go test ./...

Fixes #23 