### PR TITLE
fix(render): tighten compact stage gap

### DIFF
--- a/internal/render/pdf/condensed.go
+++ b/internal/render/pdf/condensed.go
@@ -498,8 +498,8 @@ func (r *condensedRenderer) BeginStageDirection(sd *ast.StageDirection) error {
 		r.ensureSpace(r.lineHeight * 2)
 		r.pdf.Ln(r.lineHeight / 2)
 	default:
-		r.ensureSpace(r.lineHeight * 3)
-		r.pdf.Ln(r.lineHeight)
+		r.ensureSpace(r.lineHeight * 2)
+		r.pdf.Ln(r.lineHeight / 2)
 	}
 
 	stageIndent := halfInchPt * pointsToMM

--- a/internal/render/pdf/pdf_test.go
+++ b/internal/render/pdf/pdf_test.go
@@ -423,3 +423,22 @@ func TestRender_StageDirectionContinuation(t *testing.T) {
 		})
 	}
 }
+
+func TestCondensedStageDirectionUsesTightLeadInSpacing(t *testing.T) {
+	r := NewCondensedRenderer(render.DefaultConfig()).(*condensedRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	line := &ast.SectionLine{
+		Content: []ast.Inline{&ast.TextNode{Value: "A line of text."}},
+	}
+	require.NoError(t, r.BeginSectionLine(line))
+	require.NoError(t, r.RenderText(line.Content[0].(*ast.TextNode)))
+	require.NoError(t, r.EndSectionLine(line))
+
+	yBefore := r.pdf.GetY()
+	require.NoError(t, r.BeginStageDirection(&ast.StageDirection{
+		Content: []ast.Inline{&ast.TextNode{Value: "He crosses to the window."}},
+	}))
+
+	assert.InDelta(t, r.lineHeight/2, r.pdf.GetY()-yBefore, 0.01)
+}


### PR DESCRIPTION
## Summary
- tighten compact PDF spacing before standalone `>` stage directions
- keep compact stage-direction spacing symmetric before and after the block
- add a regression test covering the condensed renderer lead-in spacing

## Test Plan
- `env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go test ./...`

## Related Issues
- Follow-up to #42
