### PR TITLE
chore(vscode): publish release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,3 +177,110 @@ jobs:
             "editors/vscode/downstage-vscode-${version}-darwin-arm64.vsix" \
             "editors/vscode/downstage-vscode-${version}-win32-x64.vsix" \
             --clobber
+
+  publish-vscode-marketplace:
+    name: Publish VS Code Marketplace Extension
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - vscode-vsix
+      - upload-vsix
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: editors/vscode/package-lock.json
+
+      - name: Install VS Code extension dependencies
+        working-directory: editors/vscode
+        run: npm ci
+
+      - name: Download VSIX artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: vscode-vsix
+          path: editors/vscode
+
+      - name: Publish VSIX packages to Visual Studio Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          if [ -z "${VSCE_PAT}" ]; then
+            echo "VSCE_PAT is not configured; skipping Visual Studio Marketplace publish."
+            exit 0
+          fi
+
+          version="${RELEASE_VERSION#v}"
+          packages=(
+            "editors/vscode/downstage-vscode-${version}-linux-x64.vsix"
+            "editors/vscode/downstage-vscode-${version}-darwin-x64.vsix"
+            "editors/vscode/downstage-vscode-${version}-darwin-arm64.vsix"
+            "editors/vscode/downstage-vscode-${version}-win32-x64.vsix"
+          )
+
+          for package in "${packages[@]}"; do
+            npx @vscode/vsce publish --packagePath "${package}"
+          done
+
+  publish-open-vsx:
+    name: Publish Open VSX Extension
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - vscode-vsix
+      - upload-vsix
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: editors/vscode/package-lock.json
+
+      - name: Install VS Code extension dependencies
+        working-directory: editors/vscode
+        run: npm ci
+
+      - name: Download VSIX artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: vscode-vsix
+          path: editors/vscode
+
+      - name: Publish VSIX packages to Open VSX
+        env:
+          OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          if [ -z "${OVSX_TOKEN}" ]; then
+            echo "OVSX_TOKEN is not configured; skipping Open VSX publish."
+            exit 0
+          fi
+
+          version="${RELEASE_VERSION#v}"
+          packages=(
+            "editors/vscode/downstage-vscode-${version}-linux-x64.vsix"
+            "editors/vscode/downstage-vscode-${version}-darwin-x64.vsix"
+            "editors/vscode/downstage-vscode-${version}-darwin-arm64.vsix"
+            "editors/vscode/downstage-vscode-${version}-win32-x64.vsix"
+          )
+
+          for package in "${packages[@]}"; do
+            npx ovsx publish "${package}" -p "${OVSX_TOKEN}"
+          done
+

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -99,6 +99,21 @@ binary is present, the extension falls back to `downstage` on your `PATH`.
 Release notes for the extension come from the repository root
 [`CHANGELOG.md`](../../CHANGELOG.md).
 
+## Release Process
+
+The VS Code extension ships from this repository. It does not maintain a
+separate release track.
+
+- Release tags `v*` drive the extension version used for packaged VSIX files.
+- `.github/workflows/release.yml` packages one VSIX per supported platform and
+  uploads them to the GitHub release.
+- If the `VSCE_PAT` GitHub Actions secret is configured, the same workflow also
+  publishes those VSIX files to the Visual Studio Marketplace.
+- If the `OVSX_TOKEN` GitHub Actions secret is configured, the workflow also
+  publishes the same VSIX files to Open VSX.
+- The registries are published independently, so one can fail without blocking
+  the other.
+
 ## Related
 
 - [Downstage documentation](https://www.getdownstage.com/docs/)


### PR DESCRIPTION
## Summary
- publish tagged VSIX artifacts to the Visual Studio Marketplace after GitHub release upload
- publish the same tagged VSIX artifacts to Open VSX when `OVSX_TOKEN` is configured
- document the extension release process and registry policy in the VS Code README

## Validation
- npm run lint
- npm run compile
- npm run package
