### PR TITLE
chore(vscode): add extension CI workflow

### DIFF
--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -1,0 +1,61 @@
+name: VS Code Extension
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/vscode.yml"
+      - "editors/vscode/**"
+      - "LICENSE"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/vscode.yml"
+      - "editors/vscode/**"
+      - "LICENSE"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vscode-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Lint, Compile, and Package
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: editors/vscode
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: editors/vscode/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Compile
+        run: npm run compile
+
+      - name: Package
+        run: npm run package
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: downstage-vscode-vsix
+          path: editors/vscode/downstage-vscode-*.vsix
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow for the VS Code extension
- run npm ci, lint, compile, and package from editors/vscode
- upload the packaged .vsix as a workflow artifact for manual validation

## Test Plan
- npm ci
- npm run lint
- npm run compile
- npm run package

## Related Issues
Closes #46