### PR TITLE
fix(ci): drop release-please package-name so merged release PRs tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
   "separate-pull-requests": false,
   "packages": {
     ".": {
-      "package-name": "downstage",
       "bump-minor-pre-major": true
     }
   }


### PR DESCRIPTION
## Summary
- PR #134 (\`chore: release main\`) merged but no v0.6.0 tag or GitHub release got created; release-please's workflow log shows it aborting with \`PR component: undefined does not match configured component: downstage\`.
- With \`"separate-pull-requests": false\` (added in #133) release-please produces a PR titled \`chore: release main\` with no component scope, so the parsed component is \`undefined\`. That doesn't match the configured \`package-name: "downstage"\` and the tag+release step is skipped, leaving #134 stuck with the \`autorelease: pending\` label.
- Drop \`package-name\` from the sole root package. A single-package repo doesn't need a component; without it the \`undefined\` PR component matches and release-please can tag + release normally.

## Expected behavior after merge
1. This merge kicks off the Release Please workflow.
2. Release-please sees manifest at 0.6.0 with no matching tag, finds merged PR #134, and this time the component check passes.
3. Workflow creates the v0.6.0 git tag and GitHub release, flips PR #134's label to \`autorelease: tagged\`.
4. Future release PRs continue working.

If step 3 still doesn't happen, fallback is manual: tag \`v0.6.0\` at \`81c0176\`, create the release with the changelog from PR #134, relabel #134 to \`autorelease: tagged\`.

## Test plan
- [ ] Merge this PR.
- [ ] Check the Release Please workflow run completes without the component-mismatch warning.
- [ ] Verify \`v0.6.0\` tag and GitHub release exist.
- [ ] PR #134's label is \`autorelease: tagged\`.