### PR TITLE
chore(release): set repo for vsix uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,7 @@ jobs:
       - name: Upload VSIX release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_VERSION: ${{ github.ref_name }}
         run: |
           version="${RELEASE_VERSION#v}"


### PR DESCRIPTION
## Summary
- set GH_REPO in the VSIX upload job so gh can target the release repo without a checkout
- prevent future release runs from failing after the assets are already built

## Testing
- verified the current v0.3.0 release manually by uploading the VSIX artifacts after reproducing the job failure
- confirmed the failing step was gh release upload running without repository context