### PR TITLE
fix(pdf): paginate dialogue continuations

### DIFF
--- a/internal/render/pdf/base.go
+++ b/internal/render/pdf/base.go
@@ -42,6 +42,17 @@ type pdfBase struct {
 	dualSide       int     // 0 = left, 1 = right
 	dualStartY     float64 // Y position at start of dual dialogue
 	dualMidY       float64 // Y after left column, to compute max height
+
+	// Buffered dialogue inline capture for custom pagination.
+	captureDialogueLine bool
+	captureStyle        string
+	captureDirDepth     int
+	capturedRuns        []dialogueTextRun
+}
+
+type dialogueTextRun struct {
+	text  string
+	style string
 }
 
 func (b *pdfBase) initPDF(fontLoader func(*fpdf.Fpdf), defaultFamily string) {
@@ -94,61 +105,113 @@ func (b *pdfBase) initPDF(fontLoader func(*fpdf.Fpdf), defaultFamily string) {
 // --- Inline rendering (shared by all PDF renderers) ---
 
 func (b *pdfBase) RenderText(t *ast.TextNode) error {
+	if b.captureDialogueLine {
+		b.appendCapturedText(t.Value)
+		return nil
+	}
 	b.pdf.Write(b.lineHeight, t.Value)
 	return nil
 }
 
 func (b *pdfBase) BeginBold(_ *ast.BoldNode) error {
+	if b.captureDialogueLine {
+		b.captureStyle = mergeStyles(b.captureStyle, "B")
+		return nil
+	}
 	b.pushStyle("B")
 	return nil
 }
 
 func (b *pdfBase) EndBold(_ *ast.BoldNode) error {
+	if b.captureDialogueLine {
+		b.captureStyle = removeStyles(b.captureStyle, "B")
+		return nil
+	}
 	b.popStyle("B")
 	return nil
 }
 
 func (b *pdfBase) BeginItalic(_ *ast.ItalicNode) error {
+	if b.captureDialogueLine {
+		b.captureStyle = mergeStyles(b.captureStyle, "I")
+		return nil
+	}
 	b.pushStyle("I")
 	return nil
 }
 
 func (b *pdfBase) EndItalic(_ *ast.ItalicNode) error {
+	if b.captureDialogueLine {
+		b.captureStyle = removeStyles(b.captureStyle, "I")
+		return nil
+	}
 	b.popStyle("I")
 	return nil
 }
 
 func (b *pdfBase) BeginBoldItalic(_ *ast.BoldItalicNode) error {
+	if b.captureDialogueLine {
+		b.captureStyle = mergeStyles(b.captureStyle, "BI")
+		return nil
+	}
 	b.pushStyle("BI")
 	return nil
 }
 
 func (b *pdfBase) EndBoldItalic(_ *ast.BoldItalicNode) error {
+	if b.captureDialogueLine {
+		b.captureStyle = removeStyles(b.captureStyle, "BI")
+		return nil
+	}
 	b.popStyle("BI")
 	return nil
 }
 
 func (b *pdfBase) BeginUnderline(_ *ast.UnderlineNode) error {
+	if b.captureDialogueLine {
+		b.captureStyle = mergeStyles(b.captureStyle, "U")
+		return nil
+	}
 	b.pushStyle("U")
 	return nil
 }
 
 func (b *pdfBase) EndUnderline(_ *ast.UnderlineNode) error {
+	if b.captureDialogueLine {
+		b.captureStyle = removeStyles(b.captureStyle, "U")
+		return nil
+	}
 	b.popStyle("U")
 	return nil
 }
 
 func (b *pdfBase) BeginStrikethrough(_ *ast.StrikethroughNode) error {
+	if b.captureDialogueLine {
+		b.captureStyle = mergeStyles(b.captureStyle, "S")
+		return nil
+	}
 	b.pushStyle("S")
 	return nil
 }
 
 func (b *pdfBase) EndStrikethrough(_ *ast.StrikethroughNode) error {
+	if b.captureDialogueLine {
+		b.captureStyle = removeStyles(b.captureStyle, "S")
+		return nil
+	}
 	b.popStyle("S")
 	return nil
 }
 
 func (b *pdfBase) BeginInlineDirection(_ *ast.InlineDirectionNode) error {
+	if b.captureDialogueLine {
+		b.captureStyle = mergeStyles(b.captureStyle, "I")
+		b.captureDirDepth++
+		if b.captureDirDepth == 1 {
+			b.appendCapturedText("(")
+		}
+		return nil
+	}
 	b.pushStyle("I")
 	b.dirDepth++
 	if b.dirDepth == 1 {
@@ -158,12 +221,47 @@ func (b *pdfBase) BeginInlineDirection(_ *ast.InlineDirectionNode) error {
 }
 
 func (b *pdfBase) EndInlineDirection(_ *ast.InlineDirectionNode) error {
+	if b.captureDialogueLine {
+		b.captureDirDepth--
+		if b.captureDirDepth == 0 {
+			b.appendCapturedText(")")
+		}
+		b.captureStyle = removeStyles(b.captureStyle, "I")
+		return nil
+	}
 	b.dirDepth--
 	if b.dirDepth == 0 {
 		b.pdf.Write(b.lineHeight, ")")
 	}
 	b.popStyle("I")
 	return nil
+}
+
+func (b *pdfBase) beginCapturedDialogueLine() {
+	b.captureDialogueLine = true
+	b.captureStyle = ""
+	b.captureDirDepth = 0
+	b.capturedRuns = b.capturedRuns[:0]
+}
+
+func (b *pdfBase) endCapturedDialogueLine() []dialogueTextRun {
+	runs := append([]dialogueTextRun(nil), b.capturedRuns...)
+	b.captureDialogueLine = false
+	b.captureStyle = ""
+	b.captureDirDepth = 0
+	b.capturedRuns = b.capturedRuns[:0]
+	return runs
+}
+
+func (b *pdfBase) appendCapturedText(text string) {
+	if text == "" {
+		return
+	}
+	if n := len(b.capturedRuns); n > 0 && b.capturedRuns[n-1].style == b.captureStyle {
+		b.capturedRuns[n-1].text += text
+		return
+	}
+	b.capturedRuns = append(b.capturedRuns, dialogueTextRun{text: text, style: b.captureStyle})
 }
 
 func (b *pdfBase) RenderPageBreak(_ *ast.PageBreak) error {

--- a/internal/render/pdf/body.go
+++ b/internal/render/pdf/body.go
@@ -164,31 +164,11 @@ func (r *pdfRenderer) BeginDialogue(d *ast.Dialogue) error {
 	if r.inDualDialogue {
 		return r.beginDualDialogueSide(d)
 	}
-
-	r.ensureSpace(r.lineHeight * 3)
-	r.pdf.Ln(r.lineHeight)
-
-	// Character name — centered, uppercase, bold
-	r.setStyle("B")
-	r.centeredText(strings.ToUpper(d.Character))
-	r.setStyle("")
-
-	// Parenthetical — centered, italic
-	if d.Parenthetical != "" {
-		r.setStyle("I")
-		paren := d.Parenthetical
-		if len(paren) == 0 || paren[0] != '(' {
-			paren = "(" + paren + ")"
-		}
-		r.centeredText(paren)
-		r.setStyle("")
+	r.activeDialogue = &bufferedDialogue{
+		character:     d.Character,
+		parenthetical: d.Parenthetical,
+		lines:         make([]bufferedDialogueLine, 0, len(d.Lines)),
 	}
-
-	// Set dialogue column margins
-	dialogueMargin := r.bodyW * 0.15
-	dialogueX := r.marginL + dialogueMargin
-	r.pdf.SetLeftMargin(dialogueX)
-	r.pdf.SetRightMargin(r.marginR + dialogueMargin)
 	return nil
 }
 
@@ -294,16 +274,20 @@ func (r *pdfRenderer) EndDialogue(_ *ast.Dialogue) error {
 		r.dualSide++
 		return nil
 	}
-	r.pdf.SetLeftMargin(r.marginL)
-	r.pdf.SetRightMargin(r.marginR)
-	return nil
+	if r.activeDialogue == nil {
+		return nil
+	}
+	dialogue := *r.activeDialogue
+	r.activeDialogue = nil
+	return r.renderBufferedDialogue(dialogue)
 }
 
 func (r *pdfRenderer) BeginDialogueLine(line *ast.DialogueLine) error {
-	if len(line.Content) == 0 {
-		return nil
-	}
 	if r.inDualDialogue {
+		r.captureDialogueLine = false
+		if len(line.Content) == 0 {
+			return nil
+		}
 		// In dual dialogue, lines flow within the current column margins
 		leftM, _, _, _ := r.pdf.GetMargins()
 		if line.IsVerse {
@@ -314,18 +298,23 @@ func (r *pdfRenderer) BeginDialogueLine(line *ast.DialogueLine) error {
 		return nil
 	}
 
-	dialogueMargin := r.bodyW * 0.15
-	dialogueX := r.marginL + dialogueMargin
-	if line.IsVerse {
-		r.pdf.SetX(dialogueX + 10)
-	} else {
-		r.pdf.SetX(dialogueX)
-	}
+	r.beginCapturedDialogueLine()
 	return nil
 }
 
-func (r *pdfRenderer) EndDialogueLine(_ *ast.DialogueLine) error {
-	r.pdf.Ln(r.lineHeight)
+func (r *pdfRenderer) EndDialogueLine(line *ast.DialogueLine) error {
+	if r.inDualDialogue {
+		r.pdf.Ln(r.lineHeight)
+		return nil
+	}
+	runs := r.endCapturedDialogueLine()
+	if r.activeDialogue == nil {
+		return nil
+	}
+	r.activeDialogue.lines = append(r.activeDialogue.lines, bufferedDialogueLine{
+		runs:    runs,
+		isVerse: line.IsVerse,
+	})
 	return nil
 }
 

--- a/internal/render/pdf/condensed.go
+++ b/internal/render/pdf/condensed.go
@@ -19,6 +19,7 @@ const (
 )
 
 var _ render.NodeRenderer = (*condensedRenderer)(nil)
+var _ dialoguePaginationStrategy = (*condensedRenderer)(nil)
 
 // NewCondensedRenderer creates an acting-edition PDF NodeRenderer.
 // Uses half-letter page, Libre Baskerville serif font, and compact layout
@@ -37,8 +38,8 @@ func NewCondensedRenderer(cfg render.Config) render.NodeRenderer {
 
 type condensedRenderer struct {
 	pdfBase
-	inDialogue bool // tracks whether we're inside a dialogue block
-	firstLine  bool // tracks first line of a dialogue (continues after character name)
+	dualDialogueInlineFirstLine bool
+	activeDialogue              *bufferedDialogue
 }
 
 // --- Lifecycle ---
@@ -307,32 +308,11 @@ func (r *condensedRenderer) BeginDialogue(d *ast.Dialogue) error {
 	if r.inDualDialogue {
 		return r.beginDualDialogueSide(d)
 	}
-
-	r.ensureSpace(r.lineHeight * 2)
-	r.pdf.Ln(r.lineHeight / 2)
-
-	r.inDialogue = true
-	r.firstLine = true
-
-	// Character name — bold, followed by period
-	r.pdf.SetX(r.marginL)
-	r.setStyle("B")
-	r.pdf.Write(r.lineHeight, strings.ToUpper(d.Character)+".")
-	r.setStyle("")
-	r.pdf.Write(r.lineHeight, "  ")
-
-	// Parenthetical — italic, inline
-	if d.Parenthetical != "" {
-		r.setStyle("I")
-		paren := d.Parenthetical
-		if len(paren) == 0 || paren[0] != '(' {
-			paren = "(" + paren + ")"
-		}
-		r.pdf.Write(r.lineHeight, paren)
-		r.setStyle("")
-		r.pdf.Write(r.lineHeight, " ")
+	r.activeDialogue = &bufferedDialogue{
+		character:     d.Character,
+		parenthetical: d.Parenthetical,
+		lines:         make([]bufferedDialogueLine, 0, len(d.Lines)),
 	}
-
 	return nil
 }
 
@@ -357,8 +337,7 @@ func (r *condensedRenderer) beginDualDialogueSide(d *ast.Dialogue) error {
 	r.pdf.SetLeftMargin(leftM)
 	r.pdf.SetRightMargin(rightM)
 
-	r.inDialogue = true
-	r.firstLine = true
+	r.dualDialogueInlineFirstLine = true
 
 	// Character name — bold, inline
 	r.pdf.SetX(leftM)
@@ -448,20 +427,33 @@ func (r *condensedRenderer) estimateDialogueHeight(d *ast.Dialogue, width float6
 func (r *condensedRenderer) EndDialogue(_ *ast.Dialogue) error {
 	if r.inDualDialogue {
 		r.dualSide++
+		return nil
 	}
-	r.inDialogue = false
-	r.firstLine = false
+	if r.activeDialogue != nil {
+		dialogue := *r.activeDialogue
+		r.activeDialogue = nil
+		if err := r.renderBufferedDialogue(dialogue); err != nil {
+			return err
+		}
+	}
+	r.dualDialogueInlineFirstLine = false
 	return nil
 }
 
 func (r *condensedRenderer) BeginDialogueLine(line *ast.DialogueLine) error {
-	if len(line.Content) == 0 {
-		r.firstLine = false
+	if !r.inDualDialogue {
+		r.beginCapturedDialogueLine()
 		return nil
 	}
-	if r.firstLine {
+	r.captureDialogueLine = false
+
+	if len(line.Content) == 0 {
+		r.dualDialogueInlineFirstLine = false
+		return nil
+	}
+	if r.dualDialogueInlineFirstLine {
 		// First line continues after character name on the same line
-		r.firstLine = false
+		r.dualDialogueInlineFirstLine = false
 		if line.IsVerse {
 			// Even verse on the first line starts inline
 		}
@@ -478,6 +470,18 @@ func (r *condensedRenderer) BeginDialogueLine(line *ast.DialogueLine) error {
 }
 
 func (r *condensedRenderer) EndDialogueLine(line *ast.DialogueLine) error {
+	if !r.inDualDialogue {
+		runs := r.endCapturedDialogueLine()
+		if r.activeDialogue == nil {
+			return nil
+		}
+		r.activeDialogue.lines = append(r.activeDialogue.lines, bufferedDialogueLine{
+			runs:    runs,
+			isVerse: line.IsVerse,
+		})
+		return nil
+	}
+
 	if len(line.Content) == 0 {
 		r.pdf.Ln(r.lineHeight / 2)
 		return nil

--- a/internal/render/pdf/condensed_dialogue_pagination.go
+++ b/internal/render/pdf/condensed_dialogue_pagination.go
@@ -1,0 +1,212 @@
+package pdf
+
+import "strings"
+
+func (r *condensedRenderer) renderBufferedDialogue(d bufferedDialogue) error {
+	return paginateBufferedDialogue(r, d)
+}
+
+func (r *condensedRenderer) prepare(lines []bufferedDialogueLine, dialogue bufferedDialogue, continuation, firstSegment bool) []bufferedDialogueLine {
+	_, firstLineWidth := r.condensedPrefixLayout(dialogue.character, dialogue.parenthetical, firstSegment)
+	return r.prepareDialogueLines(lines, firstLineWidth)
+}
+
+func (r *condensedRenderer) availableWrappedLines(dialogue bufferedDialogue, continuation, firstSegment bool) int {
+	prefixExtraLines, _ := r.condensedPrefixLayout(dialogue.character, dialogue.parenthetical, firstSegment)
+	leadInHeight := 0.0
+	if firstSegment {
+		leadInHeight = r.lineHeight / 2
+	}
+	if leadInHeight > r.remainingPageHeight() {
+		r.pdf.AddPage()
+		leadInHeight = 0
+		prefixExtraLines, _ = r.condensedPrefixLayout(dialogue.character, dialogue.parenthetical, firstSegment)
+	}
+	return max(int((r.remainingPageHeight()-leadInHeight)/r.lineHeight)-prefixExtraLines, 0)
+}
+
+func (r *condensedRenderer) renderSegment(dialogue bufferedDialogue, continuation, firstSegment bool, lines []bufferedDialogueLine, showMore bool) {
+	r.renderDialogueSegment(dialogue.character, dialogue.parenthetical, continuation, firstSegment, lines, showMore)
+}
+
+func (r *condensedRenderer) addPage() {
+	r.pdf.AddPage()
+}
+
+func (r *condensedRenderer) showContinuationFooter() bool {
+	return false
+}
+
+func (r *condensedRenderer) renderDialogueSegment(character, parenthetical string, continuation, firstSegment bool, lines []bufferedDialogueLine, showMore bool) {
+	if firstSegment {
+		r.ensureSpace(r.lineHeight * 2)
+		r.pdf.Ln(r.lineHeight / 2)
+
+		cue := strings.ToUpper(character) + "."
+		r.pdf.SetX(r.marginL)
+		r.setStyle("B")
+		r.pdf.Write(r.lineHeight, cue)
+		r.setStyle("")
+		r.pdf.Write(r.lineHeight, "  ")
+
+		if parenthetical != "" {
+			r.setStyle("I")
+			r.pdf.Write(r.lineHeight, parentheticalText(parenthetical))
+			r.setStyle("")
+			r.pdf.Write(r.lineHeight, " ")
+		}
+	}
+
+	firstRenderedLine := true
+	for _, line := range lines {
+		if len(line.runs) == 0 {
+			r.pdf.Ln(r.lineHeight / 2)
+			continue
+		}
+
+		if firstRenderedLine {
+			firstOffset := dialogueSplitOffset(line.plainText, line.wrappedText[:1])
+			firstRuns, remainingRuns := splitDialogueRuns(line.runs, firstOffset)
+			for _, run := range firstRuns {
+				r.setStyle(run.style)
+				r.pdf.CellFormat(r.pdf.GetStringWidth(run.text), r.lineHeight, run.text, "", 0, "", false, 0, "")
+			}
+			r.setStyle("")
+			if len(remainingRuns) == 0 {
+				r.pdf.Ln(r.lineHeight)
+				firstRenderedLine = false
+				continue
+			}
+			r.pdf.Ln(r.lineHeight)
+			line.runs = remainingRuns
+		}
+
+		if !firstRenderedLine {
+			if line.isVerse {
+				r.pdf.SetX(r.marginL + 10)
+			} else {
+				r.pdf.SetX(r.marginL)
+			}
+		}
+		for _, run := range line.runs {
+			r.setStyle(run.style)
+			r.pdf.Write(r.lineHeight, run.text)
+		}
+		r.setStyle("")
+		r.pdf.Ln(r.lineHeight)
+		firstRenderedLine = false
+	}
+
+	if showMore && r.showContinuationFooter() {
+		r.setStyle("B")
+		r.centeredText(continuedDialogueFooter)
+		r.setStyle("")
+	}
+}
+
+func (r *condensedRenderer) prepareDialogueLines(lines []bufferedDialogueLine, firstLineWidth float64) []bufferedDialogueLine {
+	prepared := make([]bufferedDialogueLine, len(lines))
+	copy(prepared, lines)
+
+	firstTextLine := true
+
+	for i := range prepared {
+		prepared[i].plainText = dialogueRunsPlainText(prepared[i].runs)
+		if prepared[i].plainText == "" {
+			prepared[i].wrappedText = nil
+			continue
+		}
+
+		width := r.condensedRegularLineWidth(prepared[i].isVerse)
+		if firstTextLine {
+			width = firstLineWidth
+			firstTextLine = false
+		}
+		prepared[i].wrappedText = r.pdf.SplitText(prepared[i].plainText, width)
+	}
+
+	return prepared
+}
+
+func (r *condensedRenderer) condensedPrefixLayout(character, parenthetical string, firstSegment bool) (int, float64) {
+	if !firstSegment {
+		return 0, r.bodyW
+	}
+
+	cue := strings.ToUpper(character)
+	cue += "."
+	x := r.measureTextWidth("B", cue) + r.measureTextWidth("", "  ")
+	extraLines := 0
+
+	if parenthetical != "" {
+		x, extraLines = r.layoutCondensedInlineText(x, extraLines, parentheticalText(parenthetical), "I")
+		spaceWidth := r.measureTextWidth("", " ")
+		if x+spaceWidth > r.bodyW {
+			extraLines++
+			x = 0
+		} else {
+			x += spaceWidth
+		}
+	}
+
+	width := r.bodyW - x
+	if width < 10 {
+		extraLines++
+		width = r.bodyW
+	}
+	return extraLines, width
+}
+
+func (r *condensedRenderer) measureTextWidth(style, text string) float64 {
+	currentStyle := r.fontStyle
+	r.setStyle(style)
+	width := r.pdf.GetStringWidth(text)
+	r.setStyle(currentStyle)
+	return width
+}
+
+func (r *condensedRenderer) layoutCondensedInlineText(startX float64, extraLines int, text, style string) (float64, int) {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return startX, extraLines
+	}
+
+	x := startX
+	for i, word := range words {
+		token := word
+		if i > 0 {
+			token = " " + word
+		}
+		tokenWidth := r.measureTextWidth(style, token)
+		if x > 0 && x+tokenWidth > r.bodyW {
+			extraLines++
+			x = r.measureTextWidth(style, word)
+			continue
+		}
+		x += tokenWidth
+	}
+
+	return x, extraLines
+}
+
+func parentheticalText(parenthetical string) string {
+	paren := parenthetical
+	if paren == "" {
+		return ""
+	}
+	if paren[0] != '(' {
+		paren = "(" + paren + ")"
+	}
+	return paren
+}
+
+func (r *condensedRenderer) condensedRegularLineWidth(isVerse bool) float64 {
+	width := r.bodyW
+	if isVerse {
+		width -= 10
+	}
+	if width < 10 {
+		return 10
+	}
+	return width
+}

--- a/internal/render/pdf/dialogue_pagination.go
+++ b/internal/render/pdf/dialogue_pagination.go
@@ -1,0 +1,365 @@
+package pdf
+
+import (
+	"strings"
+	"unicode"
+)
+
+const minContinuedDialogueLines = 3
+const continuedDialogueSuffix = " (CONT'D)"
+const continuedDialogueFooter = "(MORE)"
+
+type bufferedDialogue struct {
+	character     string
+	parenthetical string
+	lines         []bufferedDialogueLine
+}
+
+type bufferedDialogueLine struct {
+	runs        []dialogueTextRun
+	isVerse     bool
+	plainText   string
+	wrappedText []string
+}
+
+func (r *pdfRenderer) prepareDialogueLine(line bufferedDialogueLine) bufferedDialogueLine {
+	line.plainText = dialogueRunsPlainText(line.runs)
+	if line.plainText == "" {
+		line.wrappedText = nil
+		return line
+	}
+	width := r.dialogueContentWidth(line.isVerse)
+	line.wrappedText = r.pdf.SplitText(line.plainText, width)
+	return line
+}
+
+func (r *pdfRenderer) renderBufferedDialogue(d bufferedDialogue) error {
+	return paginateBufferedDialogue(r, d)
+}
+
+func (r *pdfRenderer) prepare(lines []bufferedDialogueLine, _ bufferedDialogue, _, _ bool) []bufferedDialogueLine {
+	prepared := make([]bufferedDialogueLine, len(lines))
+	for i := range lines {
+		prepared[i] = r.prepareDialogueLine(lines[i])
+	}
+	return prepared
+}
+
+func (r *pdfRenderer) availableWrappedLines(dialogue bufferedDialogue, _ bool, firstSegment bool) int {
+	headerHeight := r.dialogueHeaderHeight(firstSegment, dialogue.parenthetical != "")
+	if headerHeight > r.remainingPageHeight() {
+		r.pdf.AddPage()
+	}
+	return max(int((r.remainingPageHeight()-headerHeight)/r.lineHeight), 0)
+}
+
+func (r *pdfRenderer) renderSegment(dialogue bufferedDialogue, continuation, firstSegment bool, lines []bufferedDialogueLine, showMore bool) {
+	r.renderDialogueSegment(dialogue.character, dialogue.parenthetical, continuation, firstSegment, lines, showMore)
+}
+
+func (r *pdfRenderer) addPage() {
+	r.pdf.AddPage()
+}
+
+func (r *pdfRenderer) showContinuationFooter() bool {
+	return true
+}
+
+func (r *pdfRenderer) renderDialogueSegment(character, parenthetical string, continuation, firstSegment bool, lines []bufferedDialogueLine, showMore bool) {
+	r.renderDialogueHeader(character, parenthetical, continuation, firstSegment)
+	dialogueMargin := r.bodyW * 0.15
+	dialogueX := r.marginL + dialogueMargin
+	r.pdf.SetLeftMargin(dialogueX)
+	r.pdf.SetRightMargin(r.marginR + dialogueMargin)
+	for _, line := range lines {
+		if len(line.runs) == 0 {
+			r.pdf.Ln(r.lineHeight)
+			continue
+		}
+
+		r.setDialogueLineX(line.isVerse)
+		for _, run := range line.runs {
+			r.setStyle(run.style)
+			r.pdf.Write(r.lineHeight, run.text)
+		}
+		r.setStyle("")
+		r.pdf.Ln(r.lineHeight)
+	}
+	if showMore {
+		r.setStyle("B")
+		r.centeredText(continuedDialogueFooter)
+		r.setStyle("")
+	}
+	r.pdf.SetLeftMargin(r.marginL)
+	r.pdf.SetRightMargin(r.marginR)
+}
+
+func (r *pdfRenderer) renderDialogueHeader(character, parenthetical string, continuation, firstSegment bool) {
+	r.pdf.Ln(r.lineHeight)
+	r.setStyle("B")
+	name := strings.ToUpper(character)
+	if continuation {
+		name += continuedDialogueSuffix
+	}
+	r.centeredText(name)
+	r.setStyle("")
+
+	if firstSegment && parenthetical != "" {
+		r.setStyle("I")
+		r.centeredText(parentheticalText(parenthetical))
+		r.setStyle("")
+	}
+}
+
+func (r *pdfRenderer) dialogueHeaderHeight(firstSegment, hasParenthetical bool) float64 {
+	height := r.lineHeight * 2
+	if firstSegment && hasParenthetical {
+		height += r.lineHeight
+	}
+	return height
+}
+
+func (r *pdfRenderer) dialogueContentWidth(isVerse bool) float64 {
+	dialogueMargin := r.bodyW * 0.15
+	width := r.bodyW - (dialogueMargin * 2)
+	if isVerse {
+		width -= 10
+	}
+	if width < 10 {
+		return 10
+	}
+	return width
+}
+
+func (r *pdfRenderer) setDialogueLineX(isVerse bool) {
+	dialogueMargin := r.bodyW * 0.15
+	dialogueX := r.marginL + dialogueMargin
+	if isVerse {
+		r.pdf.SetX(dialogueX + 10)
+		return
+	}
+	r.pdf.SetX(dialogueX)
+}
+
+func fitCompleteDialogueLines(lines []bufferedDialogueLine, maxWrappedLines int) (count int, used int) {
+	if maxWrappedLines <= 0 {
+		return 0, 0
+	}
+	for _, line := range lines {
+		next := line.wrappedLineCount()
+		if used+next > maxWrappedLines {
+			break
+		}
+		used += next
+		count++
+	}
+	return count, used
+}
+
+func splitRawDialogueLine(raw, prepared bufferedDialogueLine, leftWrappedLines, minLeftWrappedLines int) (bufferedDialogueLine, bufferedDialogueLine, bool) {
+	if leftWrappedLines <= 0 || leftWrappedLines >= len(prepared.wrappedText) {
+		return bufferedDialogueLine{}, raw, false
+	}
+
+	// `prepared` carries wrap measurements only; split offsets must still map
+	// 1:1 onto the original captured runs in `raw`.
+	offset, ok := preferredSplitOffset(prepared, leftWrappedLines, minLeftWrappedLines)
+	if !ok {
+		return bufferedDialogueLine{}, raw, false
+	}
+
+	leftRuns, rightRuns := splitDialogueRuns(raw.runs, offset)
+	return bufferedDialogueLine{runs: leftRuns, isVerse: raw.isVerse}, bufferedDialogueLine{runs: rightRuns, isVerse: raw.isVerse}, true
+}
+
+func preferredSplitOffset(line bufferedDialogueLine, preferred, minLeft int) (int, bool) {
+	if preferred < minLeft {
+		return 0, false
+	}
+	ranges := wrappedLineRuneRanges(line.plainText, line.wrappedText)
+
+	boundaries := sentenceBoundaryOffsets(line.plainText)
+	if len(boundaries) > 0 {
+		for i := len(boundaries) - 1; i >= 0; i-- {
+			offset := boundaries[i]
+			leftCount, _ := wrappedLineCountsForOffset(ranges, offset)
+			if leftCount > preferred {
+				continue
+			}
+			if leftCount < minLeft {
+				break
+			}
+			return offset, true
+		}
+	}
+
+	rawOffset := dialogueSplitOffset(line.plainText, line.wrappedText[:preferred])
+	leftCount, rightCount := wrappedLineCountsForOffset(ranges, rawOffset)
+	if leftCount < minLeft || rightCount < minContinuedDialogueLines {
+		return 0, false
+	}
+	return rawOffset, true
+}
+
+func dialogueRunsPlainText(runs []dialogueTextRun) string {
+	var b strings.Builder
+	for _, run := range runs {
+		b.WriteString(run.text)
+	}
+	return b.String()
+}
+
+func dialogueSplitOffset(text string, wrapped []string) int {
+	runes := []rune(text)
+	offset := 0
+	for _, part := range wrapped {
+		partRunes := []rune(part)
+		offset += len(partRunes)
+		for offset < len(runes) && runes[offset] == ' ' {
+			offset++
+		}
+	}
+	return offset
+}
+
+type wrappedLineRuneRange struct {
+	start int
+	end   int
+}
+
+func wrappedLineRuneRanges(text string, wrapped []string) []wrappedLineRuneRange {
+	ranges := make([]wrappedLineRuneRange, 0, len(wrapped))
+	runes := []rune(text)
+	offset := 0
+	for _, part := range wrapped {
+		start := offset
+		end := start + len([]rune(part))
+		ranges = append(ranges, wrappedLineRuneRange{start: start, end: end})
+		offset = end
+		for offset < len(runes) && runes[offset] == ' ' {
+			offset++
+		}
+	}
+	return ranges
+}
+
+func sentenceBoundaryOffsets(text string) []int {
+	runes := []rune(text)
+	var offsets []int
+	for i := 0; i < len(runes); i++ {
+		if !isSentenceTerminal(runes[i]) {
+			continue
+		}
+		j := i + 1
+		for j < len(runes) && isSentenceCloser(runes[j]) {
+			j++
+		}
+		offsets = append(offsets, skipSentenceBoundarySpacing(text, j))
+	}
+	return offsets
+}
+
+func wrappedLineCountsForOffset(ranges []wrappedLineRuneRange, offset int) (int, int) {
+	leftCount := 0
+	rightCount := 0
+	for _, r := range ranges {
+		switch {
+		case offset >= r.end:
+			leftCount++
+		case offset <= r.start:
+			rightCount++
+		default:
+			leftCount++
+			rightCount++
+		}
+	}
+	return leftCount, rightCount
+}
+
+func skipSentenceBoundarySpacing(text string, offset int) int {
+	runes := []rune(text)
+	for offset < len(runes) && unicode.IsSpace(runes[offset]) {
+		offset++
+	}
+	return offset
+}
+
+func splitDialogueRuns(runs []dialogueTextRun, offset int) ([]dialogueTextRun, []dialogueTextRun) {
+	if offset <= 0 {
+		return nil, append([]dialogueTextRun(nil), runs...)
+	}
+
+	var left []dialogueTextRun
+	var right []dialogueTextRun
+	remaining := offset
+
+	for _, run := range runs {
+		runes := []rune(run.text)
+		if remaining >= len(runes) {
+			left = append(left, run)
+			remaining -= len(runes)
+			continue
+		}
+		if remaining > 0 {
+			left = append(left, dialogueTextRun{text: string(runes[:remaining]), style: run.style})
+			right = append(right, dialogueTextRun{text: string(runes[remaining:]), style: run.style})
+			remaining = 0
+			continue
+		}
+		right = append(right, run)
+	}
+
+	return trimDialogueRunsRight(left), trimDialogueRunsLeft(right)
+}
+
+func (l bufferedDialogueLine) wrappedLineCount() int {
+	if len(l.runs) == 0 {
+		return 1
+	}
+	if len(l.wrappedText) == 0 {
+		return 1
+	}
+	return len(l.wrappedText)
+}
+
+func isSentenceTerminal(r rune) bool {
+	switch r {
+	case '.', '!', '?':
+		return true
+	default:
+		return false
+	}
+}
+
+func isSentenceCloser(r rune) bool {
+	switch r {
+	case '"', '\'', ')', ']', '}':
+		return true
+	default:
+		return false
+	}
+}
+
+func trimDialogueRunsLeft(runs []dialogueTextRun) []dialogueTextRun {
+	for i := 0; i < len(runs); i++ {
+		trimmed := strings.TrimLeftFunc(runs[i].text, unicode.IsSpace)
+		if trimmed == "" {
+			continue
+		}
+		runs[i].text = trimmed
+		return runs[i:]
+	}
+	return nil
+}
+
+func trimDialogueRunsRight(runs []dialogueTextRun) []dialogueTextRun {
+	for i := len(runs) - 1; i >= 0; i-- {
+		trimmed := strings.TrimRightFunc(runs[i].text, unicode.IsSpace)
+		if trimmed == "" {
+			continue
+		}
+		runs[i].text = trimmed
+		return runs[:i+1]
+	}
+	return nil
+}

--- a/internal/render/pdf/dialogue_pagination_test.go
+++ b/internal/render/pdf/dialogue_pagination_test.go
@@ -1,0 +1,286 @@
+package pdf
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/ast"
+	"github.com/jscaltreto/downstage/internal/render"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitDialogueRunsPreservesStyles(t *testing.T) {
+	runs := []dialogueTextRun{
+		{text: "Hello ", style: ""},
+		{text: "brave ", style: "B"},
+		{text: "world", style: ""},
+	}
+
+	left, right := splitDialogueRuns(runs, len([]rune("Hello brave ")))
+
+	require.Equal(t, []dialogueTextRun{
+		{text: "Hello ", style: ""},
+		{text: "brave", style: "B"},
+	}, left)
+	require.Equal(t, []dialogueTextRun{
+		{text: "world", style: ""},
+	}, right)
+}
+
+func TestSplitDialogueRunsTrimsBoundaryWhitespace(t *testing.T) {
+	runs := []dialogueTextRun{
+		{text: "Hello.   ", style: ""},
+		{text: " next", style: "I"},
+	}
+
+	left, right := splitDialogueRuns(runs, len([]rune("Hello.   ")))
+
+	require.Equal(t, []dialogueTextRun{{text: "Hello.", style: ""}}, left)
+	require.Equal(t, []dialogueTextRun{{text: "next", style: "I"}}, right)
+}
+
+func TestPreferredSplitOffsetUsesSentenceBoundary(t *testing.T) {
+	line := bufferedDialogueLine{
+		plainText: strings.Join([]string{
+			"First sentence continues",
+			"and keeps going",
+			"until this sentence ends.",
+			"next fragment carries on",
+			"for a while longer",
+			"before it stops",
+		}, " "),
+		wrappedText: []string{
+			"First sentence continues",
+			"and keeps going",
+			"until this sentence ends.",
+			"next fragment carries on",
+			"for a while longer",
+			"before it stops",
+		},
+	}
+
+	split, ok := preferredSplitOffset(line, 5, minContinuedDialogueLines)
+	require.True(t, ok)
+	assert.Equal(t, dialogueSplitOffset(line.plainText, line.wrappedText[:3]), split)
+}
+
+func TestPreferredSplitWrappedLinesFallsBackWhenNoSentenceBoundary(t *testing.T) {
+	line := bufferedDialogueLine{
+		plainText: strings.Join([]string{
+			"First fragment",
+			"Second fragment",
+			"Third fragment",
+			"Fourth fragment",
+			"Fifth fragment",
+			"Sixth fragment",
+		}, " "),
+		wrappedText: []string{
+			"First fragment",
+			"Second fragment",
+			"Third fragment",
+			"Fourth fragment",
+			"Fifth fragment",
+			"Sixth fragment",
+		},
+	}
+
+	split, ok := preferredSplitOffset(line, 3, minContinuedDialogueLines)
+	require.True(t, ok)
+	assert.Equal(t, dialogueSplitOffset(line.plainText, line.wrappedText[:3]), split)
+}
+
+func TestPreferredSplitWrappedLinesUsesNearbySentenceBoundary(t *testing.T) {
+	line := bufferedDialogueLine{
+		plainText: strings.Join([]string{
+			"Opening fragment",
+			"middle fragment",
+			"Sentence ends here.",
+			"Second sentence keeps going",
+			"without punctuation",
+			"to the end",
+		}, " "),
+		wrappedText: []string{
+			"Opening fragment",
+			"middle fragment",
+			"Sentence ends here.",
+			"Second sentence keeps going",
+			"without punctuation",
+			"to the end",
+		},
+	}
+
+	split, ok := preferredSplitOffset(line, 5, minContinuedDialogueLines)
+	require.True(t, ok)
+	assert.Equal(t, dialogueSplitOffset(line.plainText, line.wrappedText[:3]), split)
+}
+
+func TestPreferredSplitOffsetRejectsNearbySentenceBoundaryBeforeMinimum(t *testing.T) {
+	line := bufferedDialogueLine{
+		plainText: strings.Join([]string{
+			"First sentence.",
+			"continuation fragment one",
+			"continuation fragment two",
+			"continuation fragment three",
+		}, " "),
+		wrappedText: []string{
+			"First sentence.",
+			"continuation fragment one",
+			"continuation fragment two",
+			"continuation fragment three",
+		},
+	}
+
+	_, ok := preferredSplitOffset(line, 3, minContinuedDialogueLines)
+	assert.False(t, ok)
+}
+
+func TestPreferredSplitOffsetRejectsSentenceBoundaryInsideFirstWrappedLine(t *testing.T) {
+	line := bufferedDialogueLine{
+		plainText: "I believe we are capable of extraordinary things. I also believe we are capable of repeating every error that condemned Porth, and every error we have made aboard this ship.",
+		wrappedText: []string{
+			"I believe we are capable of extraordinary things. I",
+			"also believe we are capable of repeating every error that",
+			"condemned Porth, and every error we",
+			"have made aboard this ship.",
+		},
+	}
+
+	_, ok := preferredSplitOffset(line, 3, minContinuedDialogueLines)
+	assert.False(t, ok)
+}
+
+func TestPreferredSplitOffsetFallsBackAfterUnusableSentenceBoundary(t *testing.T) {
+	line := bufferedDialogueLine{
+		plainText: strings.Join([]string{
+			"First sentence.",
+			"very long fragment one",
+			"very long fragment two",
+			"very long fragment three",
+			"very long fragment four",
+			"very long fragment five",
+		}, " "),
+		wrappedText: []string{
+			"First sentence.",
+			"very long fragment one",
+			"very long fragment two",
+			"very long fragment three",
+			"very long fragment four",
+			"very long fragment five",
+		},
+	}
+
+	split, ok := preferredSplitOffset(line, 3, minContinuedDialogueLines)
+	require.True(t, ok)
+	assert.Equal(t, dialogueSplitOffset(line.plainText, line.wrappedText[:3]), split)
+}
+
+func TestPreferredSplitWrappedLinesAllowsShortRemainderAtSentenceBoundary(t *testing.T) {
+	line := bufferedDialogueLine{
+		plainText: strings.Join([]string{
+			"long fragment one",
+			"long fragment two",
+			"long fragment three",
+			"Sentence ends here.",
+			"short remainder one",
+			"short remainder two",
+		}, " "),
+		wrappedText: []string{
+			"long fragment one",
+			"long fragment two",
+			"long fragment three",
+			"Sentence ends here.",
+			"short remainder one",
+			"short remainder two",
+		},
+	}
+
+	split, ok := preferredSplitOffset(line, 4, minContinuedDialogueLines)
+	require.True(t, ok)
+	assert.Equal(t, dialogueSplitOffset(line.plainText, line.wrappedText[:4]), split)
+}
+
+func TestRenderBufferedDialogueStartsContinuationOnNewPage(t *testing.T) {
+	r := NewRenderer(render.DefaultConfig()).(*pdfRenderer)
+	var buf bytes.Buffer
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &buf))
+	r.pdf.SetCompression(false)
+
+	r.pdf.SetY(r.pageH - r.marginB - (r.lineHeight * 8))
+	dialogue := bufferedDialogue{
+		character: "HAMLET",
+		lines: []bufferedDialogueLine{
+			{runs: []dialogueTextRun{{text: "Short line.", style: ""}}},
+			{runs: []dialogueTextRun{{text: strings.Repeat("word ", 80), style: ""}}},
+		},
+	}
+
+	require.NoError(t, r.renderBufferedDialogue(dialogue))
+	require.NoError(t, r.EndDocument(&ast.Document{}))
+	assert.Greater(t, r.pdf.PageNo(), 1)
+}
+
+func TestRenderBufferedDialogueForceSplitsSingleLongLine(t *testing.T) {
+	r := NewRenderer(render.DefaultConfig()).(*pdfRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	dialogue := bufferedDialogue{
+		character: "HAMLET",
+		lines: []bufferedDialogueLine{
+			{runs: []dialogueTextRun{{text: strings.Repeat("word ", 1200), style: ""}}},
+		},
+	}
+
+	require.NoError(t, r.renderBufferedDialogue(dialogue))
+	assert.Greater(t, r.pdf.PageNo(), 1)
+}
+
+func TestRenderBufferedDialogueStartsContinuationOnNewPageCondensed(t *testing.T) {
+	r := NewCondensedRenderer(render.DefaultConfig()).(*condensedRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	r.pdf.SetY(r.pageH - r.marginB - (r.lineHeight * 8))
+	dialogue := bufferedDialogue{
+		character: "HAMLET",
+		lines: []bufferedDialogueLine{
+			{runs: []dialogueTextRun{{text: "Short line.", style: ""}}},
+			{runs: []dialogueTextRun{{text: strings.Repeat("word ", 80), style: ""}}},
+		},
+	}
+
+	require.NoError(t, r.renderBufferedDialogue(dialogue))
+	assert.Greater(t, r.pdf.PageNo(), 1)
+}
+
+func TestRenderBufferedDialogueWithCapturedStyles(t *testing.T) {
+	r := NewRenderer(render.DefaultConfig()).(*pdfRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	dialogue := &ast.Dialogue{Character: "HAMLET"}
+	require.NoError(t, r.BeginDialogue(dialogue))
+
+	line := &ast.DialogueLine{Content: []ast.Inline{
+		&ast.TextNode{Value: strings.Repeat("word ", 80)},
+		&ast.BoldNode{Content: []ast.Inline{&ast.TextNode{Value: "bold"}}},
+		&ast.TextNode{Value: " "},
+		&ast.ItalicNode{Content: []ast.Inline{&ast.TextNode{Value: "italic"}}},
+	}}
+	require.NoError(t, r.BeginDialogueLine(line))
+	require.NoError(t, r.RenderText(line.Content[0].(*ast.TextNode)))
+	require.NoError(t, r.BeginBold(line.Content[1].(*ast.BoldNode)))
+	require.NoError(t, r.RenderText(line.Content[1].(*ast.BoldNode).Content[0].(*ast.TextNode)))
+	require.NoError(t, r.EndBold(line.Content[1].(*ast.BoldNode)))
+	require.NoError(t, r.RenderText(line.Content[2].(*ast.TextNode)))
+	require.NoError(t, r.BeginItalic(line.Content[3].(*ast.ItalicNode)))
+	require.NoError(t, r.RenderText(line.Content[3].(*ast.ItalicNode).Content[0].(*ast.TextNode)))
+	require.NoError(t, r.EndItalic(line.Content[3].(*ast.ItalicNode)))
+	require.NoError(t, r.EndDialogueLine(line))
+	require.Len(t, r.activeDialogue.lines, 1)
+	require.Equal(t, strings.Repeat("word ", 80)+"bold italic", dialogueRunsPlainText(r.activeDialogue.lines[0].runs))
+	require.Contains(t, r.activeDialogue.lines[0].runs, dialogueTextRun{text: "bold", style: "B"})
+	require.Contains(t, r.activeDialogue.lines[0].runs, dialogueTextRun{text: "italic", style: "I"})
+	require.NoError(t, r.EndDialogue(dialogue))
+
+	assert.Greater(t, r.pdf.PageNo(), 0)
+}

--- a/internal/render/pdf/dialogue_paginator.go
+++ b/internal/render/pdf/dialogue_paginator.go
@@ -1,0 +1,133 @@
+package pdf
+
+import "fmt"
+
+type dialoguePaginationStrategy interface {
+	prepare(lines []bufferedDialogueLine, dialogue bufferedDialogue, continuation, firstSegment bool) []bufferedDialogueLine
+	availableWrappedLines(dialogue bufferedDialogue, continuation, firstSegment bool) int
+	// renderSegment receives lines already prepared for the current segment
+	// context. Strategies must not re-wrap them.
+	renderSegment(dialogue bufferedDialogue, continuation, firstSegment bool, lines []bufferedDialogueLine, showMore bool)
+	addPage()
+	showContinuationFooter() bool
+}
+
+func paginateBufferedDialogue(strategy dialoguePaginationStrategy, dialogue bufferedDialogue) error {
+	remaining := append([]bufferedDialogueLine(nil), dialogue.lines...)
+	firstSegment := true
+	retriedFreshPage := false
+
+	for len(remaining) > 0 {
+		continuation := !firstSegment
+		prepared := strategy.prepare(remaining, dialogue, continuation, firstSegment)
+		linesFit := strategy.availableWrappedLines(dialogue, continuation, firstSegment)
+
+		if fullCount, _ := fitCompleteDialogueLines(prepared, linesFit); fullCount == len(prepared) {
+			strategy.renderSegment(dialogue, continuation, firstSegment, prepared, false)
+			return nil
+		}
+
+		if strategy.showContinuationFooter() {
+			linesFit = max(linesFit-1, 0)
+		}
+		fullCount, usedLines := fitCompleteDialogueLines(prepared, linesFit)
+
+		if fullCount == 0 {
+			left, right, ok := forceSplitDialogueLine(remaining[0], prepared[0], linesFit)
+			if ok {
+				leftPrepared := strategy.prepare([]bufferedDialogueLine{left}, dialogue, continuation, firstSegment)
+				strategy.renderSegment(dialogue, continuation, firstSegment, leftPrepared, true)
+				strategy.addPage()
+				remaining = append([]bufferedDialogueLine{right}, remaining[1:]...)
+				firstSegment = false
+				retriedFreshPage = false
+				continue
+			}
+			if retriedFreshPage {
+				return fmt.Errorf("dialogue line cannot fit on a fresh page")
+			}
+			strategy.addPage()
+			retriedFreshPage = true
+			continue
+		}
+
+		if usedLines < minContinuedDialogueLines {
+			if retriedFreshPage {
+				return fmt.Errorf("dialogue line cannot leave the minimum fragment on a fresh page")
+			}
+			strategy.addPage()
+			retriedFreshPage = true
+			continue
+		}
+
+		currentPrepared := prepared[fullCount]
+		if len(currentPrepared.wrappedText) == 0 || currentPrepared.wrappedLineCount() <= linesFit {
+			strategy.renderSegment(dialogue, continuation, firstSegment, prepared[:fullCount], true)
+			strategy.addPage()
+			remaining = remaining[fullCount:]
+			firstSegment = false
+			retriedFreshPage = false
+			continue
+		}
+
+		fitInCurrent := linesFit - usedLines
+		if fitInCurrent < minContinuedDialogueLines {
+			strategy.renderSegment(dialogue, continuation, firstSegment, prepared[:fullCount], true)
+			strategy.addPage()
+			remaining = remaining[fullCount:]
+			firstSegment = false
+			retriedFreshPage = false
+			continue
+		}
+
+		totalCurrentLines := currentPrepared.wrappedLineCount()
+		if totalCurrentLines-fitInCurrent < minContinuedDialogueLines {
+			fitInCurrent = totalCurrentLines - minContinuedDialogueLines
+		}
+		if fitInCurrent < minContinuedDialogueLines {
+			strategy.renderSegment(dialogue, continuation, firstSegment, prepared[:fullCount], true)
+			strategy.addPage()
+			remaining = remaining[fullCount:]
+			firstSegment = false
+			retriedFreshPage = false
+			continue
+		}
+
+		left, right, ok := splitRawDialogueLine(remaining[fullCount], currentPrepared, fitInCurrent, minContinuedDialogueLines)
+		if !ok || len(right.runs) == 0 {
+			strategy.renderSegment(dialogue, continuation, firstSegment, prepared[:fullCount], true)
+			strategy.addPage()
+			remaining = remaining[fullCount:]
+			firstSegment = false
+			retriedFreshPage = false
+			continue
+		}
+
+		segment := append(append([]bufferedDialogueLine(nil), remaining[:fullCount]...), left)
+		segmentPrepared := strategy.prepare(segment, dialogue, continuation, firstSegment)
+		strategy.renderSegment(dialogue, continuation, firstSegment, segmentPrepared, true)
+		strategy.addPage()
+		remaining = append(append([]bufferedDialogueLine(nil), right), remaining[fullCount+1:]...)
+		firstSegment = false
+		retriedFreshPage = false
+	}
+
+	return nil
+}
+
+func forceSplitDialogueLine(raw, prepared bufferedDialogueLine, linesFit int) (bufferedDialogueLine, bufferedDialogueLine, bool) {
+	if linesFit < minContinuedDialogueLines {
+		return bufferedDialogueLine{}, bufferedDialogueLine{}, false
+	}
+
+	totalLines := prepared.wrappedLineCount()
+	leftLines := linesFit
+	if totalLines-leftLines < minContinuedDialogueLines {
+		leftLines = totalLines - minContinuedDialogueLines
+	}
+	if leftLines < minContinuedDialogueLines {
+		return bufferedDialogueLine{}, bufferedDialogueLine{}, false
+	}
+
+	return splitRawDialogueLine(raw, prepared, leftLines, minContinuedDialogueLines)
+}

--- a/internal/render/pdf/pdf.go
+++ b/internal/render/pdf/pdf.go
@@ -11,6 +11,7 @@ import (
 const manuscriptLineHeight = 5.0 // mm
 
 var _ render.NodeRenderer = (*pdfRenderer)(nil)
+var _ dialoguePaginationStrategy = (*pdfRenderer)(nil)
 
 // NewRenderer creates a manuscript-style PDF NodeRenderer.
 func NewRenderer(cfg render.Config) render.NodeRenderer {
@@ -19,6 +20,7 @@ func NewRenderer(cfg render.Config) render.NodeRenderer {
 
 type pdfRenderer struct {
 	pdfBase
+	activeDialogue *bufferedDialogue
 }
 
 // --- Lifecycle ---


### PR DESCRIPTION
Summary:
- buffer dialogue and paginate it as complete speech segments instead of letting lines spill across page breaks
- add manuscript continuation handling with sentence-aware splits, MORE markers, and continued character cues
- refactor pagination into a shared strategy-driven paginator while keeping condensed acting-edition continuations marker-free

Testing:
- env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go test ./...