### PR TITLE
fix: harden web editor wasm startup

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -104,7 +104,13 @@ async function main() {
     "save-source",
   ) as HTMLButtonElement;
 
-  await initWasm();
+  try {
+    await initWasm();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    loading.textContent = `Failed to load Downstage editor: ${message}`;
+    return;
+  }
 
   loading.style.display = "none";
   workspace.classList.remove("hidden");

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -26,10 +26,20 @@ export interface ParseError {
 
 export async function initWasm(): Promise<void> {
   const go = new window.Go();
-  const result = await WebAssembly.instantiateStreaming(
-    fetch("downstage.wasm"),
-    go.importObject,
-  );
+  const response = await fetch("downstage.wasm");
+  if (!response.ok) {
+    throw new Error(`failed to fetch downstage.wasm: ${response.status} ${response.statusText}`);
+  }
+
+  let result: WebAssembly.WebAssemblyInstantiatedSource;
+  try {
+    result = await WebAssembly.instantiateStreaming(response, go.importObject);
+  } catch {
+    // Some static hosts do not serve .wasm with the correct MIME type.
+    const bytes = await response.arrayBuffer();
+    result = await WebAssembly.instantiate(bytes, go.importObject);
+  }
+
   go.run(result.instance);
 }
 


### PR DESCRIPTION
## Summary
- fall back to  when the host serves  with the wrong MIME type
- show a real load error instead of leaving the editor stuck on the loading screen

## Testing
- npm run build

Fixes the post-merge startup issue on the deployed web editor.
