### PR TITLE
fix: tighten condensed layout and formatting

### DIFF
--- a/editors/vscode/syntaxes/downstage.tmLanguage.json
+++ b/editors/vscode/syntaxes/downstage.tmLanguage.json
@@ -7,7 +7,7 @@
       "include": "#comments"
     },
     {
-      "include": "#metadata"
+      "include": "#titlePage"
     },
     {
       "include": "#headings"
@@ -226,6 +226,24 @@
               "name": "string.unquoted.metadata-value.downstage"
             }
           }
+        }
+      ]
+    },
+    "titlePage": {
+      "patterns": [
+        {
+          "name": "meta.title-page.downstage",
+          "begin": "\\A(?=[A-Za-z][A-Za-z ]*:)",
+          "end": "(?=^(?!(?:[A-Za-z][A-Za-z ]*:\\s*|[ \\t].*|\\s*$)).+$)",
+          "patterns": [
+            {
+              "include": "#metadata"
+            },
+            {
+              "name": "string.unquoted.metadata-value.downstage",
+              "match": "^[ \\t]+.*$"
+            }
+          ]
         }
       ]
     },

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -238,12 +238,13 @@ var _ Node = (*Dialogue)(nil)
 
 // Dialogue represents character dialogue.
 type Dialogue struct {
-	Character          string
-	Parenthetical      string
-	Lines              []DialogueLine
-	Range              token.Range
-	nameRange          token.Range
-	parentheticalRange token.Range
+	Character            string
+	Parenthetical        string
+	parentheticalInlines []Inline
+	Lines                []DialogueLine
+	Range                token.Range
+	nameRange            token.Range
+	parentheticalRange   token.Range
 }
 
 func (d *Dialogue) NodeRange() token.Range { return d.Range }
@@ -266,6 +267,12 @@ func (d *Dialogue) ParentheticalRange() token.Range {
 }
 func (d *Dialogue) SetParentheticalRange(r token.Range) {
 	d.parentheticalRange = r
+}
+func (d *Dialogue) ParentheticalInlines() []Inline {
+	return d.parentheticalInlines
+}
+func (d *Dialogue) SetParentheticalInlines(inlines []Inline) {
+	d.parentheticalInlines = inlines
 }
 
 // --- Dual Dialogue ---

