### PR TITLE
chore(release): keep single vX.Y.Z tag format

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
+  "include-component-in-tag": false,
+  "separate-pull-requests": false,
   "packages": {
     ".": {
       "package-name": "downstage",


### PR DESCRIPTION
Pin release-please to the historical single-tag format instead of manifest component tags.

## Background

Adding a release-please config file in #131 flipped release-please from tag-based single-package mode (tags like \`v0.5.0\`) to manifest component mode (tags like \`downstage-v0.5.0\`). Since no \`downstage-v*\` tag exists, release-please reset the baseline and opened #132 for \`0.1.0\` alongside the stale tag-mode #130 for \`0.6.0\`.

## Fix

- \`include-component-in-tag: false\` — tags stay on the project's \`vX.Y.Z\` convention so the existing \`v0.5.0\` tag is recognized as the baseline.
- \`separate-pull-requests: false\` — one release PR for the root package.

Manifest (\`.release-please-manifest.json\`) already pins the current version to \`0.5.0\`, which is correct.

## After merging

1. Close #130 and #132 (both stale from the wrong tag format).
2. Release-please runs on the merge of this PR and opens a fresh \`0.6.0\` PR with tags matching \`v0.6.0\`, including the ⚠ BREAKING CHANGES section from #131's squash message.