### PR TITLE
fix(site): respect Pages path prefix

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -8,6 +8,7 @@ function escapeHtml(value) {
 }
 
 const downstageGrammar = require("./editors/vscode/syntaxes/downstage.tmLanguage.json");
+const pathPrefix = process.env.SITE_BASE_PATH || "/";
 
 module.exports = function (eleventyConfig) {
   let highlighterPromise;
@@ -69,6 +70,7 @@ module.exports = function (eleventyConfig) {
   );
 
   return {
+    pathPrefix,
     dir: {
       input: "site",
       includes: "_includes",

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,6 +42,8 @@ jobs:
         run: npm ci
 
       - name: Build site
+        env:
+          SITE_BASE_PATH: /downstage/
         run: npm run build:site
 
       - name: Configure GitHub Pages

--- a/site/_includes/partials/section.njk
+++ b/site/_includes/partials/section.njk
@@ -123,7 +123,7 @@
     {% if section.data.actions %}
       <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
         {% for action in section.data.actions %}
-          <a class="{% if action.kind == 'primary' %}button-primary{% else %}button-secondary{% endif %}" href="{{ action.href }}">{{ action.label }}</a>
+          <a class="{% if action.kind == 'primary' %}button-primary{% else %}button-secondary{% endif %}" href="{% if action.href and action.href[0] == '/' %}{{ action.href | url }}{% else %}{{ action.href }}{% endif %}">{{ action.label }}</a>
         {% endfor %}
       </div>
     {% endif %}

--- a/site/content/home/02-getting-started.md
+++ b/site/content/home/02-getting-started.md
@@ -27,5 +27,5 @@ steps:
     code: downstage render my-play.ds
 callout:
   title: Need the reference?
-  text: The full reference, examples, and syntax guide live in <a href="/docs/">the docs</a>.
+  text: The full reference, examples, and syntax guide live in <a href="{{ '/docs/' | url }}">the docs</a>.
 ---

--- a/site/docs/index.njk
+++ b/site/docs/index.njk
@@ -34,8 +34,8 @@ permalink: /docs/
     data-mobile-menu-panel
     aria-label="Documentation menu"
   >
-    <a class="inline-flex items-center gap-3 no-underline" href="/">
-      <img class="h-12 w-12 object-contain" src="/downstage_logo.png" alt="Downstage logo">
+    <a class="inline-flex items-center gap-3 no-underline" href="{{ '/' | url }}">
+      <img class="h-12 w-12 object-contain" src="{{ '/downstage_logo.png' | url }}" alt="Downstage logo">
       <span class="font-serif text-3xl font-bold text-parchment-200">Downstage</span>
     </a>
     <p class="mb-5 mt-3 leading-7 text-parchment-300">How to start, how it works, and where to dig deeper.</p>
@@ -47,7 +47,7 @@ permalink: /docs/
     <div class="mt-5 border-t border-white/10 pt-4">
       <p class="px-3 pb-2 text-xs font-bold uppercase tracking-[0.16em] text-brass-300">Project resources</p>
       <div class="grid gap-1">
-        <a class="nav-link rounded-xl px-3 py-2 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="/">Home</a>
+        <a class="nav-link rounded-xl px-3 py-2 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="{{ '/' | url }}">Home</a>
         <a class="nav-link rounded-xl px-3 py-2 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="https://github.com/jscaltreto/downstage#readme">Project README</a>
         <a class="nav-link rounded-xl px-3 py-2 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="https://github.com/jscaltreto/downstage/blob/main/SPEC.md">Full Specification</a>
         <a class="nav-link rounded-xl px-3 py-2 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="https://github.com/jscaltreto/downstage">Source on GitHub</a>
@@ -55,8 +55,8 @@ permalink: /docs/
     </div>
   </div>
   <aside class="docs-nav docs-nav-panel hidden h-fit border-brass-500/20 bg-[linear-gradient(180deg,rgba(127,39,24,0.38),transparent_28%),rgba(66,39,31,0.96)] p-5 lg:block">
-    <a class="inline-flex items-center gap-3 no-underline" href="/">
-      <img class="h-12 w-12 object-contain" src="/downstage_logo.png" alt="Downstage logo">
+    <a class="inline-flex items-center gap-3 no-underline" href="{{ '/' | url }}">
+      <img class="h-12 w-12 object-contain" src="{{ '/downstage_logo.png' | url }}" alt="Downstage logo">
       <span class="font-serif text-3xl font-bold text-parchment-200">Downstage</span>
     </a>
     <p class="mb-5 mt-3 leading-7 text-parchment-300">How to start, how it works, and where to dig deeper.</p>
@@ -68,7 +68,7 @@ permalink: /docs/
     <div class="mt-5 border-t border-white/10 pt-4">
       <p class="px-3 pb-2 text-xs font-bold uppercase tracking-[0.16em] text-brass-300">Project resources</p>
       <div class="grid gap-1">
-      <a class="nav-link rounded-xl px-3 py-2 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="/">Home</a>
+      <a class="nav-link rounded-xl px-3 py-2 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="{{ '/' | url }}">Home</a>
         <a class="nav-link rounded-xl px-3 py-2 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="https://github.com/jscaltreto/downstage#readme">Project README</a>
         <a class="nav-link rounded-xl px-3 py-2 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="https://github.com/jscaltreto/downstage/blob/main/SPEC.md">Full Specification</a>
         <a class="nav-link rounded-xl px-3 py-2 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="https://github.com/jscaltreto/downstage">Source on GitHub</a>

--- a/site/index.njk
+++ b/site/index.njk
@@ -40,7 +40,7 @@ permalink: /
           <a class="nav-link rounded-xl px-3 py-3 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="#{{ section.data.id }}">{{ section.data.navTitle or section.data.title }}</a>
         {% endif %}
       {% endfor %}
-      <a class="nav-link rounded-xl px-3 py-3 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="/docs/">Docs</a>
+      <a class="nav-link rounded-xl px-3 py-3 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="{{ '/docs/' | url }}">Docs</a>
       <a class="nav-link rounded-xl px-3 py-3 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="https://github.com/jscaltreto/downstage">GitHub</a>
     </nav>
   </div>
@@ -50,7 +50,7 @@ permalink: /
         <div class="flex justify-center">
           <img
             class="h-auto w-[220px] drop-shadow-[0_20px_30px_rgba(0,0,0,0.28)] sm:w-[280px] lg:w-[360px]"
-            src="/downstage_logo.png"
+            src="{{ '/downstage_logo.png' | url }}"
             alt="Downstage logo"
           >
         </div>
@@ -66,7 +66,7 @@ permalink: /
         </p>
         <div class="mt-7 flex flex-col items-center justify-center gap-3 sm:flex-row">
           <a class="inline-flex min-h-12 items-center justify-center rounded-full bg-gradient-to-br from-brass-500 to-brass-400 px-5 font-semibold text-ember-850" href="#getting-started">Start Writing</a>
-          <a class="inline-flex min-h-12 items-center justify-center rounded-full border border-white/15 bg-white/5 px-5 font-semibold text-parchment-200" href="/docs/">Open Docs</a>
+          <a class="inline-flex min-h-12 items-center justify-center rounded-full border border-white/15 bg-white/5 px-5 font-semibold text-parchment-200" href="{{ '/docs/' | url }}">Open Docs</a>
         </div>
       </div>
     </section>
@@ -77,7 +77,7 @@ permalink: /
           <a class="nav-link rounded-xl px-3 py-2 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="#{{ section.data.id }}">{{ section.data.navTitle or section.data.title }}</a>
         {% endif %}
       {% endfor %}
-      <a class="nav-link rounded-xl px-3 py-2 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="/docs/">Docs</a>
+      <a class="nav-link rounded-xl px-3 py-2 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="{{ '/docs/' | url }}">Docs</a>
       <span class="min-w-0 flex-1" aria-hidden="true"></span>
       <a class="nav-link inline-flex min-h-[42px] min-w-[42px] items-center justify-center rounded-xl px-3 py-2 text-sm text-parchment-300 transition hover:translate-x-0.5 hover:bg-white/5 hover:text-parchment-200" href="https://github.com/jscaltreto/downstage" aria-label="GitHub">
         <svg class="h-5 w-5" viewBox="0 0 16 16" aria-hidden="true">


### PR DESCRIPTION
## Summary
- build the Eleventy site with the GitHub Pages project-site path prefix
- route internal site links and assets through the Eleventy url filter
- keep the Pages workflow building with /downstage/ so deployed assets resolve correctly

## Testing
- SITE_BASE_PATH=/downstage/ npm run build:site
- xmllint --html --noout dist/index.html
- xmllint --html --noout dist/docs/index.html