### PR TITLE
ci(workflows): verify site build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,15 @@ jobs:
           cache: true
           check-latest: true
 
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            web/package-lock.json
+
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
@@ -39,6 +48,12 @@ jobs:
 
       - name: Download modules
         run: go mod download
+
+      - name: Install site dependencies
+        run: npm ci
+
+      - name: Install web editor dependencies
+        run: npm --prefix web ci
 
       - name: Run checks
         id: checks
@@ -56,6 +71,12 @@ jobs:
         id: wasm
         run: GOOS=js GOARCH=wasm go build -o /dev/null ./cmd/wasm/
 
+      - name: Build site
+        id: site
+        env:
+          RELEASE_VERSION: ci
+        run: npm run build:site
+
       - name: Job summary
         if: always()
         run: |
@@ -67,3 +88,4 @@ jobs:
           echo "| Release config | \`${{ steps.release-check.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Build  | \`${{ steps.build.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| WASM   | \`${{ steps.wasm.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Site   | \`${{ steps.site.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- add Node setup and npm install steps to the main CI workflow
- run npm run build:site in CI so the actual Pages/release build path is validated on every PR
- include the site build result in the job summary

## Why
- the release path already depends on npm run build:site, which builds assets, rebuilds the WASM editor bundle, and runs Eleventy
- CI previously checked Go/WASM compilation, but it did not verify the site build end to end
- this keeps the build contract explicit instead of making web/package.json silently generate WASM artifacts

## Validation
- npm run build:site