--- a/internal/ast/walk.go
+++ b/internal/ast/walk.go
@@ -47,6 +47,7 @@ func Walk(v Visitor, node Node) {
 		Walk(v, n.Right)
 
 	case *Dialogue:
+		walkInlines(v, n.ParentheticalInlines())
 		for _, line := range n.Lines {
 			walkInlines(v, line.Content)
 		}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -782,6 +782,11 @@ func (p *parser) parseDialogue() *ast.Dialogue {
 		if strings.HasPrefix(lit, "(") && strings.HasSuffix(lit, ")") {
 			pTok := p.advance()
 			dlg.Parenthetical = strings.TrimSpace(pTok.Literal)
+			inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(dlg.Parenthetical, "("), ")"))
+			if inner != "" {
+				innerRange := sliceInlineRange(dlg.Parenthetical, pTok.Range, 1, len(dlg.Parenthetical)-1)
+				dlg.SetParentheticalInlines(parseInlineContent(inner, innerRange))
+			}
 			dlg.SetParentheticalRange(pTok.Range)
 		}
 	}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1130,7 +1130,7 @@ func parseInlines(s string, r token.Range) []ast.Inline {
 				inner := s[i+1 : i+1+end]
 				nodeRange := sliceInlineRange(s, r, i, i+1+end+1)
 				result = append(result, &ast.InlineDirectionNode{
-					Content: []ast.Inline{&ast.TextNode{Value: inner, Range: sliceInlineRange(s, r, i+1, i+1+end)}},
+					Content: parseInlineContent(inner, sliceInlineRange(s, r, i+1, i+1+end)),
 					Range:   nodeRange,
 				})
 				i = i + 1 + end + 1

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -186,6 +186,32 @@ Hold there.`
 	assert.Equal(t, " NOTBOB", dlg.ParentheticalInlines()[4].(*ast.TextNode).Value)
 }
 
+func TestDialogueInlineDirectionWithFormatting(t *testing.T) {
+	input := `# Play
+
+GIDEON
+The state of our ship is strong.
+(beat; _almost_ fighting the impulse to continue.)
+By all measures.`
+
+	doc, errs := Parse([]byte(input))
+	require.Empty(t, errs)
+
+	var dlg *ast.Dialogue
+	findDialogue(doc.Body, &dlg)
+	require.NotNil(t, dlg)
+	require.Len(t, dlg.Lines, 3)
+	require.Len(t, dlg.Lines[1].Content, 1)
+
+	dir, ok := dlg.Lines[1].Content[0].(*ast.InlineDirectionNode)
+	require.True(t, ok)
+	require.Len(t, dir.Content, 3)
+	assert.Equal(t, "beat; ", dir.Content[0].(*ast.TextNode).Value)
+	_, ok = dir.Content[1].(*ast.UnderlineNode)
+	require.True(t, ok)
+	assert.Equal(t, " fighting the impulse to continue.", dir.Content[2].(*ast.TextNode).Value)
+}
+
 func TestForcedCharacter(t *testing.T) {
 	input := `# Play
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -158,7 +158,32 @@ To be or not to be.`
 	assert.Equal(t, 3, dlg.ParentheticalRange().Start.Line)
 	assert.Equal(t, 0, dlg.ParentheticalRange().Start.Column)
 	assert.Equal(t, 7, dlg.ParentheticalRange().End.Column)
+	require.Len(t, dlg.ParentheticalInlines(), 1)
+	assert.Equal(t, "aside", dlg.ParentheticalInlines()[0].(*ast.TextNode).Value)
 	assert.Len(t, dlg.Lines, 1)
+}
+
+func TestDialogueWithFormattedParenthetical(t *testing.T) {
+	input := `# Play
+
+GUARD
+(offstage, _exasperated_; **overlapping** NOTBOB)
+Hold there.`
+
+	doc, errs := Parse([]byte(input))
+	require.Empty(t, errs)
+
+	var dlg *ast.Dialogue
+	findDialogue(doc.Body, &dlg)
+	require.NotNil(t, dlg)
+	require.Len(t, dlg.ParentheticalInlines(), 5)
+	assert.Equal(t, "offstage, ", dlg.ParentheticalInlines()[0].(*ast.TextNode).Value)
+	_, ok := dlg.ParentheticalInlines()[1].(*ast.UnderlineNode)
+	require.True(t, ok)
+	assert.Equal(t, "; ", dlg.ParentheticalInlines()[2].(*ast.TextNode).Value)
+	_, ok = dlg.ParentheticalInlines()[3].(*ast.BoldNode)
+	require.True(t, ok)
+	assert.Equal(t, " NOTBOB", dlg.ParentheticalInlines()[4].(*ast.TextNode).Value)
 }
 
 func TestForcedCharacter(t *testing.T) {

--- a/internal/render/html/css.go
+++ b/internal/render/html/css.go
@@ -252,6 +252,7 @@ body {
   line-height: 1.4;
   color: #000;
   background: #fff;
+  --downstage-condensed-small-gap: 0.15em;
 }
 
 .downstage-document {
@@ -377,7 +378,7 @@ body {
   margin-left: 2em;
 }
 .downstage-line-break { display: block; }
-.downstage-dialogue-break { display: block; margin-top: 0.3em; }
+.downstage-dialogue-break { display: block; margin-top: var(--downstage-condensed-small-gap); }
 
 /* Dual Dialogue */
 .downstage-dual-dialogue {
@@ -405,7 +406,7 @@ body {
   margin-bottom: 0;
 }
 .downstage-stage-direction + .downstage-stage-direction:not(.downstage-continuation) {
-  margin-top: 0.3em;
+  margin-top: var(--downstage-condensed-small-gap);
 }
 
 /* Callout */
@@ -423,7 +424,7 @@ body {
   margin-bottom: 0;
 }
 .downstage-callout + .downstage-callout:not(.downstage-continuation) {
-  margin-top: 0.3em;
+  margin-top: var(--downstage-condensed-small-gap);
 }
 
 /* Song */

--- a/internal/render/html/html.go
+++ b/internal/render/html/html.go
@@ -308,12 +308,10 @@ func (r *htmlRenderer) BeginDialogue(d *ast.Dialogue) error {
 	fmt.Fprintf(&r.buf, "<div class=\"downstage-dialogue\"%s>\n", r.sourceAttr(d.NodeRange()))
 	fmt.Fprintf(&r.buf, "<p class=\"downstage-character\">%s</p>\n", html.EscapeString(strings.ToUpper(d.Character)))
 	if d.Parenthetical != "" {
-		paren := d.Parenthetical
-		if len(paren) == 0 || paren[0] != '(' {
-			paren = "(" + paren + ")"
-		}
-		fmt.Fprintf(&r.buf, "<p class=\"downstage-parenthetical\">%s</p>\n",
-			html.EscapeString(paren))
+		r.buf.WriteString("<p class=\"downstage-parenthetical\">")
+		r.buf.WriteString("(")
+		r.renderInlineContent(dialogueParentheticalInlines(d))
+		r.buf.WriteString(")</p>\n")
 	}
 	return nil
 }
@@ -508,6 +506,56 @@ func (r *htmlRenderer) EndInlineDirection(_ *ast.InlineDirectionNode) error {
 		r.buf.WriteString(")</span>")
 	}
 	return nil
+}
+
+func (r *htmlRenderer) renderInlineContent(inlines []ast.Inline) {
+	for _, inline := range inlines {
+		switch n := inline.(type) {
+		case *ast.TextNode:
+			r.buf.WriteString(html.EscapeString(n.Value))
+		case *ast.BoldNode:
+			r.buf.WriteString("<strong>")
+			r.renderInlineContent(n.Content)
+			r.buf.WriteString("</strong>")
+		case *ast.ItalicNode:
+			r.buf.WriteString("<em>")
+			r.renderInlineContent(n.Content)
+			r.buf.WriteString("</em>")
+		case *ast.BoldItalicNode:
+			r.buf.WriteString("<strong><em>")
+			r.renderInlineContent(n.Content)
+			r.buf.WriteString("</em></strong>")
+		case *ast.UnderlineNode:
+			r.buf.WriteString("<u>")
+			r.renderInlineContent(n.Content)
+			r.buf.WriteString("</u>")
+		case *ast.StrikethroughNode:
+			r.buf.WriteString("<del>")
+			r.renderInlineContent(n.Content)
+			r.buf.WriteString("</del>")
+		case *ast.InlineDirectionNode:
+			r.dirDepth++
+			if r.dirDepth == 1 {
+				r.buf.WriteString("<span class=\"downstage-inline-direction\">(")
+			}
+			r.renderInlineContent(n.Content)
+			r.dirDepth--
+			if r.dirDepth == 0 {
+				r.buf.WriteString(")</span>")
+			}
+		}
+	}
+}
+
+func dialogueParentheticalInlines(d *ast.Dialogue) []ast.Inline {
+	if len(d.ParentheticalInlines()) > 0 {
+		return d.ParentheticalInlines()
+	}
+	paren := strings.TrimSpace(d.Parenthetical)
+	if strings.HasPrefix(paren, "(") && strings.HasSuffix(paren, ")") {
+		paren = strings.TrimSuffix(strings.TrimPrefix(paren, "("), ")")
+	}
+	return []ast.Inline{&ast.TextNode{Value: paren}}
 }
 
 // --- Helpers ---

--- a/internal/render/html/html_test.go
+++ b/internal/render/html/html_test.go
@@ -95,6 +95,31 @@ func TestRender_DialogueWithFormatting(t *testing.T) {
 	assert.Contains(t, out, "</div>")
 }
 
+func TestRender_DialogueParentheticalWithFormatting(t *testing.T) {
+	parenthetical := []ast.Inline{
+		&ast.TextNode{Value: "offstage, "},
+		&ast.UnderlineNode{Content: []ast.Inline{&ast.TextNode{Value: "exasperated"}}},
+		&ast.TextNode{Value: "; "},
+		&ast.BoldNode{Content: []ast.Inline{&ast.TextNode{Value: "overlapping"}}},
+		&ast.TextNode{Value: " NOTBOB"},
+	}
+	doc := &ast.Document{
+		Body: []ast.Node{
+			&ast.Dialogue{
+				Character:     "GUARD",
+				Parenthetical: "(offstage, _exasperated_; **overlapping** NOTBOB)",
+				Lines: []ast.DialogueLine{
+					{Content: []ast.Inline{&ast.TextNode{Value: "Hold there."}}},
+				},
+			},
+		},
+	}
+	doc.Body[0].(*ast.Dialogue).SetParentheticalInlines(parenthetical)
+	out := renderHTML(t, doc)
+
+	assert.Contains(t, out, `<p class="downstage-parenthetical">(offstage, <u>exasperated</u>; <strong>overlapping</strong> NOTBOB)</p>`)
+}
+
 func TestRender_DualDialogue(t *testing.T) {
 	doc := &ast.Document{
 		Body: []ast.Node{
@@ -140,6 +165,25 @@ func TestRender_StageDirection(t *testing.T) {
 	out := renderHTML(t, doc)
 
 	assert.Contains(t, out, "<p class=\"downstage-stage-direction\">The lights dim slowly.</p>")
+}
+
+func TestRender_StageDirectionWithNestedItalic(t *testing.T) {
+	doc := &ast.Document{
+		Body: []ast.Node{
+			&ast.StageDirection{
+				Content: []ast.Inline{
+					&ast.TextNode{Value: "Not performing humanity, not approximating it--"},
+					&ast.ItalicNode{Content: []ast.Inline{
+						&ast.TextNode{Value: "inhabiting"},
+					}},
+					&ast.TextNode{Value: " it."},
+				},
+			},
+		},
+	}
+	out := renderHTML(t, doc)
+
+	assert.Contains(t, out, "<p class=\"downstage-stage-direction\">Not performing humanity, not approximating it--<em>inhabiting</em> it.</p>")
 }
 
 func TestRender_Callout(t *testing.T) {

--- a/internal/render/html/html_test.go
+++ b/internal/render/html/html_test.go
@@ -120,6 +120,28 @@ func TestRender_DialogueParentheticalWithFormatting(t *testing.T) {
 	assert.Contains(t, out, `<p class="downstage-parenthetical">(offstage, <u>exasperated</u>; <strong>overlapping</strong> NOTBOB)</p>`)
 }
 
+func TestRender_InlineDirectionWithFormatting(t *testing.T) {
+	doc := &ast.Document{
+		Body: []ast.Node{
+			&ast.Dialogue{
+				Character: "GIDEON",
+				Lines: []ast.DialogueLine{
+					{Content: []ast.Inline{
+						&ast.InlineDirectionNode{Content: []ast.Inline{
+							&ast.TextNode{Value: "beat; "},
+							&ast.UnderlineNode{Content: []ast.Inline{&ast.TextNode{Value: "almost"}}},
+							&ast.TextNode{Value: " fighting the impulse to continue."},
+						}},
+					}},
+				},
+			},
+		},
+	}
+	out := renderHTML(t, doc)
+
+	assert.Contains(t, out, `<span class="downstage-inline-direction">(beat; <u>almost</u> fighting the impulse to continue.)</span>`)
+}
+
 func TestRender_DualDialogue(t *testing.T) {
 	doc := &ast.Document{
 		Body: []ast.Node{

--- a/internal/render/pdf/base.go
+++ b/internal/render/pdf/base.go
@@ -95,8 +95,7 @@ func (b *pdfBase) initPDF(fontLoader func(*fpdf.Fpdf), defaultFamily string) {
 	b.pdf.SetFooterFunc(func() {
 		b.pdf.SetY(-b.marginB + 5)
 		b.pdf.SetFont(b.cfg.FontFamily, "", b.cfg.FontSize-2)
-		b.pdf.CellFormat(0, 10, fmt.Sprintf("%d", b.pdf.PageNo()),
-			"", 0, "C", false, 0, "")
+		b.renderPageNumberFooter(fmt.Sprintf("%d", b.pdf.PageNo()), 10)
 		b.pdf.SetFont(b.cfg.FontFamily, "", b.cfg.FontSize)
 	})
 
@@ -333,6 +332,12 @@ func (b *pdfBase) ensureSpace(mm float64) {
 
 func (b *pdfBase) centeredText(text string) {
 	b.pdf.CellFormat(b.bodyW, b.lineHeight, text, "", 1, "C", false, 0, "")
+}
+
+func (b *pdfBase) renderPageNumberFooter(text string, height float64) {
+	width := b.pdf.GetStringWidth(text)
+	b.pdf.SetX((b.pageW - width) / 2)
+	b.pdf.CellFormat(width, height, text, "", 0, "", false, 0, "")
 }
 
 func (b *pdfBase) centeredInlines(inlines []ast.Inline, prefix, suffix string) error {

--- a/internal/render/pdf/base.go
+++ b/internal/render/pdf/base.go
@@ -26,6 +26,7 @@ type pdfBase struct {
 	marginB        float64
 	bodyW          float64 // pageW - marginL - marginR
 	fontStyle      string  // tracks current accumulated style
+	styleStack     []string
 	dirDepth       int     // nesting depth of InlineDirectionNodes
 	hasTitlePage   bool    // whether a title page was rendered
 	hasBody        bool    // whether the document has body content after front matter
@@ -46,6 +47,7 @@ type pdfBase struct {
 	// Buffered dialogue inline capture for custom pagination.
 	captureDialogueLine bool
 	captureStyle        string
+	captureStyleStack   []string
 	captureDirDepth     int
 	capturedRuns        []dialogueTextRun
 }
@@ -100,6 +102,7 @@ func (b *pdfBase) initPDF(fontLoader func(*fpdf.Fpdf), defaultFamily string) {
 
 	b.pdf.AddPage()
 	b.fontStyle = ""
+	b.styleStack = b.styleStack[:0]
 }
 
 // --- Inline rendering (shared by all PDF renderers) ---
@@ -115,7 +118,7 @@ func (b *pdfBase) RenderText(t *ast.TextNode) error {
 
 func (b *pdfBase) BeginBold(_ *ast.BoldNode) error {
 	if b.captureDialogueLine {
-		b.captureStyle = mergeStyles(b.captureStyle, "B")
+		b.pushCaptureStyle("B")
 		return nil
 	}
 	b.pushStyle("B")
@@ -124,16 +127,16 @@ func (b *pdfBase) BeginBold(_ *ast.BoldNode) error {
 
 func (b *pdfBase) EndBold(_ *ast.BoldNode) error {
 	if b.captureDialogueLine {
-		b.captureStyle = removeStyles(b.captureStyle, "B")
+		b.popCaptureStyle()
 		return nil
 	}
-	b.popStyle("B")
+	b.popStyle()
 	return nil
 }
 
 func (b *pdfBase) BeginItalic(_ *ast.ItalicNode) error {
 	if b.captureDialogueLine {
-		b.captureStyle = mergeStyles(b.captureStyle, "I")
+		b.pushCaptureStyle("I")
 		return nil
 	}
 	b.pushStyle("I")
@@ -142,16 +145,16 @@ func (b *pdfBase) BeginItalic(_ *ast.ItalicNode) error {
 
 func (b *pdfBase) EndItalic(_ *ast.ItalicNode) error {
 	if b.captureDialogueLine {
-		b.captureStyle = removeStyles(b.captureStyle, "I")
+		b.popCaptureStyle()
 		return nil
 	}
-	b.popStyle("I")
+	b.popStyle()
 	return nil
 }
 
 func (b *pdfBase) BeginBoldItalic(_ *ast.BoldItalicNode) error {
 	if b.captureDialogueLine {
-		b.captureStyle = mergeStyles(b.captureStyle, "BI")
+		b.pushCaptureStyle("BI")
 		return nil
 	}
 	b.pushStyle("BI")
@@ -160,16 +163,16 @@ func (b *pdfBase) BeginBoldItalic(_ *ast.BoldItalicNode) error {
 
 func (b *pdfBase) EndBoldItalic(_ *ast.BoldItalicNode) error {
 	if b.captureDialogueLine {
-		b.captureStyle = removeStyles(b.captureStyle, "BI")
+		b.popCaptureStyle()
 		return nil
 	}
-	b.popStyle("BI")
+	b.popStyle()
 	return nil
 }
 
 func (b *pdfBase) BeginUnderline(_ *ast.UnderlineNode) error {
 	if b.captureDialogueLine {
-		b.captureStyle = mergeStyles(b.captureStyle, "U")
+		b.pushCaptureStyle("U")
 		return nil
 	}
 	b.pushStyle("U")
@@ -178,16 +181,16 @@ func (b *pdfBase) BeginUnderline(_ *ast.UnderlineNode) error {
 
 func (b *pdfBase) EndUnderline(_ *ast.UnderlineNode) error {
 	if b.captureDialogueLine {
-		b.captureStyle = removeStyles(b.captureStyle, "U")
+		b.popCaptureStyle()
 		return nil
 	}
-	b.popStyle("U")
+	b.popStyle()
 	return nil
 }
 
 func (b *pdfBase) BeginStrikethrough(_ *ast.StrikethroughNode) error {
 	if b.captureDialogueLine {
-		b.captureStyle = mergeStyles(b.captureStyle, "S")
+		b.pushCaptureStyle("S")
 		return nil
 	}
 	b.pushStyle("S")
@@ -196,16 +199,16 @@ func (b *pdfBase) BeginStrikethrough(_ *ast.StrikethroughNode) error {
 
 func (b *pdfBase) EndStrikethrough(_ *ast.StrikethroughNode) error {
 	if b.captureDialogueLine {
-		b.captureStyle = removeStyles(b.captureStyle, "S")
+		b.popCaptureStyle()
 		return nil
 	}
-	b.popStyle("S")
+	b.popStyle()
 	return nil
 }
 
 func (b *pdfBase) BeginInlineDirection(_ *ast.InlineDirectionNode) error {
 	if b.captureDialogueLine {
-		b.captureStyle = mergeStyles(b.captureStyle, "I")
+		b.pushCaptureStyle("I")
 		b.captureDirDepth++
 		if b.captureDirDepth == 1 {
 			b.appendCapturedText("(")
@@ -226,20 +229,21 @@ func (b *pdfBase) EndInlineDirection(_ *ast.InlineDirectionNode) error {
 		if b.captureDirDepth == 0 {
 			b.appendCapturedText(")")
 		}
-		b.captureStyle = removeStyles(b.captureStyle, "I")
+		b.popCaptureStyle()
 		return nil
 	}
 	b.dirDepth--
 	if b.dirDepth == 0 {
 		b.pdf.Write(b.lineHeight, ")")
 	}
-	b.popStyle("I")
+	b.popStyle()
 	return nil
 }
 
 func (b *pdfBase) beginCapturedDialogueLine() {
 	b.captureDialogueLine = true
 	b.captureStyle = ""
+	b.captureStyleStack = b.captureStyleStack[:0]
 	b.captureDirDepth = 0
 	b.capturedRuns = b.capturedRuns[:0]
 }
@@ -248,6 +252,7 @@ func (b *pdfBase) endCapturedDialogueLine() []dialogueTextRun {
 	runs := append([]dialogueTextRun(nil), b.capturedRuns...)
 	b.captureDialogueLine = false
 	b.captureStyle = ""
+	b.captureStyleStack = b.captureStyleStack[:0]
 	b.captureDirDepth = 0
 	b.capturedRuns = b.capturedRuns[:0]
 	return runs
@@ -290,13 +295,34 @@ func (b *pdfBase) setStyle(style string) {
 }
 
 func (b *pdfBase) pushStyle(add string) {
+	b.styleStack = append(b.styleStack, b.fontStyle)
 	merged := mergeStyles(b.fontStyle, add)
 	b.setStyle(merged)
 }
 
-func (b *pdfBase) popStyle(remove string) {
-	result := removeStyles(b.fontStyle, remove)
-	b.setStyle(result)
+func (b *pdfBase) popStyle() {
+	if len(b.styleStack) == 0 {
+		b.setStyle("")
+		return
+	}
+	prev := b.styleStack[len(b.styleStack)-1]
+	b.styleStack = b.styleStack[:len(b.styleStack)-1]
+	b.setStyle(prev)
+}
+
+func (b *pdfBase) pushCaptureStyle(add string) {
+	b.captureStyleStack = append(b.captureStyleStack, b.captureStyle)
+	b.captureStyle = mergeStyles(b.captureStyle, add)
+}
+
+func (b *pdfBase) popCaptureStyle() {
+	if len(b.captureStyleStack) == 0 {
+		b.captureStyle = ""
+		return
+	}
+	prev := b.captureStyleStack[len(b.captureStyleStack)-1]
+	b.captureStyleStack = b.captureStyleStack[:len(b.captureStyleStack)-1]
+	b.captureStyle = prev
 }
 
 func (b *pdfBase) ensureSpace(mm float64) {
@@ -307,6 +333,23 @@ func (b *pdfBase) ensureSpace(mm float64) {
 
 func (b *pdfBase) centeredText(text string) {
 	b.pdf.CellFormat(b.bodyW, b.lineHeight, text, "", 1, "C", false, 0, "")
+}
+
+func (b *pdfBase) centeredInlines(inlines []ast.Inline, prefix, suffix string) error {
+	text := prefix + render.PlainText(inlines) + suffix
+	width := b.pdf.GetStringWidth(text)
+	b.pdf.SetX(b.marginL + (b.bodyW-width)/2)
+	if prefix != "" {
+		b.pdf.Write(b.lineHeight, prefix)
+	}
+	if err := b.renderInlineContent(inlines); err != nil {
+		return err
+	}
+	if suffix != "" {
+		b.pdf.Write(b.lineHeight, suffix)
+	}
+	b.pdf.Ln(b.lineHeight)
+	return nil
 }
 
 func (b *pdfBase) remainingPageHeight() float64 {
@@ -344,17 +387,106 @@ func mergeStyles(a, b string) string {
 	return out.String()
 }
 
-// removeStyles removes specific style flags from a style string.
-func removeStyles(style, remove string) string {
-	removeSet := make(map[byte]bool)
-	for i := range len(remove) {
-		removeSet[remove[i]] = true
-	}
-	var out strings.Builder
-	for i := range len(style) {
-		if !removeSet[style[i]] {
-			out.WriteByte(style[i])
+func (b *pdfBase) renderInlineContent(inlines []ast.Inline) error {
+	for _, inline := range inlines {
+		switch n := inline.(type) {
+		case *ast.TextNode:
+			if err := b.RenderText(n); err != nil {
+				return err
+			}
+		case *ast.BoldNode:
+			if err := b.BeginBold(n); err != nil {
+				return err
+			}
+			if err := b.renderInlineContent(n.Content); err != nil {
+				return err
+			}
+			if err := b.EndBold(n); err != nil {
+				return err
+			}
+		case *ast.ItalicNode:
+			if err := b.BeginItalic(n); err != nil {
+				return err
+			}
+			if err := b.renderInlineContent(n.Content); err != nil {
+				return err
+			}
+			if err := b.EndItalic(n); err != nil {
+				return err
+			}
+		case *ast.BoldItalicNode:
+			if err := b.BeginBoldItalic(n); err != nil {
+				return err
+			}
+			if err := b.renderInlineContent(n.Content); err != nil {
+				return err
+			}
+			if err := b.EndBoldItalic(n); err != nil {
+				return err
+			}
+		case *ast.UnderlineNode:
+			if err := b.BeginUnderline(n); err != nil {
+				return err
+			}
+			if err := b.renderInlineContent(n.Content); err != nil {
+				return err
+			}
+			if err := b.EndUnderline(n); err != nil {
+				return err
+			}
+		case *ast.StrikethroughNode:
+			if err := b.BeginStrikethrough(n); err != nil {
+				return err
+			}
+			if err := b.renderInlineContent(n.Content); err != nil {
+				return err
+			}
+			if err := b.EndStrikethrough(n); err != nil {
+				return err
+			}
+		case *ast.InlineDirectionNode:
+			if err := b.BeginInlineDirection(n); err != nil {
+				return err
+			}
+			if err := b.renderInlineContent(n.Content); err != nil {
+				return err
+			}
+			if err := b.EndInlineDirection(n); err != nil {
+				return err
+			}
 		}
 	}
-	return out.String()
+	return nil
+}
+
+func dialogueParentheticalInlines(d *ast.Dialogue) []ast.Inline {
+	return parentheticalInlineContent(d.Parenthetical, d.ParentheticalInlines())
+}
+
+func parentheticalInlineContent(parenthetical string, inlines []ast.Inline) []ast.Inline {
+	if len(inlines) > 0 {
+		return inlines
+	}
+	paren := strings.TrimSpace(parenthetical)
+	if strings.HasPrefix(paren, "(") && strings.HasSuffix(paren, ")") {
+		paren = strings.TrimSuffix(strings.TrimPrefix(paren, "("), ")")
+	}
+	if paren == "" {
+		return nil
+	}
+	return []ast.Inline{&ast.TextNode{Value: paren}}
+}
+
+func parentheticalPlainText(parenthetical string, inlines []ast.Inline) string {
+	if len(inlines) > 0 {
+		return "(" + render.PlainText(inlines) + ")"
+	}
+	paren := parenthetical
+	if paren == "" {
+		return ""
+	}
+	if paren[0] != '(' {
+		paren = "(" + paren + ")"
+	}
+	return paren
 }

--- a/internal/render/pdf/body.go
+++ b/internal/render/pdf/body.go
@@ -165,9 +165,10 @@ func (r *pdfRenderer) BeginDialogue(d *ast.Dialogue) error {
 		return r.beginDualDialogueSide(d)
 	}
 	r.activeDialogue = &bufferedDialogue{
-		character:     d.Character,
-		parenthetical: d.Parenthetical,
-		lines:         make([]bufferedDialogueLine, 0, len(d.Lines)),
+		character:            d.Character,
+		parenthetical:        d.Parenthetical,
+		parentheticalInlines: dialogueParentheticalInlines(d),
+		lines:                make([]bufferedDialogueLine, 0, len(d.Lines)),
 	}
 	return nil
 }
@@ -206,14 +207,16 @@ func (r *pdfRenderer) beginDualDialogueSide(d *ast.Dialogue) error {
 
 	// Parenthetical — centered in column, italic
 	if d.Parenthetical != "" {
+		parenInlines := dialogueParentheticalInlines(d)
 		r.setStyle("I")
-		paren := d.Parenthetical
-		if len(paren) == 0 || paren[0] != '(' {
-			paren = "(" + paren + ")"
-		}
+		paren := parentheticalPlainText(d.Parenthetical, parenInlines)
 		parenW := r.pdf.GetStringWidth(paren)
 		r.pdf.SetX(leftM + (colW-parenW)/2)
-		r.pdf.Write(r.lineHeight, paren)
+		r.pdf.Write(r.lineHeight, "(")
+		if err := r.renderInlineContent(parenInlines); err != nil {
+			return err
+		}
+		r.pdf.Write(r.lineHeight, ")")
 		r.pdf.Ln(r.lineHeight)
 		r.setStyle("")
 	}

--- a/internal/render/pdf/condensed.go
+++ b/internal/render/pdf/condensed.go
@@ -94,8 +94,7 @@ func (r *condensedRenderer) initCondensedPDF() {
 	r.pdf.SetFooterFunc(func() {
 		r.pdf.SetY(-r.marginB + 3)
 		r.pdf.SetFont(r.cfg.FontFamily, "", r.cfg.FontSize-2)
-		r.pdf.CellFormat(0, 8, fmt.Sprintf("%d", r.pdf.PageNo()),
-			"", 0, "C", false, 0, "")
+		r.renderPageNumberFooter(fmt.Sprintf("%d", r.pdf.PageNo()), 8)
 		r.pdf.SetFont(r.cfg.FontFamily, "", r.cfg.FontSize)
 	})
 

--- a/internal/render/pdf/condensed.go
+++ b/internal/render/pdf/condensed.go
@@ -11,6 +11,7 @@ import (
 
 const condensedLineHeight = 4.5 // mm
 const halfInchPt = 36.0         // 0.5 inch in points
+const condensedSmallGapFactor = 0.25
 
 // Half-letter page size: 5.5" x 8.5"
 const (
@@ -40,6 +41,10 @@ type condensedRenderer struct {
 	pdfBase
 	dualDialogueInlineFirstLine bool
 	activeDialogue              *bufferedDialogue
+}
+
+func (r *condensedRenderer) condensedSmallGap() float64 {
+	return r.lineHeight * condensedSmallGapFactor
 }
 
 // --- Lifecycle ---
@@ -309,9 +314,10 @@ func (r *condensedRenderer) BeginDialogue(d *ast.Dialogue) error {
 		return r.beginDualDialogueSide(d)
 	}
 	r.activeDialogue = &bufferedDialogue{
-		character:     d.Character,
-		parenthetical: d.Parenthetical,
-		lines:         make([]bufferedDialogueLine, 0, len(d.Lines)),
+		character:            d.Character,
+		parenthetical:        d.Parenthetical,
+		parentheticalInlines: dialogueParentheticalInlines(d),
+		lines:                make([]bufferedDialogueLine, 0, len(d.Lines)),
 	}
 	return nil
 }
@@ -325,13 +331,13 @@ func (r *condensedRenderer) beginDualDialogueSide(d *ast.Dialogue) error {
 	if r.dualSide == 0 {
 		leftM = r.marginL
 		rightM = r.pageW - r.marginL - colW
-		r.pdf.Ln(r.lineHeight / 2)
+		r.pdf.Ln(r.condensedSmallGap())
 	} else {
 		r.dualMidY = r.pdf.GetY()
 		r.pdf.SetY(r.dualStartY)
 		leftM = r.marginL + halfW + gap/2
 		rightM = r.marginR
-		r.pdf.Ln(r.lineHeight / 2)
+		r.pdf.Ln(r.condensedSmallGap())
 	}
 
 	r.pdf.SetLeftMargin(leftM)
@@ -348,12 +354,13 @@ func (r *condensedRenderer) beginDualDialogueSide(d *ast.Dialogue) error {
 
 	// Parenthetical
 	if d.Parenthetical != "" {
+		parenInlines := dialogueParentheticalInlines(d)
 		r.setStyle("I")
-		paren := d.Parenthetical
-		if len(paren) == 0 || paren[0] != '(' {
-			paren = "(" + paren + ")"
+		r.pdf.Write(r.lineHeight, "(")
+		if err := r.renderInlineContent(parenInlines); err != nil {
+			return err
 		}
-		r.pdf.Write(r.lineHeight, paren)
+		r.pdf.Write(r.lineHeight, ")")
 		r.setStyle("")
 		r.pdf.Write(r.lineHeight, " ")
 	}
@@ -379,14 +386,10 @@ func (r *condensedRenderer) estimateDialogueHeight(d *ast.Dialogue, width float6
 		return 0
 	}
 
-	height := r.lineHeight / 2
+	height := r.condensedSmallGap()
 	firstLineWidth := width - r.pdf.GetStringWidth(strings.ToUpper(d.Character)+".  ")
 	if d.Parenthetical != "" {
-		paren := d.Parenthetical
-		if len(paren) == 0 || paren[0] != '(' {
-			paren = "(" + paren + ")"
-		}
-		firstLineWidth -= r.pdf.GetStringWidth(paren + " ")
+		firstLineWidth -= r.pdf.GetStringWidth(parentheticalPlainText(d.Parenthetical, dialogueParentheticalInlines(d)) + " ")
 	}
 	if firstLineWidth < 10 {
 		firstLineWidth = 10
@@ -398,7 +401,7 @@ func (r *condensedRenderer) estimateDialogueHeight(d *ast.Dialogue, width float6
 
 	for i, line := range d.Lines {
 		if len(line.Content) == 0 {
-			height += r.lineHeight / 2
+			height += r.condensedSmallGap()
 			continue
 		}
 		lineWidth := width
@@ -483,7 +486,7 @@ func (r *condensedRenderer) EndDialogueLine(line *ast.DialogueLine) error {
 	}
 
 	if len(line.Content) == 0 {
-		r.pdf.Ln(r.lineHeight / 2)
+		r.pdf.Ln(r.condensedSmallGap())
 		return nil
 	}
 	r.pdf.Ln(r.lineHeight)
@@ -500,10 +503,10 @@ func (r *condensedRenderer) BeginStageDirection(sd *ast.StageDirection) error {
 	case r.prevWasStageDirection:
 		// Separated by blank lines — small paragraph break
 		r.ensureSpace(r.lineHeight * 2)
-		r.pdf.Ln(r.lineHeight / 2)
+		r.pdf.Ln(r.condensedSmallGap())
 	default:
 		r.ensureSpace(r.lineHeight * 2)
-		r.pdf.Ln(r.lineHeight / 2)
+		r.pdf.Ln(r.condensedSmallGap())
 	}
 
 	stageIndent := halfInchPt * pointsToMM
@@ -529,10 +532,10 @@ func (r *condensedRenderer) BeginCallout(c *ast.Callout) error {
 	case c.Continuation:
 	case r.prevWasCallout:
 		r.ensureSpace(r.lineHeight * 2)
-		r.pdf.Ln(r.lineHeight)
+		r.pdf.Ln(r.condensedSmallGap())
 	default:
 		r.ensureSpace(r.lineHeight * 2)
-		r.pdf.Ln(r.lineHeight / 2)
+		r.pdf.Ln(r.condensedSmallGap())
 	}
 
 	calloutIndent := 2 * halfInchPt * pointsToMM

--- a/internal/render/pdf/condensed_dialogue_pagination.go
+++ b/internal/render/pdf/condensed_dialogue_pagination.go
@@ -232,37 +232,32 @@ func (r *condensedRenderer) captureInlineRuns(inlines []ast.Inline, baseStyle st
 
 func (r *condensedRenderer) renderWrappedStyledRuns(startX float64, runs []dialogueTextRun, maxWidth float64) float64 {
 	leftM, _, _, _ := r.pdf.GetMargins()
+	tokens := tokenizeDialogueRuns(runs)
 	x := startX
-	var pendingSpaces []styledDialogueToken
 
-	for _, token := range tokenizeDialogueRuns(runs) {
-		if token.whitespace {
-			pendingSpaces = append(pendingSpaces, token)
-			continue
-		}
-
-		spaceWidth := 0.0
-		for _, ws := range pendingSpaces {
-			spaceWidth += r.measureTextWidth(ws.style, ws.text)
-		}
-		tokenWidth := r.measureTextWidth(token.style, token.text)
-		if x > 0 && x+spaceWidth+tokenWidth > maxWidth {
+	for len(tokens) > 0 {
+		lineRuns, remainingTokens, endX := r.fitStyledRunsToWidth(x, tokens, maxWidth)
+		if len(lineRuns) == 0 {
 			r.pdf.Ln(r.lineHeight)
 			r.pdf.SetX(leftM)
 			x = 0
-			pendingSpaces = nil
-			spaceWidth = 0
+			tokens = trimLeadingWhitespaceTokens(tokens)
+			continue
 		}
 
-		for _, ws := range pendingSpaces {
-			r.setStyle(ws.style)
-			r.pdf.Write(r.lineHeight, ws.text)
-			x += r.measureTextWidth(ws.style, ws.text)
+		for _, run := range lineRuns {
+			r.setStyle(run.style)
+			r.pdf.Write(r.lineHeight, run.text)
 		}
-		r.setStyle(token.style)
-		r.pdf.Write(r.lineHeight, token.text)
-		x += tokenWidth
-		pendingSpaces = nil
+		x = endX
+		tokens = remainingTokens
+		if len(tokens) == 0 {
+			break
+		}
+
+		r.pdf.Ln(r.lineHeight)
+		r.pdf.SetX(leftM)
+		x = 0
 	}
 
 	r.setStyle("")
@@ -302,36 +297,8 @@ func tokenizeDialogueRuns(runs []dialogueTextRun) []styledDialogueToken {
 }
 
 func (r *condensedRenderer) splitRunsForWidth(startX float64, runs []dialogueTextRun, maxWidth float64) ([]dialogueTextRun, []dialogueTextRun) {
-	tokens := tokenizeDialogueRuns(runs)
-	x := startX
-	var pendingSpaces []styledDialogueToken
-	var first []dialogueTextRun
-
-	for i, token := range tokens {
-		if token.whitespace {
-			pendingSpaces = append(pendingSpaces, token)
-			continue
-		}
-
-		spaceWidth := 0.0
-		for _, ws := range pendingSpaces {
-			spaceWidth += r.measureTextWidth(ws.style, ws.text)
-		}
-		tokenWidth := r.measureTextWidth(token.style, token.text)
-		if x > 0 && x+spaceWidth+tokenWidth > maxWidth {
-			return first, collapseStyledTokens(tokens[i:])
-		}
-
-		for _, ws := range pendingSpaces {
-			first = appendDialogueRun(first, ws.text, ws.style)
-			x += r.measureTextWidth(ws.style, ws.text)
-		}
-		first = appendDialogueRun(first, token.text, token.style)
-		x += tokenWidth
-		pendingSpaces = nil
-	}
-
-	return first, nil
+	first, remaining, _ := r.fitStyledRunsToWidth(startX, tokenizeDialogueRuns(runs), maxWidth)
+	return first, collapseStyledTokens(remaining)
 }
 
 func collapseStyledTokens(tokens []styledDialogueToken) []dialogueTextRun {
@@ -351,6 +318,52 @@ func appendDialogueRun(runs []dialogueTextRun, text, style string) []dialogueTex
 		return runs
 	}
 	return append(runs, dialogueTextRun{text: text, style: style})
+}
+
+func (r *condensedRenderer) fitStyledRunsToWidth(startX float64, tokens []styledDialogueToken, maxWidth float64) ([]dialogueTextRun, []styledDialogueToken, float64) {
+	x := startX
+	var lineRuns []dialogueTextRun
+	var pendingSpaces []styledDialogueToken
+
+	for i, token := range tokens {
+		if token.whitespace {
+			pendingSpaces = append(pendingSpaces, token)
+			continue
+		}
+
+		spaceWidth := r.measureStyledTokenWidth(pendingSpaces)
+		tokenWidth := r.measureTextWidth(token.style, token.text)
+		if x > 0 && x+spaceWidth+tokenWidth > maxWidth {
+			return lineRuns, trimLeadingWhitespaceTokens(tokens[i:]), x
+		}
+
+		for _, ws := range pendingSpaces {
+			lineRuns = appendDialogueRun(lineRuns, ws.text, ws.style)
+			x += r.measureTextWidth(ws.style, ws.text)
+		}
+		lineRuns = appendDialogueRun(lineRuns, token.text, token.style)
+		x += tokenWidth
+		pendingSpaces = nil
+	}
+
+	return lineRuns, nil, x
+}
+
+func (r *condensedRenderer) measureStyledTokenWidth(tokens []styledDialogueToken) float64 {
+	width := 0.0
+	for _, token := range tokens {
+		width += r.measureTextWidth(token.style, token.text)
+	}
+	return width
+}
+
+func trimLeadingWhitespaceTokens(tokens []styledDialogueToken) []styledDialogueToken {
+	for i, token := range tokens {
+		if !token.whitespace {
+			return tokens[i:]
+		}
+	}
+	return nil
 }
 
 func (r *condensedRenderer) layoutCondensedInlineText(startX float64, extraLines int, text, style string) (float64, int) {

--- a/internal/render/pdf/condensed_dialogue_pagination.go
+++ b/internal/render/pdf/condensed_dialogue_pagination.go
@@ -233,31 +233,36 @@ func (r *condensedRenderer) captureInlineRuns(inlines []ast.Inline, baseStyle st
 func (r *condensedRenderer) renderWrappedStyledRuns(startX float64, runs []dialogueTextRun, maxWidth float64) float64 {
 	leftM, _, _, _ := r.pdf.GetMargins()
 	x := startX
-	pendingSpaces := ""
+	var pendingSpaces []styledDialogueToken
 
 	for _, token := range tokenizeDialogueRuns(runs) {
 		if token.whitespace {
-			pendingSpaces += token.text
+			pendingSpaces = append(pendingSpaces, token)
 			continue
 		}
 
-		text := token.text
-		if x > 0 {
-			text = pendingSpaces + text
+		spaceWidth := 0.0
+		for _, ws := range pendingSpaces {
+			spaceWidth += r.measureTextWidth(ws.style, ws.text)
 		}
-		width := r.measureTextWidth(token.style, text)
-		if x > 0 && x+width > maxWidth {
+		tokenWidth := r.measureTextWidth(token.style, token.text)
+		if x > 0 && x+spaceWidth+tokenWidth > maxWidth {
 			r.pdf.Ln(r.lineHeight)
 			r.pdf.SetX(leftM)
 			x = 0
-			text = token.text
-			width = r.measureTextWidth(token.style, text)
+			pendingSpaces = nil
+			spaceWidth = 0
 		}
 
+		for _, ws := range pendingSpaces {
+			r.setStyle(ws.style)
+			r.pdf.Write(r.lineHeight, ws.text)
+			x += r.measureTextWidth(ws.style, ws.text)
+		}
 		r.setStyle(token.style)
-		r.pdf.Write(r.lineHeight, text)
-		x += width
-		pendingSpaces = ""
+		r.pdf.Write(r.lineHeight, token.text)
+		x += tokenWidth
+		pendingSpaces = nil
 	}
 
 	r.setStyle("")
@@ -299,27 +304,31 @@ func tokenizeDialogueRuns(runs []dialogueTextRun) []styledDialogueToken {
 func (r *condensedRenderer) splitRunsForWidth(startX float64, runs []dialogueTextRun, maxWidth float64) ([]dialogueTextRun, []dialogueTextRun) {
 	tokens := tokenizeDialogueRuns(runs)
 	x := startX
-	pendingSpaces := ""
+	var pendingSpaces []styledDialogueToken
 	var first []dialogueTextRun
 
 	for i, token := range tokens {
 		if token.whitespace {
-			pendingSpaces += token.text
+			pendingSpaces = append(pendingSpaces, token)
 			continue
 		}
 
-		text := token.text
-		if x > 0 {
-			text = pendingSpaces + text
+		spaceWidth := 0.0
+		for _, ws := range pendingSpaces {
+			spaceWidth += r.measureTextWidth(ws.style, ws.text)
 		}
-		width := r.measureTextWidth(token.style, text)
-		if x > 0 && x+width > maxWidth {
+		tokenWidth := r.measureTextWidth(token.style, token.text)
+		if x > 0 && x+spaceWidth+tokenWidth > maxWidth {
 			return first, collapseStyledTokens(tokens[i:])
 		}
 
-		first = appendDialogueRun(first, text, token.style)
-		x += width
-		pendingSpaces = ""
+		for _, ws := range pendingSpaces {
+			first = appendDialogueRun(first, ws.text, ws.style)
+			x += r.measureTextWidth(ws.style, ws.text)
+		}
+		first = appendDialogueRun(first, token.text, token.style)
+		x += tokenWidth
+		pendingSpaces = nil
 	}
 
 	return first, nil

--- a/internal/render/pdf/condensed_dialogue_pagination.go
+++ b/internal/render/pdf/condensed_dialogue_pagination.go
@@ -137,15 +137,50 @@ func (r *condensedRenderer) prepareDialogueLines(lines []bufferedDialogueLine, f
 			continue
 		}
 
-		width := r.condensedRegularLineWidth(prepared[i].isVerse)
+		prepared[i].wrappedText = r.wrapCondensedDialogueText(
+			prepared[i].plainText,
+			prepared[i].isVerse,
+			firstTextLine,
+			firstLineWidth,
+		)
 		if firstTextLine {
-			width = firstLineWidth
 			firstTextLine = false
 		}
-		prepared[i].wrappedText = r.pdf.SplitText(prepared[i].plainText, width)
 	}
 
 	return prepared
+}
+
+func (r *condensedRenderer) wrapCondensedDialogueText(text string, isVerse, useReducedFirstLine bool, firstLineWidth float64) []string {
+	if text == "" {
+		return nil
+	}
+
+	regularWidth := r.condensedRegularLineWidth(isVerse)
+	if !useReducedFirstLine {
+		return r.pdf.SplitText(text, regularWidth)
+	}
+
+	runes := []rune(text)
+	if len(runes) == 0 {
+		return nil
+	}
+
+	firstWrapped := r.pdf.SplitText(text, firstLineWidth)
+	if len(firstWrapped) == 0 {
+		return nil
+	}
+
+	firstLine := firstWrapped[0]
+	offset := dialogueSplitOffset(text, []string{firstLine})
+	lines := []string{firstLine}
+
+	remaining := strings.TrimLeftFunc(string(runes[offset:]), unicode.IsSpace)
+	if remaining == "" {
+		return lines
+	}
+
+	return append(lines, r.pdf.SplitText(remaining, regularWidth)...)
 }
 
 func (r *condensedRenderer) condensedPrefixLayout(character, parenthetical string, parentheticalInlines []ast.Inline, firstSegment bool) (int, float64) {

--- a/internal/render/pdf/condensed_dialogue_pagination.go
+++ b/internal/render/pdf/condensed_dialogue_pagination.go
@@ -1,32 +1,37 @@
 package pdf
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+
+	"github.com/jscaltreto/downstage/internal/ast"
+)
 
 func (r *condensedRenderer) renderBufferedDialogue(d bufferedDialogue) error {
 	return paginateBufferedDialogue(r, d)
 }
 
 func (r *condensedRenderer) prepare(lines []bufferedDialogueLine, dialogue bufferedDialogue, continuation, firstSegment bool) []bufferedDialogueLine {
-	_, firstLineWidth := r.condensedPrefixLayout(dialogue.character, dialogue.parenthetical, firstSegment)
+	_, firstLineWidth := r.condensedPrefixLayout(dialogue.character, dialogue.parenthetical, dialogue.parentheticalInlines, firstSegment)
 	return r.prepareDialogueLines(lines, firstLineWidth)
 }
 
 func (r *condensedRenderer) availableWrappedLines(dialogue bufferedDialogue, continuation, firstSegment bool) int {
-	prefixExtraLines, _ := r.condensedPrefixLayout(dialogue.character, dialogue.parenthetical, firstSegment)
+	prefixExtraLines, _ := r.condensedPrefixLayout(dialogue.character, dialogue.parenthetical, dialogue.parentheticalInlines, firstSegment)
 	leadInHeight := 0.0
 	if firstSegment {
-		leadInHeight = r.lineHeight / 2
+		leadInHeight = r.condensedSmallGap()
 	}
 	if leadInHeight > r.remainingPageHeight() {
 		r.pdf.AddPage()
 		leadInHeight = 0
-		prefixExtraLines, _ = r.condensedPrefixLayout(dialogue.character, dialogue.parenthetical, firstSegment)
+		prefixExtraLines, _ = r.condensedPrefixLayout(dialogue.character, dialogue.parenthetical, dialogue.parentheticalInlines, firstSegment)
 	}
 	return max(int((r.remainingPageHeight()-leadInHeight)/r.lineHeight)-prefixExtraLines, 0)
 }
 
 func (r *condensedRenderer) renderSegment(dialogue bufferedDialogue, continuation, firstSegment bool, lines []bufferedDialogueLine, showMore bool) {
-	r.renderDialogueSegment(dialogue.character, dialogue.parenthetical, continuation, firstSegment, lines, showMore)
+	r.renderDialogueSegment(dialogue.character, dialogue.parenthetical, dialogue.parentheticalInlines, continuation, firstSegment, lines, showMore)
 }
 
 func (r *condensedRenderer) addPage() {
@@ -37,36 +42,51 @@ func (r *condensedRenderer) showContinuationFooter() bool {
 	return false
 }
 
-func (r *condensedRenderer) renderDialogueSegment(character, parenthetical string, continuation, firstSegment bool, lines []bufferedDialogueLine, showMore bool) {
+func (r *condensedRenderer) renderDialogueSegment(character, parenthetical string, parentheticalInlines []ast.Inline, continuation, firstSegment bool, lines []bufferedDialogueLine, showMore bool) {
+	parentheticalInlines = parentheticalInlineContent(parenthetical, parentheticalInlines)
 	if firstSegment {
 		r.ensureSpace(r.lineHeight * 2)
-		r.pdf.Ln(r.lineHeight / 2)
+		r.pdf.Ln(r.condensedSmallGap())
 
 		cue := strings.ToUpper(character) + "."
+		x := r.measureTextWidth("B", cue) + r.measureTextWidth("", "  ")
 		r.pdf.SetX(r.marginL)
 		r.setStyle("B")
 		r.pdf.Write(r.lineHeight, cue)
 		r.setStyle("")
 		r.pdf.Write(r.lineHeight, "  ")
 
-		if parenthetical != "" {
-			r.setStyle("I")
-			r.pdf.Write(r.lineHeight, parentheticalText(parenthetical))
-			r.setStyle("")
-			r.pdf.Write(r.lineHeight, " ")
+		if parenthetical != "" || len(parentheticalInlines) > 0 {
+			runs, err := r.captureInlineRuns(parentheticalInlines, "I")
+			if err != nil {
+				return
+			}
+			runs = append([]dialogueTextRun{{text: "(", style: "I"}}, runs...)
+			runs = append(runs, dialogueTextRun{text: ")", style: "I"})
+			x = r.renderWrappedStyledRuns(x, runs, r.bodyW)
+			spaceWidth := r.measureTextWidth("", " ")
+			if x > 0 && x+spaceWidth > r.bodyW {
+				r.pdf.Ln(r.lineHeight)
+				r.pdf.SetX(r.marginL)
+			} else {
+				r.pdf.Write(r.lineHeight, " ")
+			}
 		}
 	}
 
 	firstRenderedLine := true
 	for _, line := range lines {
 		if len(line.runs) == 0 {
-			r.pdf.Ln(r.lineHeight / 2)
+			r.pdf.Ln(r.condensedSmallGap())
 			continue
 		}
 
 		if firstRenderedLine {
-			firstOffset := dialogueSplitOffset(line.plainText, line.wrappedText[:1])
-			firstRuns, remainingRuns := splitDialogueRuns(line.runs, firstOffset)
+			startX := r.pdf.GetX() - r.marginL
+			if startX < 0 {
+				startX = 0
+			}
+			firstRuns, remainingRuns := r.splitRunsForWidth(startX, line.runs, r.bodyW)
 			for _, run := range firstRuns {
 				r.setStyle(run.style)
 				r.pdf.CellFormat(r.pdf.GetStringWidth(run.text), r.lineHeight, run.text, "", 0, "", false, 0, "")
@@ -128,7 +148,8 @@ func (r *condensedRenderer) prepareDialogueLines(lines []bufferedDialogueLine, f
 	return prepared
 }
 
-func (r *condensedRenderer) condensedPrefixLayout(character, parenthetical string, firstSegment bool) (int, float64) {
+func (r *condensedRenderer) condensedPrefixLayout(character, parenthetical string, parentheticalInlines []ast.Inline, firstSegment bool) (int, float64) {
+	parentheticalInlines = parentheticalInlineContent(parenthetical, parentheticalInlines)
 	if !firstSegment {
 		return 0, r.bodyW
 	}
@@ -138,8 +159,8 @@ func (r *condensedRenderer) condensedPrefixLayout(character, parenthetical strin
 	x := r.measureTextWidth("B", cue) + r.measureTextWidth("", "  ")
 	extraLines := 0
 
-	if parenthetical != "" {
-		x, extraLines = r.layoutCondensedInlineText(x, extraLines, parentheticalText(parenthetical), "I")
+	if parenthetical != "" || len(parentheticalInlines) > 0 {
+		x, extraLines = r.layoutCondensedInlineText(x, extraLines, parentheticalPlainText(parenthetical, parentheticalInlines), "I")
 		spaceWidth := r.measureTextWidth("", " ")
 		if x+spaceWidth > r.bodyW {
 			extraLines++
@@ -165,6 +186,129 @@ func (r *condensedRenderer) measureTextWidth(style, text string) float64 {
 	return width
 }
 
+func (r *condensedRenderer) captureInlineRuns(inlines []ast.Inline, baseStyle string) ([]dialogueTextRun, error) {
+	r.beginCapturedDialogueLine()
+	r.captureStyle = baseStyle
+	if err := r.renderInlineContent(inlines); err != nil {
+		return nil, err
+	}
+	return r.endCapturedDialogueLine(), nil
+}
+
+func (r *condensedRenderer) renderWrappedStyledRuns(startX float64, runs []dialogueTextRun, maxWidth float64) float64 {
+	leftM, _, _, _ := r.pdf.GetMargins()
+	x := startX
+	pendingSpaces := ""
+
+	for _, token := range tokenizeDialogueRuns(runs) {
+		if token.whitespace {
+			pendingSpaces += token.text
+			continue
+		}
+
+		text := token.text
+		if x > 0 {
+			text = pendingSpaces + text
+		}
+		width := r.measureTextWidth(token.style, text)
+		if x > 0 && x+width > maxWidth {
+			r.pdf.Ln(r.lineHeight)
+			r.pdf.SetX(leftM)
+			x = 0
+			text = token.text
+			width = r.measureTextWidth(token.style, text)
+		}
+
+		r.setStyle(token.style)
+		r.pdf.Write(r.lineHeight, text)
+		x += width
+		pendingSpaces = ""
+	}
+
+	r.setStyle("")
+	return x
+}
+
+type styledDialogueToken struct {
+	text       string
+	style      string
+	whitespace bool
+}
+
+func tokenizeDialogueRuns(runs []dialogueTextRun) []styledDialogueToken {
+	var tokens []styledDialogueToken
+	for _, run := range runs {
+		for len(run.text) > 0 {
+			split := strings.IndexFunc(run.text, unicode.IsSpace)
+			if split == -1 {
+				tokens = append(tokens, styledDialogueToken{text: run.text, style: run.style})
+				break
+			}
+			if split > 0 {
+				tokens = append(tokens, styledDialogueToken{text: run.text[:split], style: run.style})
+				run.text = run.text[split:]
+				continue
+			}
+			end := strings.IndexFunc(run.text, func(r rune) bool { return !unicode.IsSpace(r) })
+			if end == -1 {
+				tokens = append(tokens, styledDialogueToken{text: run.text, style: run.style, whitespace: true})
+				break
+			}
+			tokens = append(tokens, styledDialogueToken{text: run.text[:end], style: run.style, whitespace: true})
+			run.text = run.text[end:]
+		}
+	}
+	return tokens
+}
+
+func (r *condensedRenderer) splitRunsForWidth(startX float64, runs []dialogueTextRun, maxWidth float64) ([]dialogueTextRun, []dialogueTextRun) {
+	tokens := tokenizeDialogueRuns(runs)
+	x := startX
+	pendingSpaces := ""
+	var first []dialogueTextRun
+
+	for i, token := range tokens {
+		if token.whitespace {
+			pendingSpaces += token.text
+			continue
+		}
+
+		text := token.text
+		if x > 0 {
+			text = pendingSpaces + text
+		}
+		width := r.measureTextWidth(token.style, text)
+		if x > 0 && x+width > maxWidth {
+			return first, collapseStyledTokens(tokens[i:])
+		}
+
+		first = appendDialogueRun(first, text, token.style)
+		x += width
+		pendingSpaces = ""
+	}
+
+	return first, nil
+}
+
+func collapseStyledTokens(tokens []styledDialogueToken) []dialogueTextRun {
+	var runs []dialogueTextRun
+	for _, token := range tokens {
+		runs = appendDialogueRun(runs, token.text, token.style)
+	}
+	return runs
+}
+
+func appendDialogueRun(runs []dialogueTextRun, text, style string) []dialogueTextRun {
+	if text == "" {
+		return runs
+	}
+	if n := len(runs); n > 0 && runs[n-1].style == style {
+		runs[n-1].text += text
+		return runs
+	}
+	return append(runs, dialogueTextRun{text: text, style: style})
+}
+
 func (r *condensedRenderer) layoutCondensedInlineText(startX float64, extraLines int, text, style string) (float64, int) {
 	words := strings.Fields(text)
 	if len(words) == 0 {
@@ -187,17 +331,6 @@ func (r *condensedRenderer) layoutCondensedInlineText(startX float64, extraLines
 	}
 
 	return x, extraLines
-}
-
-func parentheticalText(parenthetical string) string {
-	paren := parenthetical
-	if paren == "" {
-		return ""
-	}
-	if paren[0] != '(' {
-		paren = "(" + paren + ")"
-	}
-	return paren
 }
 
 func (r *condensedRenderer) condensedRegularLineWidth(isVerse bool) float64 {

--- a/internal/render/pdf/dialogue_pagination.go
+++ b/internal/render/pdf/dialogue_pagination.go
@@ -3,6 +3,8 @@ package pdf
 import (
 	"strings"
 	"unicode"
+
+	"github.com/jscaltreto/downstage/internal/ast"
 )
 
 const minContinuedDialogueLines = 3
@@ -10,9 +12,10 @@ const continuedDialogueSuffix = " (CONT'D)"
 const continuedDialogueFooter = "(MORE)"
 
 type bufferedDialogue struct {
-	character     string
-	parenthetical string
-	lines         []bufferedDialogueLine
+	character            string
+	parenthetical        string
+	parentheticalInlines []ast.Inline
+	lines                []bufferedDialogueLine
 }
 
 type bufferedDialogueLine struct {
@@ -46,7 +49,7 @@ func (r *pdfRenderer) prepare(lines []bufferedDialogueLine, _ bufferedDialogue, 
 }
 
 func (r *pdfRenderer) availableWrappedLines(dialogue bufferedDialogue, _ bool, firstSegment bool) int {
-	headerHeight := r.dialogueHeaderHeight(firstSegment, dialogue.parenthetical != "")
+	headerHeight := r.dialogueHeaderHeight(firstSegment, len(dialogue.parentheticalInlines) > 0 || dialogue.parenthetical != "")
 	if headerHeight > r.remainingPageHeight() {
 		r.pdf.AddPage()
 	}
@@ -54,7 +57,7 @@ func (r *pdfRenderer) availableWrappedLines(dialogue bufferedDialogue, _ bool, f
 }
 
 func (r *pdfRenderer) renderSegment(dialogue bufferedDialogue, continuation, firstSegment bool, lines []bufferedDialogueLine, showMore bool) {
-	r.renderDialogueSegment(dialogue.character, dialogue.parenthetical, continuation, firstSegment, lines, showMore)
+	r.renderDialogueSegment(dialogue.character, dialogue.parenthetical, dialogue.parentheticalInlines, continuation, firstSegment, lines, showMore)
 }
 
 func (r *pdfRenderer) addPage() {
@@ -65,8 +68,8 @@ func (r *pdfRenderer) showContinuationFooter() bool {
 	return true
 }
 
-func (r *pdfRenderer) renderDialogueSegment(character, parenthetical string, continuation, firstSegment bool, lines []bufferedDialogueLine, showMore bool) {
-	r.renderDialogueHeader(character, parenthetical, continuation, firstSegment)
+func (r *pdfRenderer) renderDialogueSegment(character, parenthetical string, parentheticalInlines []ast.Inline, continuation, firstSegment bool, lines []bufferedDialogueLine, showMore bool) {
+	r.renderDialogueHeader(character, parenthetical, parentheticalInlines, continuation, firstSegment)
 	dialogueMargin := r.bodyW * 0.15
 	dialogueX := r.marginL + dialogueMargin
 	r.pdf.SetLeftMargin(dialogueX)
@@ -94,7 +97,8 @@ func (r *pdfRenderer) renderDialogueSegment(character, parenthetical string, con
 	r.pdf.SetRightMargin(r.marginR)
 }
 
-func (r *pdfRenderer) renderDialogueHeader(character, parenthetical string, continuation, firstSegment bool) {
+func (r *pdfRenderer) renderDialogueHeader(character, parenthetical string, parentheticalInlines []ast.Inline, continuation, firstSegment bool) {
+	parentheticalInlines = parentheticalInlineContent(parenthetical, parentheticalInlines)
 	r.pdf.Ln(r.lineHeight)
 	r.setStyle("B")
 	name := strings.ToUpper(character)
@@ -104,9 +108,9 @@ func (r *pdfRenderer) renderDialogueHeader(character, parenthetical string, cont
 	r.centeredText(name)
 	r.setStyle("")
 
-	if firstSegment && parenthetical != "" {
+	if firstSegment && (parenthetical != "" || len(parentheticalInlines) > 0) {
 		r.setStyle("I")
-		r.centeredText(parentheticalText(parenthetical))
+		_ = r.centeredInlines(parentheticalInlines, "(", ")")
 		r.setStyle("")
 	}
 }

--- a/internal/render/pdf/dialogue_pagination_test.go
+++ b/internal/render/pdf/dialogue_pagination_test.go
@@ -41,6 +41,48 @@ func TestSplitDialogueRunsTrimsBoundaryWhitespace(t *testing.T) {
 	require.Equal(t, []dialogueTextRun{{text: "next", style: "I"}}, right)
 }
 
+func TestSplitDialogueRunsPreservesUnderlineWordBoundary(t *testing.T) {
+	runs := []dialogueTextRun{
+		{text: "(beat; ", style: "I"},
+		{text: "almost", style: "IU"},
+		{text: " fighting the impulse to continue.)", style: "I"},
+	}
+
+	left, right := splitDialogueRuns(runs, len([]rune("(beat; almost")))
+
+	require.Equal(t, []dialogueTextRun{
+		{text: "(beat; ", style: "I"},
+		{text: "almost", style: "IU"},
+	}, left)
+	require.Equal(t, []dialogueTextRun{
+		{text: "fighting the impulse to continue.)", style: "I"},
+	}, right)
+}
+
+func TestCondensedSplitRunsForWidthPreservesWhitespaceStyles(t *testing.T) {
+	r := NewCondensedRenderer(render.DefaultConfig()).(*condensedRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	runs := []dialogueTextRun{
+		{text: "(beat;", style: "I"},
+		{text: " ", style: "I"},
+		{text: "almost", style: "IU"},
+		{text: " fighting the impulse to continue.)", style: "I"},
+	}
+	startX := r.measureTextWidth("B", "NOTBOB.") + r.measureTextWidth("", "  ")
+	maxWidth := startX + r.measureTextWidth("I", "(beat; ") + r.measureTextWidth("IU", "almost")
+
+	first, remaining := r.splitRunsForWidth(startX, runs, maxWidth)
+
+	require.Equal(t, []dialogueTextRun{
+		{text: "(beat; ", style: "I"},
+		{text: "almost", style: "IU"},
+	}, first)
+	require.Equal(t, []dialogueTextRun{
+		{text: "fighting the impulse to continue.)", style: "I"},
+	}, remaining)
+}
+
 func TestPreferredSplitOffsetUsesSentenceBoundary(t *testing.T) {
 	line := bufferedDialogueLine{
 		plainText: strings.Join([]string{

--- a/internal/render/pdf/dialogue_pagination_test.go
+++ b/internal/render/pdf/dialogue_pagination_test.go
@@ -284,3 +284,39 @@ func TestRenderBufferedDialogueWithCapturedStyles(t *testing.T) {
 
 	assert.Greater(t, r.pdf.PageNo(), 0)
 }
+
+func TestRenderBufferedDialogue_InlineDirectionNestedItalicPreservesItalicContext(t *testing.T) {
+	r := NewRenderer(render.DefaultConfig()).(*pdfRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	dialogue := &ast.Dialogue{Character: "HAMLET"}
+	require.NoError(t, r.BeginDialogue(dialogue))
+
+	line := &ast.DialogueLine{Content: []ast.Inline{
+		&ast.TextNode{Value: "To be "},
+		&ast.InlineDirectionNode{Content: []ast.Inline{
+			&ast.TextNode{Value: "not merely "},
+			&ast.ItalicNode{Content: []ast.Inline{&ast.TextNode{Value: "appearing"}}},
+			&ast.TextNode{Value: " so"},
+		}},
+		&ast.TextNode{Value: "."},
+	}}
+	require.NoError(t, r.BeginDialogueLine(line))
+	require.NoError(t, r.RenderText(line.Content[0].(*ast.TextNode)))
+	require.NoError(t, r.BeginInlineDirection(line.Content[1].(*ast.InlineDirectionNode)))
+	require.NoError(t, r.RenderText(line.Content[1].(*ast.InlineDirectionNode).Content[0].(*ast.TextNode)))
+	require.NoError(t, r.BeginItalic(line.Content[1].(*ast.InlineDirectionNode).Content[1].(*ast.ItalicNode)))
+	require.NoError(t, r.RenderText(line.Content[1].(*ast.InlineDirectionNode).Content[1].(*ast.ItalicNode).Content[0].(*ast.TextNode)))
+	require.NoError(t, r.EndItalic(line.Content[1].(*ast.InlineDirectionNode).Content[1].(*ast.ItalicNode)))
+	require.NoError(t, r.RenderText(line.Content[1].(*ast.InlineDirectionNode).Content[2].(*ast.TextNode)))
+	require.NoError(t, r.EndInlineDirection(line.Content[1].(*ast.InlineDirectionNode)))
+	require.NoError(t, r.RenderText(line.Content[2].(*ast.TextNode)))
+	require.NoError(t, r.EndDialogueLine(line))
+	require.Len(t, r.activeDialogue.lines, 1)
+	require.Equal(t, []dialogueTextRun{
+		{text: "To be ", style: ""},
+		{text: "(not merely appearing so)", style: "I"},
+		{text: ".", style: ""},
+	}, r.activeDialogue.lines[0].runs)
+	require.NoError(t, r.EndDialogue(dialogue))
+}

--- a/internal/render/pdf/pdf_test.go
+++ b/internal/render/pdf/pdf_test.go
@@ -458,7 +458,7 @@ func TestCondensedStageDirectionUsesTightLeadInSpacing(t *testing.T) {
 		Content: []ast.Inline{&ast.TextNode{Value: "He crosses to the window."}},
 	}))
 
-	assert.InDelta(t, r.lineHeight/2, r.pdf.GetY()-yBefore, 0.01)
+	assert.InDelta(t, r.condensedSmallGap(), r.pdf.GetY()-yBefore, 0.01)
 }
 
 func TestStandardCalloutSetsIndentedLeftMargin(t *testing.T) {
@@ -477,6 +477,51 @@ func TestStandardCalloutSetsIndentedLeftMargin(t *testing.T) {
 	assert.InDelta(t, r.marginL, left, 0.01)
 }
 
+func TestStageDirectionNestedItalicPreservesOuterItalic(t *testing.T) {
+	r := NewRenderer(render.DefaultConfig()).(*pdfRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	stageDirection := &ast.StageDirection{
+		Content: []ast.Inline{
+			&ast.TextNode{Value: "Not performing humanity, not approximating it--"},
+			&ast.ItalicNode{Content: []ast.Inline{&ast.TextNode{Value: "inhabiting"}}},
+			&ast.TextNode{Value: " it."},
+		},
+	}
+
+	require.NoError(t, r.BeginStageDirection(stageDirection))
+	require.Equal(t, "I", r.fontStyle)
+	require.NoError(t, r.RenderText(stageDirection.Content[0].(*ast.TextNode)))
+	require.NoError(t, r.BeginItalic(stageDirection.Content[1].(*ast.ItalicNode)))
+	require.Equal(t, "I", r.fontStyle)
+	require.NoError(t, r.RenderText(stageDirection.Content[1].(*ast.ItalicNode).Content[0].(*ast.TextNode)))
+	require.NoError(t, r.EndItalic(stageDirection.Content[1].(*ast.ItalicNode)))
+	assert.Equal(t, "I", r.fontStyle)
+	require.NoError(t, r.RenderText(stageDirection.Content[2].(*ast.TextNode)))
+	require.NoError(t, r.EndStageDirection(stageDirection))
+	assert.Equal(t, "", r.fontStyle)
+}
+
+func TestDialogueParentheticalNestedFormattingPreservesOuterItalic(t *testing.T) {
+	r := NewRenderer(render.DefaultConfig()).(*pdfRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	inlines := []ast.Inline{
+		&ast.TextNode{Value: "offstage, "},
+		&ast.UnderlineNode{Content: []ast.Inline{&ast.TextNode{Value: "exasperated"}}},
+		&ast.TextNode{Value: "; "},
+		&ast.BoldNode{Content: []ast.Inline{&ast.TextNode{Value: "overlapping"}}},
+	}
+
+	r.setStyle("I")
+	r.pdf.Write(r.lineHeight, "(")
+	require.NoError(t, r.renderInlineContent(inlines))
+	assert.Equal(t, "I", r.fontStyle)
+	r.pdf.Write(r.lineHeight, ")")
+	r.setStyle("")
+	assert.Equal(t, "", r.fontStyle)
+}
+
 func TestCondensedCalloutUsesParagraphGapAfterPreviousCallout(t *testing.T) {
 	r := NewCondensedRenderer(render.DefaultConfig()).(*condensedRenderer)
 	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
@@ -491,5 +536,47 @@ func TestCondensedCalloutUsesParagraphGapAfterPreviousCallout(t *testing.T) {
 		Content: []ast.Inline{&ast.TextNode{Value: "Second callout."}},
 	}))
 
-	assert.InDelta(t, r.lineHeight, r.pdf.GetY()-yBefore, 0.01)
+	assert.InDelta(t, r.condensedSmallGap(), r.pdf.GetY()-yBefore, 0.01)
+}
+
+func TestCondensedDialogueLongParentheticalWrapsDuringRendering(t *testing.T) {
+	r := NewCondensedRenderer(render.DefaultConfig()).(*condensedRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	inlines := []ast.Inline{
+		&ast.TextNode{Value: "fewer voices than before; but the ones who say it, mean it and keep saying it long after the room should have gone quiet"},
+	}
+	runs, err := r.captureInlineRuns(inlines, "I")
+	require.NoError(t, err)
+	runs = append([]dialogueTextRun{{text: "(", style: "I"}}, runs...)
+	runs = append(runs, dialogueTextRun{text: ")", style: "I"})
+
+	startX := r.measureTextWidth("B", "ALL.") + r.measureTextWidth("", "  ")
+	yBefore := r.pdf.GetY()
+	xAfter := r.renderWrappedStyledRuns(startX, runs, r.bodyW)
+
+	assert.Greater(t, r.pdf.GetY(), yBefore)
+	assert.LessOrEqual(t, xAfter, r.bodyW)
+}
+
+func TestCondensedDialogueExactReportedParentheticalWraps(t *testing.T) {
+	r := NewCondensedRenderer(render.DefaultConfig()).(*condensedRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	dialogue := &ast.Dialogue{
+		Character:     "ALL",
+		Parenthetical: "(fewer voices than before; but the ones who say it, mean it)",
+		Lines: []ast.DialogueLine{
+			{Content: []ast.Inline{&ast.TextNode{Value: "Thank Bob."}}},
+		},
+	}
+
+	yBefore := r.pdf.GetY()
+	require.NoError(t, r.BeginDialogue(dialogue))
+	require.NoError(t, r.BeginDialogueLine(&dialogue.Lines[0]))
+	require.NoError(t, r.RenderText(dialogue.Lines[0].Content[0].(*ast.TextNode)))
+	require.NoError(t, r.EndDialogueLine(&dialogue.Lines[0]))
+	require.NoError(t, r.EndDialogue(dialogue))
+
+	assert.Greater(t, r.pdf.GetY(), yBefore+r.lineHeight)
 }

--- a/internal/render/pdf/pdf_test.go
+++ b/internal/render/pdf/pdf_test.go
@@ -580,3 +580,17 @@ func TestCondensedDialogueExactReportedParentheticalWraps(t *testing.T) {
 
 	assert.Greater(t, r.pdf.GetY(), yBefore+r.lineHeight)
 }
+
+func TestCondensedPrepareDialogueLinesOnlyNarrowsFirstVisualLine(t *testing.T) {
+	r := NewCondensedRenderer(render.DefaultConfig()).(*condensedRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	text := "As I record this, we are celebrating the very first in what I hope will become an enduring tradition: Ascension Day. Today marks twenty-five years since our departure from Earth, and it's hard to believe that an entire generation of children born here aboard Nemus Dianae will begin their adulthood, never having known the world I was born into."
+	lines := []bufferedDialogueLine{{runs: []dialogueTextRun{{text: text, style: ""}}}}
+
+	prepared := r.prepareDialogueLines(lines, 45)
+	require.Len(t, prepared, 1)
+
+	narrowAllLines := r.pdf.SplitText(text, 45)
+	assert.Less(t, len(prepared[0].wrappedText), len(narrowAllLines))
+}


### PR DESCRIPTION
## Summary
- fix condensed PDF wrapping when dialogue follows long parentheticals, including the reported page 12 overflow case
- preserve inline formatting inside character parentheticals across parsing and HTML/PDF rendering
- tighten condensed dialogue, stage-direction, and callout spacing behind shared gap constants, and include the bundled VS Code syntax-highlighting fix for colon-bearing lines

## Testing
- env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go test ./...