### PR TITLE
fix(ci): drop separate-pull-requests so release PR merge can tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
   "include-component-in-tag": false,
-  "separate-pull-requests": false,
-  "pull-request-title-pattern": "chore${scope}: release ${component} ${version}",
   "packages": {
     ".": {
       "package-name": "downstage",


### PR DESCRIPTION
## Summary
The real root cause of why release PRs (#134, #139) merge but never produce a \`v0.X.Y\` tag. Confirmed by reading release-please 17.1.3 source.

\`separate-pull-requests: false\` forces release-please's [\`Merge\` plugin](https://github.com/googleapis/release-please/blob/v17.1.3/src/plugins/merge.ts#L122-L124) to set the release PR's head branch to:

\`\`\`
release-please--branches--main
\`\`\`

no component suffix. On merge, [\`base.ts\` L641-L650](https://github.com/googleapis/release-please/blob/v17.1.3/src/strategies/base.ts#L641-L650) parses that branch name (via \`BranchName.parse\`), gets back \`component = undefined\`, compares it against the configured \`downstage\` component, and short-circuits before tagging. That's the \`PR component: undefined does not match configured component: downstage\` warning from the workflow logs, and why #134 never produced \`v0.6.0\`.

For a single-package config, [\`separate-pull-requests\` defaults to \`true\`](https://github.com/googleapis/release-please/blob/v17.1.3/src/manifest.ts#L372-L374), which skips the \`Merge\` plugin and creates the release PR on:

\`\`\`
release-please--branches--main--components--downstage
\`\`\`

That parses cleanly, component matches, release pipeline completes.

## Changes
- Drop \`separate-pull-requests: false\`.
- Drop \`pull-request-title-pattern\` added in #138. The title pattern was never the issue — the component check reads the branch name, not the title.

Remaining config is the minimal working shape: \`release-type: go\`, \`include-component-in-tag: false\` (keeps historical \`vX.Y.Z\` tag format), \`package-name: downstage\`, \`bump-minor-pre-major: true\` (keeps breaking changes on the 0.x minor track).

## Expected behavior after merge
1. Release Please workflow runs.
2. Opens a new release PR on branch \`release-please--branches--main--components--downstage\`, title something like \`chore(main): release downstage 0.6.0\`, body covering #129, #131, #133, #135, #136, #138, and this commit.
3. When that release PR merges, the component check passes, \`v0.6.0\` tag and GitHub release are created, PR gets \`autorelease: tagged\` label.

## Test plan
- [ ] Merge this PR.
- [ ] New release PR appears on branch \`release-please--branches--main--components--downstage\`.
- [ ] Merge that release PR; \`v0.6.0\` tag exists and GitHub release published.
- [ ] Future \`feat:\` / \`fix:\` merges produce fresh release PRs the same way.