### PR TITLE
chore(release): fix goreleaser config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,23 @@ jobs:
           cache: true
           check-latest: true
 
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          install-only: true
+
       - name: Download modules
         run: go mod download
 
       - name: Run checks
         id: checks
         run: make check
+
+      - name: Validate release config
+        id: release-check
+        run: make release-check
 
       - name: Build binary
         id: build
@@ -53,5 +64,6 @@ jobs:
           echo "| Step | Status |" >> "$GITHUB_STEP_SUMMARY"
           echo "|------|--------|" >> "$GITHUB_STEP_SUMMARY"
           echo "| Checks | \`${{ steps.checks.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Release config | \`${{ steps.release-check.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Build  | \`${{ steps.build.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| WASM   | \`${{ steps.wasm.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,7 +63,6 @@ signs:
       - ${artifact}
     env:
       - COSIGN_YES=true
-    if: "{{ not .IsSnapshot }}"
 
 snapshot:
   version_template: "{{ incpatch .Version }}-next"


### PR DESCRIPTION
## Summary
- remove the unsupported GoReleaser sign condition that broke the v0.3.0 release job
- validate GoReleaser config in CI before tag-driven releases run

## Testing
- env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go test ./...
- env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go vet ./...
- env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go run github.com/goreleaser/goreleaser/v2@v2.15.2 check