### PR TITLE
chore(release): update cosign bundle output

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,12 +54,11 @@ signs:
   - cmd: cosign
     artifacts: checksum
     output: true
-    certificate: ${artifact}.pem
+    signature: ${artifact}.sigstore.json
     args:
       - sign-blob
       - --yes
-      - --output-certificate=${certificate}
-      - --output-signature=${signature}
+      - --bundle=${signature}
       - ${artifact}
     env:
       - COSIGN_YES=true


### PR DESCRIPTION
## Summary
- switch GoReleaser checksum signing to cosign bundle output
- remove deprecated split signature and certificate output flags

## Testing
- env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go run github.com/goreleaser/goreleaser/v2@v2.15.2 check