### PR TITLE
feat(web): wire LSP completions and code actions into editor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,10 @@ jobs:
         id: wasm
         run: GOOS=js GOARCH=wasm go build -o /dev/null ./cmd/wasm/
 
+      - name: Run web editor tests
+        id: web-test
+        run: npm --prefix web test
+
       - name: Build site
         id: site
         env:
@@ -88,4 +92,5 @@ jobs:
           echo "| Release config | \`${{ steps.release-check.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Build  | \`${{ steps.build.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| WASM   | \`${{ steps.wasm.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Web tests | \`${{ steps.web-test.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Site   | \`${{ steps.site.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ SONG END
   - Go-to-definition (jump to character's dramatis personae entry)
   - Context-aware completion for character cues
   - Diagnostics (parse errors, unknown character warnings)
+  - Code actions (quick fixes for unknown characters and unnumbered or
+    misnumbered acts/scenes)
 - Neovim integration out of the box (0.11+)
 - CLI tools for parsing and validation
 
@@ -239,7 +241,8 @@ Extension Development Host.
 
 [**Start writing**](https://www.getdownstage.com/editor/) in the Web Editor, a
 modern browser-based editor built with Vue 3, Tailwind CSS v4, and CodeMirror 6.
-It features live preview, adaptive syntax highlighting, and PDF export. No
+It features live preview, adaptive syntax highlighting, completions and
+quick-fix code actions sourced from the Downstage LSP, and PDF export. No
 install required; the entire pipeline runs client-side via WebAssembly.
 
 For local development:

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -20,6 +20,8 @@ func main() {
 
 	ds.Set("parse", js.FuncOf(parse))
 	ds.Set("diagnostics", js.FuncOf(diagnostics))
+	ds.Set("completion", js.FuncOf(completion))
+	ds.Set("codeActions", js.FuncOf(codeActions))
 	ds.Set("renderHTML", js.FuncOf(renderHTML))
 	ds.Set("renderPDF", js.FuncOf(renderPDF))
 	ds.Set("semanticTokens", js.FuncOf(semanticTokens))
@@ -87,6 +89,72 @@ func diagnostics(_ js.Value, args []js.Value) any {
 	}
 
 	data, _ := json.Marshal(map[string]any{"diagnostics": out})
+	return js.Global().Get("JSON").Call("parse", string(data))
+}
+
+const codeActionsURI protocol.DocumentURI = "inmemory://document.ds"
+
+func completion(_ js.Value, args []js.Value) any {
+	source := args[0].String()
+	line := args[1].Int()
+	col := args[2].Int()
+
+	doc, errs := parser.Parse([]byte(source))
+	list := lsp.ComputeCompletion(doc, errs, source, protocol.Position{
+		Line:      uint32(line),
+		Character: uint32(col),
+	})
+	if list == nil {
+		list = &protocol.CompletionList{Items: []protocol.CompletionItem{}}
+	}
+
+	data, _ := json.Marshal(list)
+	return js.Global().Get("JSON").Call("parse", string(data))
+}
+
+func codeActions(_ js.Value, args []js.Value) any {
+	source := args[0].String()
+	line := args[1].Int()
+	col := args[2].Int()
+
+	var codeFilter map[string]struct{}
+	if len(args) > 3 && args[3].Type() == js.TypeObject {
+		codeFilter = make(map[string]struct{})
+		length := args[3].Length()
+		for i := 0; i < length; i++ {
+			codeFilter[args[3].Index(i).String()] = struct{}{}
+		}
+	}
+
+	doc, errs := parser.Parse([]byte(source))
+	allDiags := lsp.ComputeDiagnostics(doc, errs)
+
+	var ctxDiags []protocol.Diagnostic
+	for _, d := range allDiags {
+		if int(d.Range.Start.Line) != line {
+			continue
+		}
+		if col < int(d.Range.Start.Character) || col > int(d.Range.End.Character) {
+			continue
+		}
+		if codeFilter != nil {
+			code, _ := d.Code.(string)
+			if _, ok := codeFilter[code]; !ok {
+				continue
+			}
+		}
+		ctxDiags = append(ctxDiags, d)
+	}
+
+	actions := lsp.ComputeCodeActions(doc, source, codeActionsURI, ctxDiags, allDiags)
+	if actions == nil {
+		actions = []protocol.CodeAction{}
+	}
+
+	data, _ := json.Marshal(map[string]any{
+		"uri":     string(codeActionsURI),
+		"actions": actions,
+	})
 	return js.Global().Get("JSON").Call("parse", string(data))
 }
 

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -41,14 +41,17 @@ type parseErrorJSON struct {
 	EndCol  int    `json:"endCol"`
 }
 
+const codeActionsURI protocol.DocumentURI = "inmemory://document.ds"
+
 type diagnosticJSON struct {
-	Message  string `json:"message"`
-	Severity string `json:"severity"`
-	Line     int    `json:"line"`
-	Col      int    `json:"col"`
-	EndLine  int    `json:"endLine"`
-	EndCol   int    `json:"endCol"`
-	Code     string `json:"code,omitempty"`
+	Message    string   `json:"message"`
+	Severity   string   `json:"severity"`
+	Line       int      `json:"line"`
+	Col        int      `json:"col"`
+	EndLine    int      `json:"endLine"`
+	EndCol     int      `json:"endCol"`
+	Code       string   `json:"code,omitempty"`
+	QuickFixes []string `json:"quickFixes,omitempty"`
 }
 
 func parse(_ js.Value, args []js.Value) any {
@@ -86,13 +89,31 @@ func diagnostics(_ js.Value, args []js.Value) any {
 			EndCol:   int(diag.Range.End.Character),
 			Code:     diagnosticCode(diag.Code),
 		}
+
+		actions := lsp.ComputeCodeActions(doc, source, codeActionsURI, []protocol.Diagnostic{diag}, diags)
+		titles := actionTitles(actions)
+		if len(titles) > 0 {
+			out[i].QuickFixes = titles
+		}
 	}
 
 	data, _ := json.Marshal(map[string]any{"diagnostics": out})
 	return js.Global().Get("JSON").Call("parse", string(data))
 }
 
-const codeActionsURI protocol.DocumentURI = "inmemory://document.ds"
+func actionTitles(actions []protocol.CodeAction) []string {
+	titles := make([]string, 0, len(actions))
+	for _, a := range actions {
+		if a.Edit == nil {
+			continue
+		}
+		if edits := a.Edit.Changes[codeActionsURI]; len(edits) == 0 {
+			continue
+		}
+		titles = append(titles, a.Title)
+	}
+	return titles
+}
 
 func completion(_ js.Value, args []js.Value) any {
 	source := args[0].String()

--- a/internal/lsp/code_actions.go
+++ b/internal/lsp/code_actions.go
@@ -8,6 +8,17 @@ import (
 	"go.lsp.dev/protocol"
 )
 
+// ComputeCodeActions returns the quick-fix actions surfaced by the Downstage LSP.
+func ComputeCodeActions(
+	doc *ast.Document,
+	content string,
+	uri protocol.DocumentURI,
+	diagnostics []protocol.Diagnostic,
+	allDiagnostics []protocol.Diagnostic,
+) []protocol.CodeAction {
+	return computeCodeActions(doc, content, uri, diagnostics, allDiagnostics)
+}
+
 func computeCodeActions(
 	doc *ast.Document,
 	content string,

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -14,6 +14,11 @@ func computeCompletion(doc *ast.Document, _ []*parser.ParseError, content string
 	return computeCompletionWithIndex(doc, newDocumentIndex(doc), content, pos)
 }
 
+// ComputeCompletion returns the completion list surfaced by the Downstage LSP.
+func ComputeCompletion(doc *ast.Document, errs []*parser.ParseError, content string, pos protocol.Position) *protocol.CompletionList {
+	return computeCompletion(doc, errs, content, pos)
+}
+
 func computeCompletionWithIndex(doc *ast.Document, index *documentIndex, content string, pos protocol.Position) *protocol.CompletionList {
 	if doc == nil {
 		return emptyCompletionList()

--- a/web/README.md
+++ b/web/README.md
@@ -1,9 +1,9 @@
 # Downstage Web Editor
 
 A browser-based Downstage editor with live preview, syntax highlighting,
-browser-local draft storage, an Open Draft picker, and PDF export. The entire parsing and
-rendering pipeline runs client-side via
-WebAssembly — no server required.
+LSP-powered autocomplete and quick-fix code actions, browser-local draft
+storage, an Open Draft picker, and PDF export. The entire parsing and
+rendering pipeline runs client-side via WebAssembly — no server required.
 
 ## Draft Storage
 
@@ -80,7 +80,9 @@ The WASM module exposes a global `downstage` object:
 | Function | Input | Output |
 |----------|-------|--------|
 | `parse(source)` | Downstage source string | `{errors: [{message, line, col, endLine, endCol}]}` |
-| `diagnostics(source)` | Downstage source string | `{diagnostics: [{message, severity, line, col, endLine, endCol, code?}]}` |
+| `diagnostics(source)` | Downstage source string | `{diagnostics: [{message, severity, line, col, endLine, endCol, code?, quickFixes?}]}` |
+| `completion(source, line, col)` | Source + 0-based LSP position | LSP `CompletionList` (`{isIncomplete, items[]}`) |
+| `codeActions(source, line, col, codes?)` | Source + 0-based LSP position + optional diagnostic-code filter | `{uri, actions: LSPCodeAction[]}` |
 | `renderHTML(source, style?)` | Source + optional style (`"standard"`/Manuscript or `"condensed"`/Acting Edition) | HTML string |
 | `renderPDF(source, style?)` | Source + optional style | `Uint8Array` (PDF bytes) |
 | `semanticTokens(source)` | Source string | `Uint32Array` (delta-encoded LSP tokens) |

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -28,7 +28,8 @@
       },
       "devDependencies": {
         "typescript": "^5.8.0",
-        "vite": "^8.0.8"
+        "vite": "^8.0.8",
+        "vitest": "^4.1.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1108,6 +1109,13 @@
       "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1388,6 +1396,31 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.5.tgz",
@@ -1409,6 +1442,129 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
       "integrity": "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==",
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.32",
@@ -1509,6 +1665,16 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
       "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -1611,6 +1777,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/codemirror": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
@@ -1625,6 +1801,13 @@
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/crelt": {
       "version": "1.0.6",
@@ -1677,6 +1860,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -1735,6 +1925,16 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2086,6 +2286,24 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2171,6 +2389,13 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2179,6 +2404,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/style-mod": {
       "version": "4.1.3",
@@ -2205,6 +2444,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2219,6 +2475,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -2349,6 +2615,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vue": {
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
@@ -2375,6 +2731,23 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "downstage-web",
       "version": "0.1.0",
       "dependencies": {
+        "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.3.2",
         "@codemirror/language": "^6.10.8",

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite",
-    "test": "vitest run"
+    "typecheck": "tsc --noEmit",
+    "test": "npm run typecheck && vitest run"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.1",

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "dev": "vite"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.20.1",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-markdown": "^6.3.2",
     "@codemirror/language": "^6.10.8",

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "dev": "vite"
+    "dev": "vite",
+    "test": "vitest run"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.1",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "typescript": "^5.8.0",
-    "vite": "^8.0.8"
+    "vite": "^8.0.8",
+    "vitest": "^4.1.4"
   }
 }

--- a/web/src/__tests__/completion.test.ts
+++ b/web/src/__tests__/completion.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { EditorState, type TransactionSpec } from "@codemirror/state";
+import type { Completion } from "@codemirror/autocomplete";
+import type { EditorView } from "@codemirror/view";
+import { toCompletion } from "../completion";
+import type { LSPCompletionItem } from "../core/types";
+
+type ApplyFn = (view: EditorView, completion: Completion, from: number, to: number) => void;
+
+function applyFn(completion: Completion): ApplyFn {
+  if (typeof completion.apply !== "function") {
+    throw new Error("expected completion.apply to be a function");
+  }
+  return completion.apply;
+}
+
+function fakeView(initialDoc: string, selectionAnchor?: number) {
+  let state = EditorState.create({
+    doc: initialDoc,
+    selection: selectionAnchor !== undefined ? { anchor: selectionAnchor } : undefined,
+  });
+  const view = {
+    get state() {
+      return state;
+    },
+    dispatch(spec: TransactionSpec) {
+      state = state.update(spec).state;
+    },
+  };
+  return view;
+}
+
+describe("toCompletion", () => {
+  it("applies a TextEdit that replaces the line prefix with the chosen label", () => {
+    // "B" on line 1; LSP range is (line=1, char=0)..(line=1, char=1), replacing with "BOB".
+    const source = "\nB";
+    const view = fakeView(source, source.length);
+    const item: LSPCompletionItem = {
+      label: "BOB",
+      kind: 6,
+      textEdit: {
+        range: { start: { line: 1, character: 0 }, end: { line: 1, character: 1 } },
+        newText: "BOB",
+      },
+    };
+
+    const completion = toCompletion(item);
+    applyFn(completion)(view as unknown as EditorView, completion, 0, 0);
+    expect(view.state.doc.toString()).toBe("\nBOB");
+  });
+
+  it("falls back to an insert at the cursor when no TextEdit is provided", () => {
+    const view = fakeView("hi ", 3);
+    const item: LSPCompletionItem = { label: "there" };
+    const completion = toCompletion(item);
+    applyFn(completion)(view as unknown as EditorView, completion, 3, 3);
+    expect(view.state.doc.toString()).toBe("hi there");
+  });
+
+  it("handles astral-character documents via UTF-16 offsets", () => {
+    // "𝐀B" → 𝐀 is 2 UTF-16 units; replacing LSP range (0,2)..(0,3) swaps "B" for "BOB".
+    const doc = "\uD835\uDC00B";
+    const view = fakeView(doc, doc.length);
+    const item: LSPCompletionItem = {
+      label: "BOB",
+      textEdit: {
+        range: { start: { line: 0, character: 2 }, end: { line: 0, character: 3 } },
+        newText: "BOB",
+      },
+    };
+    const completion = toCompletion(item);
+    applyFn(completion)(view as unknown as EditorView, completion, 0, 0);
+    expect(view.state.doc.toString()).toBe("\uD835\uDC00BOB");
+  });
+});

--- a/web/src/__tests__/diagnostics.test.ts
+++ b/web/src/__tests__/diagnostics.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { EditorState, type TransactionSpec } from "@codemirror/state";
+import { applyLSPEdits } from "../diagnostics";
+import type { LSPTextEdit } from "../core/types";
+
+function fakeView(initialDoc: string) {
+  let state = EditorState.create({ doc: initialDoc });
+  const view = {
+    get state() {
+      return state;
+    },
+    dispatch(spec: TransactionSpec) {
+      state = state.update(spec).state;
+    },
+  };
+  return view;
+}
+
+describe("applyLSPEdits", () => {
+  it("applies a single-line TextEdit in place", () => {
+    const view = fakeView("FRED\n");
+    const edits: LSPTextEdit[] = [
+      { range: { start: { line: 0, character: 0 }, end: { line: 0, character: 4 } }, newText: "FREDDY" },
+    ];
+    applyLSPEdits(view as any, edits);
+    expect(view.state.doc.toString()).toBe("FREDDY\n");
+  });
+
+  it("applies multiple non-overlapping edits as a bulk change (e.g. renumber all scenes)", () => {
+    const source = [
+      "### SCENE A",
+      "CHAR",
+      "line",
+      "",
+      "### SCENE B",
+      "CHAR",
+      "line",
+      "",
+      "### SCENE C",
+    ].join("\n");
+
+    const view = fakeView(source);
+    const edits: LSPTextEdit[] = [
+      { range: { start: { line: 0, character: 0 }, end: { line: 0, character: 11 } }, newText: "### SCENE 1" },
+      { range: { start: { line: 4, character: 0 }, end: { line: 4, character: 11 } }, newText: "### SCENE 2" },
+      { range: { start: { line: 8, character: 0 }, end: { line: 8, character: 11 } }, newText: "### SCENE 3" },
+    ];
+    applyLSPEdits(view as any, edits);
+
+    const updated = view.state.doc.toString();
+    expect(updated).toContain("### SCENE 1");
+    expect(updated).toContain("### SCENE 2");
+    expect(updated).toContain("### SCENE 3");
+    expect(updated).not.toContain("SCENE A");
+    expect(updated).not.toContain("SCENE B");
+    expect(updated).not.toContain("SCENE C");
+  });
+
+  it("is a no-op for an empty edit list", () => {
+    const view = fakeView("unchanged\n");
+    applyLSPEdits(view as any, []);
+    expect(view.state.doc.toString()).toBe("unchanged\n");
+  });
+});

--- a/web/src/__tests__/lsp-offsets.test.ts
+++ b/web/src/__tests__/lsp-offsets.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { Text } from "@codemirror/state";
+import { offsetFromLSP } from "../lsp-offsets";
+
+describe("offsetFromLSP", () => {
+  it("converts line/character to flat offset on ASCII content", () => {
+    const doc = Text.of(["first", "second", "third"]);
+    expect(offsetFromLSP(doc, 0, 0)).toBe(0);
+    expect(offsetFromLSP(doc, 1, 0)).toBe(6);
+    expect(offsetFromLSP(doc, 1, 3)).toBe(9);
+    expect(offsetFromLSP(doc, 2, 5)).toBe(18);
+  });
+
+  it("clamps characters past the end of a line to the line's end", () => {
+    const doc = Text.of(["short"]);
+    expect(offsetFromLSP(doc, 0, 99)).toBe(5);
+  });
+
+  it("returns 0 for negative lines and end-of-doc for lines past the end", () => {
+    const doc = Text.of(["a", "bb"]);
+    expect(offsetFromLSP(doc, -1, 0)).toBe(0);
+    expect(offsetFromLSP(doc, 99, 99)).toBe(4);
+  });
+
+  it("treats characters as UTF-16 code units (astral chars take 2 units)", () => {
+    // "a𝐀b" where 𝐀 (U+1D400) is encoded as a surrogate pair (2 UTF-16 units).
+    // LSP character for 'b' is 3 (1 + 2 surrogate units).
+    const doc = Text.of(["a\uD835\uDC00b"]);
+    expect(offsetFromLSP(doc, 0, 0)).toBe(0);
+    expect(offsetFromLSP(doc, 0, 1)).toBe(1); // after 'a'
+    expect(offsetFromLSP(doc, 0, 3)).toBe(3); // after 𝐀
+    expect(offsetFromLSP(doc, 0, 4)).toBe(4); // after 'b'
+  });
+});

--- a/web/src/completion.ts
+++ b/web/src/completion.ts
@@ -1,0 +1,83 @@
+import {
+  autocompletion,
+  type Completion,
+  type CompletionContext,
+  type CompletionResult,
+} from "@codemirror/autocomplete";
+import type { EditorView } from "@codemirror/view";
+import type { EditorEnv, LSPCompletionItem } from "./core/types";
+import { offsetFromLSP } from "./lsp-offsets";
+
+// LSP CompletionItemKind values we map onto CodeMirror completion types.
+const kindToType: Record<number, string> = {
+  6: "variable",
+  14: "keyword",
+};
+
+function toCompletion(item: LSPCompletionItem): Completion {
+  const label = item.label;
+  return {
+    label,
+    detail: item.detail,
+    type: item.kind !== undefined ? kindToType[item.kind] : undefined,
+    boost: 0,
+    apply: (view: EditorView) => {
+      const edit = item.textEdit;
+      if (edit) {
+        const from = offsetFromLSP(view.state.doc, edit.range.start.line, edit.range.start.character);
+        const to = offsetFromLSP(view.state.doc, edit.range.end.line, edit.range.end.character);
+        view.dispatch({
+          changes: { from, to, insert: edit.newText },
+          selection: { anchor: from + edit.newText.length },
+          scrollIntoView: true,
+        });
+        return;
+      }
+      const insert = item.insertText ?? label;
+      const { from, to } = view.state.selection.main;
+      view.dispatch({
+        changes: { from, to, insert },
+        selection: { anchor: from + insert.length },
+        scrollIntoView: true,
+      });
+    },
+  };
+}
+
+export function createDownstageCompletion(env: EditorEnv) {
+  async function source(context: CompletionContext): Promise<CompletionResult | null> {
+    const { state, pos } = context;
+    const line = state.doc.lineAt(pos);
+    const lspLine = line.number - 1;
+    const character = pos - line.from;
+
+    let list;
+    try {
+      list = await env.completion(state.doc.toString(), lspLine, character);
+    } catch {
+      return null;
+    }
+
+    if (!list || !list.items || list.items.length === 0) {
+      return null;
+    }
+
+    const items = list.items.slice().sort((a, b) => {
+      const sa = a.sortText ?? a.label;
+      const sb = b.sortText ?? b.label;
+      return sa.localeCompare(sb);
+    });
+
+    return {
+      from: line.from,
+      to: pos,
+      options: items.map(toCompletion),
+      filter: false,
+    };
+  }
+
+  return autocompletion({
+    activateOnTyping: true,
+    override: [source],
+  });
+}

--- a/web/src/completion.ts
+++ b/web/src/completion.ts
@@ -14,7 +14,7 @@ const kindToType: Record<number, string> = {
   14: "keyword",
 };
 
-function toCompletion(item: LSPCompletionItem): Completion {
+export function toCompletion(item: LSPCompletionItem): Completion {
   const label = item.label;
   return {
     label,

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -201,13 +201,69 @@ function toggleStyle() {
 
 <style>
 .cm-editor { height: 100%; outline: none !important; }
-.cm-gutters { 
+.cm-gutters {
     background-color: transparent !important;
     color: var(--color-text-muted) !important;
-    border-right: 1px solid var(--border-color) !important; 
+    border-right: 1px solid var(--border-color) !important;
 }
 .dark .cm-activeLine { background-color: rgba(255, 255, 255, 0.05) !important; }
 .cm-activeLine { background-color: rgba(0, 0, 0, 0.03) !important; }
+
+.dark .cm-tooltip.cm-tooltip-autocomplete > ul > li {
+    color: var(--color-text-muted);
+}
+.dark .cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected] {
+    background: var(--color-brass-500);
+    color: var(--color-ember-950);
+}
+.dark .cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected] .cm-completionDetail {
+    color: var(--color-ember-900);
+}
+
+.cm-tooltip-lint .cm-diagnostic {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.4rem;
+    padding: 0.5rem 0.65rem;
+    max-width: 420px;
+}
+.cm-tooltip-lint .cm-diagnosticText {
+    white-space: normal;
+    line-height: 1.35;
+}
+.cm-tooltip-lint .cm-diagnosticAction {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0;
+    padding: 0.25rem 0.55rem;
+    border-radius: 4px;
+    border: 1px solid var(--border-color);
+    background: var(--color-toolbar-bg);
+    color: var(--color-accent);
+    font-size: 0.85em;
+    font-weight: 500;
+    cursor: pointer;
+    align-self: flex-start;
+    transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+}
+.cm-tooltip-lint .cm-diagnosticAction:hover {
+    background: var(--color-accent);
+    color: var(--color-page-bg);
+    border-color: var(--color-accent);
+}
+.cm-tooltip-lint .cm-diagnosticAction::before {
+    content: "";
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    flex-shrink: 0;
+    background-color: currentColor;
+    -webkit-mask: var(--cm-lightbulb) no-repeat center / contain;
+    mask: var(--cm-lightbulb) no-repeat center / contain;
+    --cm-lightbulb: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-2 -2 28 28' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M15 14c.2-1 .7-1.7 1.5-2.5 1.1-1 2.5-2.2 2.5-4.5A6 6 0 0 0 7 7c0 2.3 1.4 3.5 2.5 4.5.8.8 1.3 1.5 1.5 2.5'/><path d='M9 18h6'/><path d='M10 22h4'/></svg>");
+}
 
 .no-scrollbar::-webkit-scrollbar { display: none; }
 .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }

--- a/web/src/core/engine.ts
+++ b/web/src/core/engine.ts
@@ -1,8 +1,10 @@
 import { EditorView, keymap, lineNumbers } from "@codemirror/view";
 import { EditorState, Compartment } from "@codemirror/state";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { completionKeymap } from "@codemirror/autocomplete";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { createDownstageLinter } from "../diagnostics";
+import { createDownstageCompletion } from "../completion";
 import { createDownstageHighlighter } from "../downstage-lang";
 import { createScrollSyncPlugin } from "../scroll-sync";
 import type { EditorEnv } from "./types";
@@ -60,10 +62,11 @@ export class Engine {
         extensions: [
           lineNumbers(),
           history(),
-          keymap.of([...defaultKeymap, ...historyKeymap]),
+          keymap.of([...completionKeymap, ...defaultKeymap, ...historyKeymap]),
           themeCompartment.of(isDark ? oneDark : lightTheme),
           customTheme,
           createDownstageHighlighter(this.env),
+          createDownstageCompletion(this.env),
           createDownstageLinter(this.env),
           createScrollSyncPlugin(this.iframe),
           EditorView.lineWrapping,

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -16,6 +16,52 @@ export interface WasmDiagnostic {
   code?: string;
 }
 
+export interface LSPPosition {
+  line: number;
+  character: number;
+}
+
+export interface LSPRange {
+  start: LSPPosition;
+  end: LSPPosition;
+}
+
+export interface LSPTextEdit {
+  range: LSPRange;
+  newText: string;
+}
+
+export interface LSPCompletionItem {
+  label: string;
+  kind?: number;
+  detail?: string;
+  filterText?: string;
+  sortText?: string;
+  insertText?: string;
+  textEdit?: LSPTextEdit;
+}
+
+export interface LSPCompletionList {
+  isIncomplete: boolean;
+  items: LSPCompletionItem[];
+}
+
+export interface LSPWorkspaceEdit {
+  changes?: Record<string, LSPTextEdit[]>;
+}
+
+export interface LSPCodeAction {
+  title: string;
+  kind?: string;
+  isPreferred?: boolean;
+  edit?: LSPWorkspaceEdit;
+}
+
+export interface LSPCodeActionsResult {
+  uri: string;
+  actions: LSPCodeAction[];
+}
+
 export interface SavedDraft {
   id: string;
   title: string;
@@ -27,6 +73,8 @@ export interface EditorEnv {
   // Parsing and Diagnostics
   parse(source: string): Promise<{ errors: ParseError[] }>;
   diagnostics(source: string): Promise<{ diagnostics: WasmDiagnostic[] }>;
+  completion(source: string, line: number, col: number): Promise<LSPCompletionList>;
+  codeActions(source: string, line: number, col: number, codes?: string[]): Promise<LSPCodeActionsResult>;
   semanticTokens(source: string): Promise<Uint32Array>;
   tokenTypeNames(): Promise<string[]>;
 

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -14,6 +14,7 @@ export interface WasmDiagnostic {
   endLine: number;
   endCol: number;
   code?: string;
+  quickFixes?: string[];
 }
 
 export interface LSPPosition {

--- a/web/src/diagnostics.ts
+++ b/web/src/diagnostics.ts
@@ -1,12 +1,59 @@
-import { linter, type Diagnostic } from "@codemirror/lint";
-import type { EditorEnv, WasmDiagnostic } from "./core/types";
+import { linter, type Action, type Diagnostic } from "@codemirror/lint";
+import type { EditorView } from "@codemirror/view";
+import type { Text } from "@codemirror/state";
+import type { EditorEnv, LSPCodeAction, LSPTextEdit, WasmDiagnostic } from "./core/types";
+import { offsetFromLSP } from "./lsp-offsets";
 
-function toDiagnostics(
-  doc: { line(n: number): { from: number; to: number } ; lines: number },
+function applyWorkspaceEdit(view: EditorView, uri: string, action: LSPCodeAction) {
+  const edits = action.edit?.changes?.[uri];
+  if (!edits || edits.length === 0) return;
+
+  const changes = edits.map((edit: LSPTextEdit) => ({
+    from: offsetFromLSP(view.state.doc, edit.range.start.line, edit.range.start.character),
+    to: offsetFromLSP(view.state.doc, edit.range.end.line, edit.range.end.character),
+    insert: edit.newText,
+  }));
+
+  view.dispatch({ changes, scrollIntoView: true });
+}
+
+async function actionsFor(
+  env: EditorEnv,
+  source: string,
+  diagnostic: WasmDiagnostic,
+): Promise<Action[]> {
+  if (!diagnostic.code) return [];
+
+  let result;
+  try {
+    result = await env.codeActions(source, diagnostic.line, diagnostic.col, [diagnostic.code]);
+  } catch {
+    return [];
+  }
+
+  if (!result || !result.actions) return [];
+
+  return result.actions
+    .filter((action) => action.edit?.changes?.[result.uri]?.length)
+    .map((action) => ({
+      name: action.title,
+      apply: (view: EditorView) => applyWorkspaceEdit(view, result.uri, action),
+    }));
+}
+
+async function toDiagnostics(
+  env: EditorEnv,
+  source: string,
+  doc: Text,
   sourceDiagnostics: WasmDiagnostic[],
-): Diagnostic[] {
+): Promise<Diagnostic[]> {
+  const actionLists = await Promise.all(
+    sourceDiagnostics.map((d) => actionsFor(env, source, d)),
+  );
+
   const result: Diagnostic[] = [];
-  for (const diagnostic of sourceDiagnostics) {
+  for (let i = 0; i < sourceDiagnostics.length; i++) {
+    const diagnostic = sourceDiagnostics[i];
     const startLine = diagnostic.line + 1; // 0-based → 1-based
     const endLine = diagnostic.endLine + 1;
     if (startLine > doc.lines || endLine > doc.lines) continue;
@@ -15,12 +62,15 @@ function toDiagnostics(
     let to = doc.line(endLine).from + diagnostic.endCol;
     if (to <= from) to = from + 1;
 
+    const actions = actionLists[i];
+
     result.push({
       from,
       to: Math.min(to, doc.line(endLine).to),
       severity: diagnostic.severity,
       message: diagnostic.message,
       source: "downstage",
+      actions: actions.length ? actions : undefined,
     });
   }
   return result;
@@ -31,7 +81,7 @@ export function createDownstageLinter(env: EditorEnv) {
     async (view) => {
       const source = view.state.doc.toString();
       const { diagnostics: sourceDiagnostics } = await env.diagnostics(source);
-      return toDiagnostics(view.state.doc, sourceDiagnostics);
+      return toDiagnostics(env, source, view.state.doc, sourceDiagnostics);
     },
     { delay: 300 },
   );

--- a/web/src/diagnostics.ts
+++ b/web/src/diagnostics.ts
@@ -1,76 +1,76 @@
 import { linter, type Action, type Diagnostic } from "@codemirror/lint";
 import type { EditorView } from "@codemirror/view";
 import type { Text } from "@codemirror/state";
-import type { EditorEnv, LSPCodeAction, LSPTextEdit, WasmDiagnostic } from "./core/types";
+import type { EditorEnv, LSPTextEdit, WasmDiagnostic } from "./core/types";
 import { offsetFromLSP } from "./lsp-offsets";
 
-function applyWorkspaceEdit(view: EditorView, uri: string, action: LSPCodeAction) {
-  const edits = action.edit?.changes?.[uri];
-  if (!edits || edits.length === 0) return;
-
-  const changes = edits.map((edit: LSPTextEdit) => ({
+export function applyLSPEdits(view: EditorView, edits: LSPTextEdit[]) {
+  if (!edits.length) return;
+  const changes = edits.map((edit) => ({
     from: offsetFromLSP(view.state.doc, edit.range.start.line, edit.range.start.character),
     to: offsetFromLSP(view.state.doc, edit.range.end.line, edit.range.end.character),
     insert: edit.newText,
   }));
-
   view.dispatch({ changes, scrollIntoView: true });
 }
 
-async function actionsFor(
+// buildQuickFixActions resolves code actions lazily: on click, we re-query the
+// Go side with the current document so TextEdit ranges reflect any edits the
+// user made since the lint pass that produced this diagnostic.
+function buildQuickFixActions(
   env: EditorEnv,
-  source: string,
-  diagnostic: WasmDiagnostic,
-): Promise<Action[]> {
-  if (!diagnostic.code) return [];
+  code: string,
+  titles: string[],
+): Action[] {
+  const codes = [code];
+  return titles.map((title) => ({
+    name: title,
+    apply: async (view: EditorView, from: number) => {
+      const doc = view.state.doc;
+      const line = doc.lineAt(from);
+      const lspLine = line.number - 1;
+      const character = from - line.from;
 
-  let result;
-  try {
-    result = await env.codeActions(source, diagnostic.line, diagnostic.col, [diagnostic.code]);
-  } catch {
-    return [];
-  }
+      let result;
+      try {
+        result = await env.codeActions(doc.toString(), lspLine, character, codes);
+      } catch {
+        return;
+      }
 
-  if (!result || !result.actions) return [];
-
-  return result.actions
-    .filter((action) => action.edit?.changes?.[result.uri]?.length)
-    .map((action) => ({
-      name: action.title,
-      apply: (view: EditorView) => applyWorkspaceEdit(view, result.uri, action),
-    }));
+      const match = result?.actions?.find((a) => a.title === title);
+      const edits = match?.edit?.changes?.[result.uri];
+      if (!edits) return;
+      applyLSPEdits(view, edits);
+    },
+  }));
 }
 
-async function toDiagnostics(
+export function toDiagnostics(
   env: EditorEnv,
-  source: string,
   doc: Text,
   sourceDiagnostics: WasmDiagnostic[],
-): Promise<Diagnostic[]> {
-  const actionLists = await Promise.all(
-    sourceDiagnostics.map((d) => actionsFor(env, source, d)),
-  );
-
+): Diagnostic[] {
   const result: Diagnostic[] = [];
-  for (let i = 0; i < sourceDiagnostics.length; i++) {
-    const diagnostic = sourceDiagnostics[i];
-    const startLine = diagnostic.line + 1; // 0-based → 1-based
-    const endLine = diagnostic.endLine + 1;
+  for (const d of sourceDiagnostics) {
+    const startLine = d.line + 1; // 0-based → 1-based
+    const endLine = d.endLine + 1;
     if (startLine > doc.lines || endLine > doc.lines) continue;
 
-    const from = doc.line(startLine).from + diagnostic.col;
-    let to = doc.line(endLine).from + diagnostic.endCol;
+    const from = doc.line(startLine).from + d.col;
+    let to = doc.line(endLine).from + d.endCol;
     if (to <= from) to = from + 1;
 
-    const actions = actionLists[i];
+    const titles = d.code && d.quickFixes ? d.quickFixes : [];
+    const actions = titles.length > 0 ? buildQuickFixActions(env, d.code!, titles) : undefined;
 
     result.push({
       from,
       to: Math.min(to, doc.line(endLine).to),
-      severity: diagnostic.severity,
-      message: diagnostic.message,
+      severity: d.severity,
+      message: d.message,
       source: "downstage",
-      actions: actions.length ? actions : undefined,
+      actions,
     });
   }
   return result;
@@ -81,7 +81,7 @@ export function createDownstageLinter(env: EditorEnv) {
     async (view) => {
       const source = view.state.doc.toString();
       const { diagnostics: sourceDiagnostics } = await env.diagnostics(source);
-      return toDiagnostics(env, source, view.state.doc, sourceDiagnostics);
+      return toDiagnostics(env, view.state.doc, sourceDiagnostics);
     },
     { delay: 300 },
   );

--- a/web/src/lsp-offsets.ts
+++ b/web/src/lsp-offsets.ts
@@ -1,0 +1,15 @@
+import type { Text } from "@codemirror/state";
+
+// Convert an LSP (line, character) position into a CodeMirror document
+// offset. LSP characters are UTF-16 code units within the line, which
+// matches how CodeMirror stores line content, so a direct add works.
+export function offsetFromLSP(doc: Text, line: number, character: number): number {
+  if (line < 0) return 0;
+  if (line >= doc.lines) {
+    const last = doc.line(doc.lines);
+    return Math.min(last.to, last.from + Math.max(0, character));
+  }
+  const lineObj = doc.line(line + 1);
+  const offset = lineObj.from + Math.max(0, character);
+  return Math.min(offset, lineObj.to);
+}

--- a/web/src/shims-vue.d.ts
+++ b/web/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, unknown>;
+  export default component;
+}

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -37,6 +37,7 @@ export interface WasmDiagnostic {
   endLine: number;
   endCol: number;
   code?: string;
+  quickFixes?: string[];
 }
 
 export interface LSPPosition {

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -11,6 +11,8 @@ declare global {
     downstage: {
       parse(source: string): { errors: ParseError[] };
       diagnostics(source: string): { diagnostics: WasmDiagnostic[] };
+      completion(source: string, line: number, col: number): LSPCompletionList;
+      codeActions(source: string, line: number, col: number, codes?: string[]): LSPCodeActionsResult;
       renderHTML(source: string, style?: string): string;
       renderPDF(source: string, style?: string): Uint8Array;
       semanticTokens(source: string): Uint32Array;
@@ -35,6 +37,53 @@ export interface WasmDiagnostic {
   endLine: number;
   endCol: number;
   code?: string;
+}
+
+export interface LSPPosition {
+  line: number;
+  character: number;
+}
+
+export interface LSPRange {
+  start: LSPPosition;
+  end: LSPPosition;
+}
+
+export interface LSPTextEdit {
+  range: LSPRange;
+  newText: string;
+}
+
+export interface LSPCompletionItem {
+  label: string;
+  kind?: number;
+  detail?: string;
+  filterText?: string;
+  sortText?: string;
+  insertText?: string;
+  textEdit?: LSPTextEdit;
+}
+
+export interface LSPCompletionList {
+  isIncomplete: boolean;
+  items: LSPCompletionItem[];
+}
+
+export interface LSPWorkspaceEdit {
+  changes?: Record<string, LSPTextEdit[]>;
+}
+
+export interface LSPCodeAction {
+  title: string;
+  kind?: string;
+  isPreferred?: boolean;
+  diagnostics?: unknown[];
+  edit?: LSPWorkspaceEdit;
+}
+
+export interface LSPCodeActionsResult {
+  uri: string;
+  actions: LSPCodeAction[];
 }
 
 import wasmExecUrl from "../build/wasm_exec.js?url";
@@ -115,6 +164,19 @@ export function parse(source: string) {
 
 export function diagnostics(source: string) {
   return window.downstage.diagnostics(source);
+}
+
+export function completion(source: string, line: number, col: number): LSPCompletionList {
+  return window.downstage.completion(source, line, col);
+}
+
+export function codeActions(
+  source: string,
+  line: number,
+  col: number,
+  codes?: string[],
+): LSPCodeActionsResult {
+  return window.downstage.codeActions(source, line, col, codes);
 }
 
 export function renderHTML(source: string, style?: string): string {

--- a/web/src/web-app.ts
+++ b/web/src/web-app.ts
@@ -2,7 +2,14 @@ import "./main.css";
 import { createApp } from "vue";
 import AppWeb from "./AppWeb.vue";
 import { initWasm } from "./wasm";
-import type { EditorEnv, SavedDraft, ParseError, WasmDiagnostic } from "./core/types";
+import type {
+  EditorEnv,
+  SavedDraft,
+  ParseError,
+  WasmDiagnostic,
+  LSPCompletionList,
+  LSPCodeActionsResult,
+} from "./core/types";
 
 declare const __APP_VERSION__: string;
 
@@ -31,6 +38,19 @@ class WebEnv implements EditorEnv {
 
   async diagnostics(source: string): Promise<{ diagnostics: WasmDiagnostic[] }> {
     return window.downstage.diagnostics(source);
+  }
+
+  async completion(source: string, line: number, col: number): Promise<LSPCompletionList> {
+    return window.downstage.completion(source, line, col);
+  }
+
+  async codeActions(
+    source: string,
+    line: number,
+    col: number,
+    codes?: string[],
+  ): Promise<LSPCodeActionsResult> {
+    return window.downstage.codeActions(source, line, col, codes);
   }
 
   async semanticTokens(source: string): Promise<Uint32Array> {

--- a/web/src/web-app.ts
+++ b/web/src/web-app.ts
@@ -107,7 +107,7 @@ class WebEnv implements EditorEnv {
   }
 
   async saveFile(filename: string, content: string | Uint8Array, _filters?: { displayName: string; pattern: string }[]): Promise<void> {
-    const blob = new Blob([content], { type: typeof content === "string" ? "text/plain" : "application/pdf" });
+    const blob = new Blob([content as BlobPart], { type: typeof content === "string" ? "text/plain" : "application/pdf" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;


### PR DESCRIPTION
## Summary

- Exposes `computeCompletion` and `computeCodeActions` through the WASM bridge and surfaces them in the CodeMirror editor. Completions come from a new autocomplete source; quick fixes attach to lint diagnostics via the per-diagnostic `actions` API, so they appear in the existing diagnostic tooltip with a small lightbulb icon and no new UI chrome.
- Batches quick-fix titles into the single `diagnostics()` WASM call (no more 1+N analyses per lint pass) and resolves each action on click against the *current* document, so stale LSP ranges can't land on the wrong span after the user edits.
- Adds a vitest suite for the browser adapters (LSP offset conversion including an astral-character case, bulk `TextEdit` application, completion apply with and without a `TextEdit`), folds `tsc --noEmit` into `npm test`, and wires the web tests into CI.

Closes #128

## Test plan
- [x] `go test ./...`
- [x] `make wasm`
- [x] `npm --prefix web run build`
- [x] `npm --prefix web test` (10/10 pass, includes `tsc --noEmit`)
- [x] Manual browser smoke: completions (character cues, `@` forced, `##`/`###` heading), quick fix for unknown character, bulk "Number all scenes in document"