### PR TITLE
docs(vscode): refresh release links

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -3,13 +3,13 @@
 # Downstage for VS Code
 
 Downstage is a VS Code extension for writing stage plays in
-[Downstage](https://jscaltreto.github.io/downstage/) markup. It provides full
+[Downstage](https://www.getdownstage.com/docs/) markup. It provides full
 LSP support, live PDF preview, render commands, snippets, diagnostics, and
 TextMate syntax highlighting.
 
 ## Quick Start
 
-1. Install this extension from the VS Code Marketplace.
+1. Install this extension from the Visual Studio Marketplace or Open VSX.
 2. On supported release builds, the extension uses its bundled `downstage`
    binary automatically.
 3. If you want to override that binary or you are on an unsupported platform,
@@ -101,7 +101,7 @@ Release notes for the extension come from the repository root
 
 ## Related
 
-- [Downstage documentation](https://jscaltreto.github.io/downstage/)
+- [Downstage documentation](https://www.getdownstage.com/docs/)
 - [GitHub repository](https://github.com/jscaltreto/downstage)
 
 ## Development

--- a/editors/vscode/SUPPORT.md
+++ b/editors/vscode/SUPPORT.md
@@ -8,7 +8,7 @@ Please open an issue on GitHub:
 ## Documentation
 
 The Downstage language reference and user guide are available at:
-<https://jscaltreto.github.io/downstage/>
+<https://www.getdownstage.com/docs/>
 
 ## Extension Configuration
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -10,7 +10,7 @@
     "color": "#1e1e1e",
     "theme": "dark"
   },
-  "homepage": "https://jscaltreto.github.io/downstage/",
+  "homepage": "https://www.getdownstage.com/",
   "repository": {
     "type": "git",
     "url": "https://github.com/jscaltreto/downstage.git",


### PR DESCRIPTION
## Summary
- point VS Code extension docs and metadata at the current getdownstage.com URLs
- mention both Visual Studio Marketplace and Open VSX in the extension quick start
- keep support and homepage links aligned with the live docs site

## Validation
- npm run lint
- npm run compile
- npm run package