### PR TITLE
feat(web): add spell check

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,9 @@ Extension Development Host.
 [**Start writing**](https://www.getdownstage.com/editor/) in the Web Editor, a
 modern browser-based editor built with Vue 3, Tailwind CSS v4, and CodeMirror 6.
 It features live preview, adaptive syntax highlighting, completions and
-quick-fix code actions sourced from the Downstage LSP, and PDF export. No
-install required; the entire pipeline runs client-side via WebAssembly.
+quick-fix code actions sourced from the Downstage LSP, spellcheck with a
+per-script dictionary, and PDF export. No install required; the entire
+pipeline runs client-side via WebAssembly.
 
 For local development:
 

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -22,6 +22,7 @@ func main() {
 
 	ds.Set("parse", js.FuncOf(parse))
 	ds.Set("diagnostics", js.FuncOf(diagnostics))
+	ds.Set("spellcheckContext", js.FuncOf(spellcheckContext))
 	ds.Set("upgradeV1", js.FuncOf(upgradeV1))
 	ds.Set("completion", js.FuncOf(completion))
 	ds.Set("codeActions", js.FuncOf(codeActions))
@@ -55,6 +56,11 @@ type diagnosticJSON struct {
 	EndCol     int      `json:"endCol"`
 	Code       string   `json:"code,omitempty"`
 	QuickFixes []string `json:"quickFixes,omitempty"`
+}
+
+type spellcheckContextJSON struct {
+	AllowWords    []string         `json:"allowWords"`
+	IgnoredRanges []protocol.Range `json:"ignoredRanges"`
 }
 
 func parse(_ js.Value, args []js.Value) any {
@@ -101,6 +107,18 @@ func diagnostics(_ js.Value, args []js.Value) any {
 	}
 
 	data, _ := json.Marshal(map[string]any{"diagnostics": out})
+	return js.Global().Get("JSON").Call("parse", string(data))
+}
+
+func spellcheckContext(_ js.Value, args []js.Value) any {
+	source := args[0].String()
+	doc, errs := parser.Parse([]byte(source))
+	ctx := lsp.ComputeSpellcheckContext(doc, errs)
+
+	data, _ := json.Marshal(spellcheckContextJSON{
+		AllowWords:    ctx.AllowWords,
+		IgnoredRanges: ctx.IgnoredRanges,
+	})
 	return js.Global().Get("JSON").Call("parse", string(data))
 }
 

--- a/internal/lsp/spellcheck.go
+++ b/internal/lsp/spellcheck.go
@@ -1,0 +1,93 @@
+package lsp
+
+import (
+	"strings"
+
+	"github.com/jscaltreto/downstage/internal/ast"
+	"github.com/jscaltreto/downstage/internal/parser"
+	"go.lsp.dev/protocol"
+)
+
+type SpellcheckContext struct {
+	AllowWords    []string
+	IgnoredRanges []protocol.Range
+}
+
+func ComputeSpellcheckContext(doc *ast.Document, _ []*parser.ParseError) SpellcheckContext {
+	index := newDocumentIndex(doc)
+
+	return SpellcheckContext{
+		AllowWords:    spellAllowWords(index.documentCharacterNames),
+		IgnoredRanges: ignoredSpellcheckRanges(doc),
+	}
+}
+
+func spellAllowWords(names []string) []string {
+	seen := make(map[string]struct{})
+	words := make([]string, 0)
+
+	for _, name := range names {
+		for _, word := range strings.FieldsFunc(name, splitSpellAllowWord) {
+			word = strings.TrimSpace(word)
+			if word == "" {
+				continue
+			}
+			key := strings.ToUpper(word)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			words = append(words, word)
+		}
+	}
+
+	return words
+}
+
+func splitSpellAllowWord(r rune) bool {
+	switch {
+	case r >= 'A' && r <= 'Z':
+		return false
+	case r >= 'a' && r <= 'z':
+		return false
+	case r == '\'' || r == '’':
+		return false
+	default:
+		return true
+	}
+}
+
+func ignoredSpellcheckRanges(doc *ast.Document) []protocol.Range {
+	if doc == nil {
+		return []protocol.Range{}
+	}
+
+	var tokens []rawToken
+	for _, node := range doc.Body {
+		tokens = append(tokens, extractTokens(node)...)
+	}
+
+	sortTokens(tokens)
+
+	ranges := make([]protocol.Range, 0)
+	for _, tok := range tokens {
+		if tok.tokenType != tokenTypeNamespace &&
+			tok.tokenType != tokenTypeType &&
+			tok.tokenType != tokenTypeKeyword &&
+			tok.tokenType != tokenTypeProperty {
+			continue
+		}
+		ranges = append(ranges, protocol.Range{
+			Start: protocol.Position{
+				Line:      uint32(tok.line),
+				Character: uint32(tok.startChar),
+			},
+			End: protocol.Position{
+				Line:      uint32(tok.line),
+				Character: uint32(tok.startChar + tok.length),
+			},
+		})
+	}
+
+	return ranges
+}

--- a/internal/lsp/spellcheck_test.go
+++ b/internal/lsp/spellcheck_test.go
@@ -1,0 +1,89 @@
+package lsp
+
+import (
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/parser"
+	"go.lsp.dev/protocol"
+)
+
+func TestComputeSpellcheckContext_AllowsCharacterWordsAndIgnoresStructuralTokens(t *testing.T) {
+	src := `# Play
+Subtitle: A Test
+
+## Dramatis Personae
+
+KING LEAR/LEAR - Ruler of Britain
+O'BRIEN
+
+## ACT I
+
+### SCENE 1
+
+KING LEAR
+Ths line has a typo.
+
+SONG 1: Ballad
+
+SONG END
+`
+
+	doc, errs := parser.Parse([]byte(src))
+	if len(errs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", errs)
+	}
+
+	ctx := ComputeSpellcheckContext(doc, errs)
+
+	assertContains(t, ctx.AllowWords, "KING")
+	assertContains(t, ctx.AllowWords, "LEAR")
+	assertContains(t, ctx.AllowWords, "O'BRIEN")
+	assertContainsRange(t, ctx.IgnoredRanges, 1, 0, 1, 8)    // Subtitle
+	assertContainsRange(t, ctx.IgnoredRanges, 12, 0, 12, 9)  // KING LEAR cue
+	assertContainsRange(t, ctx.IgnoredRanges, 15, 0, 15, 14) // SONG 1: Ballad
+	assertContainsRange(t, ctx.IgnoredRanges, 17, 0, 17, 8)  // SONG END
+}
+
+func TestSpellAllowWords_SplitsMultiWordNamesAndDedupes(t *testing.T) {
+	words := spellAllowWords([]string{"KING LEAR", "Lear", "O'BRIEN"})
+
+	assertContains(t, words, "KING")
+	assertContains(t, words, "LEAR")
+	assertContains(t, words, "O'BRIEN")
+	if countOccurrences(words, "LEAR") != 1 {
+		t.Fatalf("expected LEAR once, got %v", words)
+	}
+}
+
+func assertContains(t *testing.T, values []string, want string) {
+	t.Helper()
+	for _, value := range values {
+		if value == want {
+			return
+		}
+	}
+	t.Fatalf("expected %q in %v", want, values)
+}
+
+func countOccurrences(values []string, want string) int {
+	count := 0
+	for _, value := range values {
+		if value == want {
+			count++
+		}
+	}
+	return count
+}
+
+func assertContainsRange(t *testing.T, ranges []protocol.Range, startLine, startChar, endLine, endChar uint32) {
+	t.Helper()
+	for _, r := range ranges {
+		if r.Start.Line == startLine &&
+			r.Start.Character == startChar &&
+			r.End.Line == endLine &&
+			r.End.Character == endChar {
+			return
+		}
+	}
+	t.Fatalf("expected range [%d:%d]-[%d:%d] in %v", startLine, startChar, endLine, endChar, ranges)
+}

--- a/web/README.md
+++ b/web/README.md
@@ -2,8 +2,9 @@
 
 A browser-based Downstage editor with live preview, syntax highlighting,
 LSP-powered autocomplete and quick-fix code actions, browser-local draft
-storage, an Open Draft picker, and PDF export. The entire parsing and
-rendering pipeline runs client-side via WebAssembly — no server required.
+storage, script-local spellcheck dictionaries, an Open Draft picker, and PDF
+export. The entire parsing and rendering pipeline runs client-side via
+WebAssembly — no server required.
 
 ## Draft Storage
 
@@ -32,6 +33,7 @@ make web-dev
 - **CodeMirror 6**: Plaintext editor core
 - **Lucide**: Consistent iconography
 - **WebAssembly**: Go-powered parsing and rendering
+- **typo-js + Web Workers**: English spellcheck off the main thread
 
 ## Building
 
@@ -81,9 +83,20 @@ The WASM module exposes a global `downstage` object:
 |----------|-------|--------|
 | `parse(source)` | Downstage source string | `{errors: [{message, line, col, endLine, endCol}]}` |
 | `diagnostics(source)` | Downstage source string | `{diagnostics: [{message, severity, line, col, endLine, endCol, code?, quickFixes?}]}` |
+| `spellcheckContext(source)` | Downstage source string | `{allowWords: string[], ignoredRanges: LSPRange[]}` |
 | `completion(source, line, col)` | Source + 0-based LSP position | LSP `CompletionList` (`{isIncomplete, items[]}`) |
 | `codeActions(source, line, col, codes?)` | Source + 0-based LSP position + optional diagnostic-code filter | `{uri, actions: LSPCodeAction[]}` |
 | `renderHTML(source, style?)` | Source + optional style (`"standard"`/Manuscript or `"condensed"`/Acting Edition) | HTML string |
 | `renderPDF(source, style?)` | Source + optional style | `Uint8Array` (PDF bytes) |
 | `semanticTokens(source)` | Source string | `Uint32Array` (delta-encoded LSP tokens) |
 | `tokenTypeNames` | — | `string[]` (token type legend) |
+
+## Spell Check
+
+The web editor ships with English spellcheck integrated into CodeMirror
+diagnostics. It is enabled by default, can be toggled from the editor
+toolbar, and supports a script-local dictionary for character names,
+invented terms, and other manuscript-specific vocabulary.
+
+Spell suggestions are loaded lazily and the dictionary work runs off the main
+thread so large scripts do not block initial editor load.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,6 +24,7 @@
         "lucide-vue-next": "^1.0.0",
         "postcss": "^8.5.9",
         "tailwindcss": "^4.2.2",
+        "typo-js": "^1.3.1",
         "vue": "^3.5.32"
       },
       "devDependencies": {
@@ -2507,6 +2508,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/typo-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/typo-js/-/typo-js-1.3.1.tgz",
+      "integrity": "sha512-elJkpCL6Z77Ghw0Lv0lGnhBAjSTOQ5FhiVOCfOuxhaoTT2xtLVbqikYItK5HHchzPbHEUFAcjOH669T2ZzeCbg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
     "lucide-vue-next": "^1.0.0",
     "postcss": "^8.5.9",
     "tailwindcss": "^4.2.2",
+    "typo-js": "^1.3.1",
     "vue": "^3.5.32"
   },
   "devDependencies": {

--- a/web/src/AppWeb.vue
+++ b/web/src/AppWeb.vue
@@ -171,15 +171,32 @@ async function createDraft(title: string, content: string) {
   flushDrafts();
   pendingDraft.value = null;
   const id = `draft-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const newDraft = {
+  const newDraft: SavedDraft = {
       id,
       title,
       content,
-      updatedAt: new Date().toISOString()
+      updatedAt: new Date().toISOString(),
+      spellAllowlist: [],
   };
   store.state.drafts.unshift(newDraft);
   await activateDraft(id);
   await props.env.saveDrafts(store.state.drafts);
+}
+
+async function addSpellAllowlistWord(word: string) {
+    const trimmed = word.trim();
+    if (!trimmed) return false;
+
+    if (!store.activeDraft() && pendingDraft.value) {
+        const title = extractDocumentTitle(activeContent.value) || pendingDraft.value.title;
+        await createDraft(title, activeContent.value);
+    }
+
+    return store.addSpellAllowlistWord(trimmed);
+}
+
+async function removeSpellAllowlistWord(word: string) {
+    return store.removeSpellAllowlistWord(word);
 }
 
 function showPendingPlaceholder(title: string, content: string) {
@@ -310,6 +327,7 @@ watch(activeContent, (newContent) => {
             title: extractDocumentTitle(newContent) || placeholder.title,
             content: newContent,
             updatedAt: new Date().toISOString(),
+            spellAllowlist: [],
         };
         store.state.drafts.unshift(newDraft);
         store.state.activeDraftId = id;
@@ -446,6 +464,9 @@ _underline_</code></pre>
         :env="env"
         v-model:content="activeContent"
         v-model:style="pageStyle"
+        :get-spell-allowlist="() => activeSavedDraft?.spellAllowlist || []"
+        :add-spell-allowlist-word="addSpellAllowlistWord"
+        :remove-spell-allowlist-word="removeSpellAllowlistWord"
         @toggle-help="showQuickReference = !showQuickReference"
         @migration-state-change="isV1Document = $event"
       />

--- a/web/src/__tests__/spellcheck.test.ts
+++ b/web/src/__tests__/spellcheck.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import { Text } from "@codemirror/state";
+import { getSpellDiagnostics, matchCase } from "../spellcheck";
+import type { SpellcheckContext } from "../core/types";
+
+function spellContext(overrides?: Partial<SpellcheckContext>): SpellcheckContext {
+  return {
+    allowWords: [],
+    ignoredRanges: [],
+    ...overrides,
+  };
+}
+
+// typo-js dictionary parse runs once on first call and is cached; bump the
+// default 5s timeout to accommodate the cold load.
+describe("getSpellDiagnostics", { timeout: 30000 }, () => {
+  it("produces a lazy diagnostic with only the add-word action up front", async () => {
+    const doc = Text.of(["mispelled"]);
+    const diagnostics = await getSpellDiagnostics(doc, spellContext(), {
+      getUserAllowlist: () => [],
+      addWord: async () => true,
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    const [diag] = diagnostics;
+    expect(diag.source).toBe("spellcheck");
+    expect(diag.severity).toBe("warning");
+    expect(diag.markClass).toBe(" cm-spellcheckRange");
+    // Replacement suggestions are rendered lazily via renderMessage, so the
+    // eager action list only holds the add-word action.
+    expect(diag.actions).toHaveLength(1);
+    expect(diag.actions?.[0]?.name).toBe('Add "mispelled" to this script dictionary');
+    expect(typeof diag.renderMessage).toBe("function");
+  });
+
+  it("suppresses diagnostics for ignored ranges and merged allowlists", async () => {
+    const doc = Text.of(["HAMLET mispelled bespoke"]);
+    const diagnostics = await getSpellDiagnostics(doc, spellContext({
+      allowWords: ["HAMLET"],
+      ignoredRanges: [{
+        start: { line: 0, character: 7 },
+        end: { line: 0, character: 16 },
+      }],
+    }), {
+      getUserAllowlist: () => ["bespoke"],
+      addWord: async () => true,
+    });
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("treats null allowWords and ignoredRanges as empty arrays", async () => {
+    const doc = Text.of(["hello"]);
+    const diagnostics = await getSpellDiagnostics(doc, {
+      allowWords: null,
+      ignoredRanges: null,
+    } as any, {
+      getUserAllowlist: () => [],
+      addWord: async () => true,
+    });
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag KEEPCASE proper nouns or capitalized contractions", async () => {
+    // Liz, Michael, English are all in en_US Hunspell with KEEPCASE; "I've"
+    // is the canonical capitalized contraction. All previously failed because
+    // we lowercased before check(), tripping KEEPCASE.
+    const doc = Text.of(["Hello Liz and Michael, I've been reading English."]);
+    const diagnostics = await getSpellDiagnostics(doc, spellContext(), {
+      getUserAllowlist: () => [],
+      addWord: async () => true,
+    });
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("skips letter-plural constructs like \"M's\" and short contractions", async () => {
+    // "M's" and "H's" are letter-plurals from prose like "two M's"; "I'd"
+    // and "I'm" are short contractions. None should flag.
+    const doc = Text.of(["Two M's and three H's, I'd say I'm sure."]);
+    const diagnostics = await getSpellDiagnostics(doc, spellContext(), {
+      getUserAllowlist: () => [],
+      addWord: async () => true,
+    });
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("accepts possessives of dictionary words like \"else's\" and \"someone's\"", async () => {
+    // These constructions don't have inflected forms in Hunspell en_US, but
+    // the bare words do. The engine retries the bare form on a 's-suffix
+    // failure rather than flagging "somebody else's".
+    const doc = Text.of(["This is somebody else's problem and someone's mistake."]);
+    const diagnostics = await getSpellDiagnostics(doc, spellContext(), {
+      getUserAllowlist: () => [],
+      addWord: async () => true,
+    });
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("treats a possessive of an allowlisted name as allowlisted", async () => {
+    // Stage direction: "ALICE crosses to ALICE's chair." The character cue
+    // allowlist contains ALICE but not ALICE's; we should still skip the
+    // possessive form rather than flagging it with an Alice's "fix".
+    const doc = Text.of(["ALICE crosses to ALICE's chair."]);
+    const diagnostics = await getSpellDiagnostics(doc, spellContext({
+      allowWords: ["ALICE"],
+    }), {
+      getUserAllowlist: () => [],
+      addWord: async () => true,
+    });
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("skips mid-sentence Title Case words but still checks them at sentence start", async () => {
+    // Esmerelda is not in en_US dict. Mid-sentence: skipped (assumed proper
+    // noun). Sentence-initial: still checked, so a typo of "Teh" is flagged.
+    const midSentence = Text.of(["I greeted Esmerelda warmly."]);
+    const midDiags = await getSpellDiagnostics(midSentence, spellContext(), {
+      getUserAllowlist: () => [],
+      addWord: async () => true,
+    });
+    expect(midDiags).toHaveLength(0);
+
+    const sentenceStart = Text.of(["Teh quick brown fox."]);
+    const startDiags = await getSpellDiagnostics(sentenceStart, spellContext(), {
+      getUserAllowlist: () => [],
+      addWord: async () => true,
+    });
+    expect(startDiags.some((d) => d.message.includes("Teh"))).toBe(true);
+  });
+
+});
+
+describe("matchCase", () => {
+  it("preserves lowercase suggestions for lowercase originals", () => {
+    expect(matchCase("teh", "the")).toBe("the");
+  });
+
+  it("upper-cases the first letter for Title Case originals", () => {
+    expect(matchCase("Teh", "the")).toBe("The");
+  });
+
+  it("upper-cases the entire suggestion for ALL-CAPS originals", () => {
+    expect(matchCase("TEH", "the")).toBe("THE");
+  });
+
+  it("treats single uppercase letters as Title Case, not ALL-CAPS", () => {
+    // A single-letter uppercase word like "I" shouldn't trigger the ALL-CAPS
+    // path (which only kicks in for 2+ chars); the Title Case rule should
+    // capitalize the first letter of the suggestion.
+    expect(matchCase("I", "in")).toBe("In");
+  });
+
+  it("leaves mixed-case originals (like \"iPhone\") untouched", () => {
+    expect(matchCase("iPhone", "iphone")).toBe("iphone");
+  });
+
+  it("returns empty suggestions unchanged", () => {
+    expect(matchCase("Teh", "")).toBe("");
+  });
+});
+
+describe("getSpellDiagnostics (extended)", { timeout: 30000 }, () => {
+  it("continues scanning past the first hundred candidate words", async () => {
+    const filler = Array.from({ length: 130 }, () => "hello").join(" ");
+    // Use a lowercase typo so the Title Case proper-noun heuristic doesn't
+    // skip it on its own.
+    const doc = Text.of([`${filler} ascenddsion`]);
+
+    const diagnostics = await getSpellDiagnostics(doc, spellContext(), {
+      getUserAllowlist: () => [],
+      addWord: async () => true,
+    });
+
+    expect(diagnostics.some((diagnostic) => diagnostic.message.includes("ascenddsion"))).toBe(true);
+  });
+});

--- a/web/src/__tests__/store.test.ts
+++ b/web/src/__tests__/store.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Store } from "../core/store";
+import type { EditorEnv, SavedDraft } from "../core/types";
+
+function draft(): SavedDraft {
+  return {
+    id: "draft-1",
+    title: "Play",
+    content: "# Play",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    spellAllowlist: [],
+  };
+}
+
+function createEnv() {
+  return {
+    getAppVersion: () => "test",
+    loadDrafts: async () => [],
+    saveDrafts: vi.fn(async () => {}),
+    loadActiveDraftId: async () => null,
+    saveActiveDraftId: async () => {},
+  } as unknown as EditorEnv & { saveDrafts: ReturnType<typeof vi.fn> };
+}
+
+describe("Store spell allowlist", () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+      },
+      configurable: true,
+    });
+
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        matchMedia: vi.fn(() => ({
+          matches: false,
+          onchange: null,
+        })),
+      },
+      configurable: true,
+    });
+
+    Object.defineProperty(globalThis, "document", {
+      value: {
+        documentElement: {
+          classList: {
+            toggle: vi.fn(),
+          },
+        },
+      },
+      configurable: true,
+    });
+  });
+
+  it("adds deduped words to the active draft and persists them", async () => {
+    const env = createEnv();
+    const store = new Store(env);
+    store.state.drafts = [draft()];
+    store.state.activeDraftId = "draft-1";
+
+    await expect(store.addSpellAllowlistWord("Nebula")).resolves.toBe(true);
+    await expect(store.addSpellAllowlistWord("nebula")).resolves.toBe(false);
+
+    expect(store.activeDraft()?.spellAllowlist).toEqual(["Nebula"]);
+    expect(env.saveDrafts).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes words case-insensitively and persists the change", async () => {
+    const env = createEnv();
+    const store = new Store(env);
+    store.state.drafts = [{
+      ...draft(),
+      spellAllowlist: ["Nebula", "Starfall"],
+    }];
+    store.state.activeDraftId = "draft-1";
+
+    await expect(store.removeSpellAllowlistWord("nebula")).resolves.toBe(true);
+
+    expect(store.activeDraft()?.spellAllowlist).toEqual(["Starfall"]);
+    expect(env.saveDrafts).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false when no active draft exists", async () => {
+    const env = createEnv();
+    const store = new Store(env);
+
+    await expect(store.addSpellAllowlistWord("Nebula")).resolves.toBe(false);
+    await expect(store.removeSpellAllowlistWord("Nebula")).resolves.toBe(false);
+    expect(env.saveDrafts).not.toHaveBeenCalled();
+  });
+
+  it("trims added words before saving", async () => {
+    const env = createEnv();
+    const store = new Store(env);
+    store.state.drafts = [draft()];
+    store.state.activeDraftId = "draft-1";
+
+    await expect(store.addSpellAllowlistWord("  Nebula  ")).resolves.toBe(true);
+
+    expect(store.activeDraft()?.spellAllowlist).toEqual(["Nebula"]);
+  });
+});

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch, inject, nextTick } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch, inject, nextTick } from 'vue';
 import { 
     Bold, Italic, Underline, MessageSquare, ChevronRight, 
     GalleryVerticalEnd, GalleryVertical, FilePlus2, Eye, EyeOff, HelpCircle, X, Music,
-    Sun, Moon, ScrollText, BookOpenText, AlertTriangle, RefreshCw
+    Sun, Moon, ScrollText, BookOpenText, AlertTriangle, RefreshCw, SpellCheck, Trash2
 } from 'lucide-vue-next';
 import { Engine } from '../../core/engine';
 import type { Store } from '../../core/store';
@@ -16,6 +16,9 @@ const props = defineProps<{
   env: EditorEnv;
   content: string;
   style: string;
+  getSpellAllowlist: () => string[];
+  addSpellAllowlistWord: (word: string) => Promise<boolean>;
+  removeSpellAllowlistWord: (word: string) => Promise<boolean>;
 }>();
 
 const emit = defineEmits<{
@@ -32,6 +35,10 @@ const renderedHtml = ref("");
 let engine: Engine | null = null;
 
 const previewVisible = ref(localStorage.getItem("downstage-editor-preview-hidden") !== "true");
+const spellcheckEnabled = ref(localStorage.getItem("downstage-editor-spellcheck-disabled") !== "true");
+const showSpellcheckModal = ref(false);
+const dictionaryWord = ref("");
+const spellAllowlist = computed(() => props.getSpellAllowlist());
 const v1DocumentDetected = ref(false);
 const showV1Modal = ref(false);
 const v1DismissedForDraftId = ref<string | null>(null);
@@ -118,9 +125,11 @@ onMounted(async () => {
         emit('update:content', content);
         scheduleRender(content, props.style);
       },
-      iframeEl
+      iframeEl,
+      () => props.getSpellAllowlist(),
+      (word) => props.addSpellAllowlistWord(word),
     );
-    engine.init(props.content, store.state.isDark);
+    engine.init(props.content, store.state.isDark, spellcheckEnabled.value);
     scheduleRender(props.content, props.style);
   }
 });
@@ -158,6 +167,11 @@ watch(previewVisible, (visible) => {
     }
 });
 
+watch(spellcheckEnabled, (enabled) => {
+    localStorage.setItem("downstage-editor-spellcheck-disabled", String(!enabled));
+    engine?.setSpellcheckEnabled(enabled);
+});
+
 function handleFormat(action: string) {
     if (!engine) return;
     engine.applyFormat(action);
@@ -166,6 +180,21 @@ function handleFormat(action: string) {
 function toggleStyle() {
     const nextStyle = props.style === "condensed" ? "standard" : "condensed";
     emit('update:style', nextStyle);
+}
+
+async function addDictionaryWord() {
+    const added = await props.addSpellAllowlistWord(dictionaryWord.value);
+    if (added) {
+        dictionaryWord.value = "";
+        engine?.refreshDiagnostics();
+    }
+}
+
+async function removeDictionaryWord(word: string) {
+    const removed = await props.removeSpellAllowlistWord(word);
+    if (removed) {
+        engine?.refreshDiagnostics();
+    }
 }
 </script>
 
@@ -185,6 +214,21 @@ function toggleStyle() {
             <ToolbarButton @click="handleFormat('scene')" title="Scene Heading"><template #icon><GalleryVertical class="w-4 h-4 opacity-70" /></template></ToolbarButton>
             <ToolbarButton @click="handleFormat('song')" title="Song Block"><template #icon><Music class="w-4 h-4" /></template></ToolbarButton>
             <ToolbarButton @click="handleFormat('page-break')" title="Page Break"><template #icon><FilePlus2 class="w-4 h-4" /></template></ToolbarButton>
+
+            <div class="w-px h-4 bg-black/10 dark:bg-white/10 mx-1"></div>
+
+            <ToolbarButton @click="showSpellcheckModal = true" title="Spell Check">
+                <template #icon>
+                    <span class="relative flex h-4 w-4 items-center justify-center">
+                        <SpellCheck class="h-4 w-4" :class="{ 'opacity-45': !spellcheckEnabled }" />
+                        <span
+                            v-if="!spellcheckEnabled"
+                            class="absolute h-[1.5px] w-5 rotate-[-35deg] rounded-full bg-current"
+                            aria-hidden="true"
+                        ></span>
+                    </span>
+                </template>
+            </ToolbarButton>
         </div>
 
         <div class="flex items-center gap-1.5 border-l border-black/10 dark:border-white/10 pl-2">
@@ -287,6 +331,88 @@ function toggleStyle() {
         </button>
     </div>
   </div>
+
+  <BaseModal
+    :open="showSpellcheckModal"
+    kicker="Writing Tools"
+    title="Spell Check"
+    message="Control spell check and manage custom words for this script only."
+    @close="showSpellcheckModal = false"
+  >
+    <div class="flex flex-col gap-5 py-1">
+        <label class="flex items-center justify-between gap-4 rounded-lg border border-border bg-black/5 px-4 py-3 dark:bg-white/5">
+            <p class="text-sm font-bold text-text-main">Enable Spell Check</p>
+            <button
+                type="button"
+                role="switch"
+                :aria-checked="spellcheckEnabled"
+                class="relative inline-flex h-7 w-12 shrink-0 items-center rounded-full border transition-colors"
+                :class="spellcheckEnabled ? 'border-brass-500 bg-brass-500/80' : 'border-border bg-black/10 dark:bg-white/10'"
+                @click="spellcheckEnabled = !spellcheckEnabled"
+            >
+                <span
+                    class="inline-block h-5 w-5 rounded-full bg-white shadow transition-transform"
+                    :class="spellcheckEnabled ? 'translate-x-6' : 'translate-x-1'"
+                ></span>
+            </button>
+        </label>
+
+        <div class="space-y-1">
+            <p class="text-sm font-bold text-text-main">Script Dictionary</p>
+            <p class="text-xs leading-relaxed text-text-muted">
+                Add custom words for this draft. These entries do not affect any other script.
+            </p>
+        </div>
+
+        <form class="flex gap-2" @submit.prevent="addDictionaryWord">
+            <input
+                v-model="dictionaryWord"
+                type="text"
+                class="flex-1 rounded-lg border border-border bg-black/5 px-3 py-2 text-sm text-text-main outline-none transition-colors placeholder:text-text-muted focus:border-brass-500 dark:bg-white/5"
+                placeholder="Add a custom word"
+            />
+            <button
+                type="submit"
+                class="rounded-lg bg-brass-500 px-4 py-2 text-sm font-bold text-ember-950 transition-colors hover:bg-brass-400 disabled:opacity-50"
+                :disabled="dictionaryWord.trim().length === 0"
+            >
+                Add
+            </button>
+        </form>
+
+        <div v-if="spellAllowlist.length === 0" class="rounded-lg border border-dashed border-border bg-black/5 px-4 py-6 text-center text-sm text-text-muted dark:bg-white/5">
+            No custom words yet.
+        </div>
+
+        <div v-else class="flex flex-col gap-2">
+            <div
+                v-for="word in spellAllowlist"
+                :key="word"
+                class="flex items-center justify-between gap-3 rounded-lg border border-border bg-black/5 px-3 py-2 dark:bg-white/5"
+            >
+                <span class="font-mono text-sm text-text-main">{{ word }}</span>
+                <button
+                    type="button"
+                    class="rounded-md p-2 text-text-muted transition-colors hover:bg-red-500/10 hover:text-red-500"
+                    :title="`Remove ${word} from this script dictionary`"
+                    @click="removeDictionaryWord(word)"
+                >
+                    <Trash2 class="h-4 w-4" />
+                </button>
+            </div>
+        </div>
+
+        <div class="flex justify-end pt-2">
+            <button
+                type="button"
+                class="rounded-lg border border-border px-4 py-2 text-sm font-bold text-text-main transition-colors hover:bg-black/5 dark:hover:bg-white/5"
+                @click="showSpellcheckModal = false"
+            >
+                OK
+            </button>
+        </div>
+    </div>
+  </BaseModal>
 
   <BaseModal
     :open="showV1Modal"
@@ -394,6 +520,23 @@ function toggleStyle() {
     -webkit-mask: var(--cm-lightbulb) no-repeat center / contain;
     mask: var(--cm-lightbulb) no-repeat center / contain;
     --cm-lightbulb: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-2 -2 28 28' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M15 14c.2-1 .7-1.7 1.5-2.5 1.1-1 2.5-2.2 2.5-4.5A6 6 0 0 0 7 7c0 2.3 1.4 3.5 2.5 4.5.8.8 1.3 1.5 1.5 2.5'/><path d='M9 18h6'/><path d='M10 22h4'/></svg>");
+}
+.cm-tooltip-lint .cm-spellMessage {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+.cm-tooltip-lint .cm-spellSuggestions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.3rem;
+}
+.cm-tooltip-lint .cm-spellLoading,
+.cm-tooltip-lint .cm-spellEmpty {
+    font-size: 0.85em;
+    font-style: italic;
+    color: var(--color-text-muted);
 }
 
 .no-scrollbar::-webkit-scrollbar { display: none; }

--- a/web/src/components/shared/ToolbarButton.vue
+++ b/web/src/components/shared/ToolbarButton.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { useSlots } from 'vue';
+import { computed, useSlots } from 'vue';
+import { Comment, Text } from 'vue';
 
 defineProps<{
   disabled?: boolean;
@@ -9,7 +10,16 @@ defineProps<{
 }>();
 
 const slots = useSlots();
-const hasText = !!slots.default;
+const hasText = computed(() => {
+  const content = slots.default?.() || [];
+  return content.some((node) => {
+    if (node.type === Comment) return false;
+    if (node.type === Text) {
+      return String(node.children ?? '').trim().length > 0;
+    }
+    return true;
+  });
+});
 </script>
 
 <template>

--- a/web/src/core/engine.ts
+++ b/web/src/core/engine.ts
@@ -3,13 +3,15 @@ import { EditorState, Compartment } from "@codemirror/state";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { completionKeymap } from "@codemirror/autocomplete";
 import { oneDark } from "@codemirror/theme-one-dark";
-import { createDownstageLinter } from "../diagnostics";
+import { createDownstageLinter, refreshDiagnostics } from "../diagnostics";
 import { createDownstageCompletion } from "../completion";
 import { createDownstageHighlighter } from "../downstage-lang";
 import { createScrollSyncPlugin } from "../scroll-sync";
+import { warmSpellDictionary } from "../spellcheck";
 import type { EditorEnv } from "./types";
 
 const themeCompartment = new Compartment();
+const lintCompartment = new Compartment();
 
 // Simple light theme for CodeMirror
 const lightTheme = EditorView.theme({
@@ -38,15 +40,23 @@ const lightTheme = EditorView.theme({
 
 export class Engine {
   private view: EditorView | null = null;
+  private spellcheckEnabled = false;
+  private spellcheckReady = false;
+  private cancelSpellcheckWarmup: (() => void) | null = null;
 
   constructor(
     private parent: HTMLElement,
     private env: EditorEnv,
     private onDocChange: (content: string) => void,
     private iframe: HTMLIFrameElement,
+    private getUserSpellAllowlist: () => string[],
+    private addUserSpellAllowlistWord: (word: string) => Promise<boolean>,
   ) {}
 
-  init(initialContent: string, isDark: boolean) {
+  init(initialContent: string, isDark: boolean, spellcheckEnabled = false) {
+    this.spellcheckEnabled = spellcheckEnabled;
+    this.spellcheckReady = !spellcheckEnabled;
+
     const customTheme = EditorView.theme({
       "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, ::selection": {
         backgroundColor: "rgba(227, 168, 87, 0.4) !important",
@@ -64,10 +74,10 @@ export class Engine {
           history(),
           keymap.of([...completionKeymap, ...defaultKeymap, ...historyKeymap]),
           themeCompartment.of(isDark ? oneDark : lightTheme),
+          lintCompartment.of(this.createLintExtension()),
           customTheme,
           createDownstageHighlighter(this.env),
           createDownstageCompletion(this.env),
-          createDownstageLinter(this.env),
           createScrollSyncPlugin(this.iframe),
           EditorView.lineWrapping,
           EditorView.updateListener.of((update) => {
@@ -79,6 +89,10 @@ export class Engine {
       }),
       parent: this.parent,
     });
+
+    if (spellcheckEnabled) {
+      this.scheduleSpellcheckWarmup();
+    }
   }
 
   applyFormat(action: string) {
@@ -157,6 +171,25 @@ export class Engine {
     });
   }
 
+  setSpellcheckEnabled(enabled: boolean) {
+    this.spellcheckEnabled = enabled;
+    if (!this.view) return;
+
+    if (!enabled) {
+      this.clearSpellcheckWarmup();
+      this.spellcheckReady = false;
+      this.refreshDiagnostics();
+      return;
+    }
+
+    this.scheduleSpellcheckWarmup();
+  }
+
+  refreshDiagnostics() {
+    if (!this.view) return;
+    refreshDiagnostics(this.view);
+  }
+
   setContent(content: string) {
     if (!this.view) return;
     if (this.getContent() === content) return;
@@ -175,6 +208,64 @@ export class Engine {
   }
 
   destroy() {
+    this.clearSpellcheckWarmup();
     this.view?.destroy();
   }
+
+  private createLintExtension() {
+    return createDownstageLinter(this.env, () => this.spellcheckEnabled && this.spellcheckReady, {
+      getUserAllowlist: this.getUserSpellAllowlist,
+      addWord: async (word) => {
+        const added = await this.addUserSpellAllowlistWord(word);
+        if (added) {
+          this.refreshDiagnostics();
+        }
+        return added;
+      },
+    });
+  }
+
+  private scheduleSpellcheckWarmup() {
+    this.clearSpellcheckWarmup();
+    this.spellcheckReady = false;
+
+    let cancelled = false;
+    const activate = async () => {
+      this.cancelSpellcheckWarmup = null;
+      if (cancelled || !this.view || !this.spellcheckEnabled) return;
+
+      // Actually construct the typo-js dictionary here so the first lint
+      // pass doesn't pay the ~50K-line parse cost on the main thread.
+      try {
+        await warmSpellDictionary();
+      } catch {
+        return;
+      }
+      if (cancelled || !this.view || !this.spellcheckEnabled) return;
+
+      this.spellcheckReady = true;
+      this.refreshDiagnostics();
+    };
+
+    if (typeof window.requestIdleCallback === "function") {
+      const callbackId = window.requestIdleCallback(() => { void activate(); }, { timeout: 500 });
+      this.cancelSpellcheckWarmup = () => {
+        cancelled = true;
+        window.cancelIdleCallback(callbackId);
+      };
+      return;
+    }
+
+    const timerId = globalThis.setTimeout(() => { void activate(); }, 300);
+    this.cancelSpellcheckWarmup = () => {
+      cancelled = true;
+      globalThis.clearTimeout(timerId);
+    };
+  }
+
+  private clearSpellcheckWarmup() {
+    this.cancelSpellcheckWarmup?.();
+    this.cancelSpellcheckWarmup = null;
+  }
+
 }

--- a/web/src/core/store.ts
+++ b/web/src/core/store.ts
@@ -66,8 +66,49 @@ export class Store {
     this.state.theme = theme;
   }
 
+  activeDraft() {
+    return this.state.drafts.find((draft) => draft.id === this.state.activeDraftId) || null;
+  }
+
+  async addSpellAllowlistWord(word: string) {
+    const draft = this.activeDraft();
+    if (!draft) return false;
+
+    const trimmed = word.trim();
+    if (!trimmed) return false;
+
+    const key = trimmed.toLocaleLowerCase();
+    if (draft.spellAllowlist.some((existing) => existing.toLocaleLowerCase() === key)) {
+      return false;
+    }
+
+    draft.spellAllowlist.push(trimmed);
+    draft.spellAllowlist.sort((a, b) => a.localeCompare(b));
+    draft.updatedAt = new Date().toISOString();
+    await this.env.saveDrafts(this.state.drafts);
+    return true;
+  }
+
+  async removeSpellAllowlistWord(word: string) {
+    const draft = this.activeDraft();
+    if (!draft) return false;
+
+    const key = word.trim().toLocaleLowerCase();
+    const nextWords = draft.spellAllowlist.filter(
+      (existing) => existing.toLocaleLowerCase() !== key,
+    );
+    if (nextWords.length === draft.spellAllowlist.length) {
+      return false;
+    }
+
+    draft.spellAllowlist = nextWords;
+    draft.updatedAt = new Date().toISOString();
+    await this.env.saveDrafts(this.state.drafts);
+    return true;
+  }
+
   async saveActiveDraft(content: string) {
-    const draft = this.state.drafts.find(d => d.id === this.state.activeDraftId);
+    const draft = this.activeDraft();
     if (!draft) return;
     draft.content = content;
     draft.title = extractDocumentTitle(content);

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -63,17 +63,29 @@ export interface LSPCodeActionsResult {
   actions: LSPCodeAction[];
 }
 
+export interface SpellcheckRange {
+  start: LSPPosition;
+  end: LSPPosition;
+}
+
+export interface SpellcheckContext {
+  allowWords: string[];
+  ignoredRanges: SpellcheckRange[];
+}
+
 export interface SavedDraft {
   id: string;
   title: string;
   content: string;
   updatedAt: string;
+  spellAllowlist: string[];
 }
 
 export interface EditorEnv {
   // Parsing and Diagnostics
   parse(source: string): Promise<{ errors: ParseError[] }>;
   diagnostics(source: string): Promise<{ diagnostics: WasmDiagnostic[] }>;
+  spellcheckContext(source: string): Promise<SpellcheckContext>;
   upgradeV1(source: string): Promise<{ source: string; changed: boolean }>;
   completion(source: string, line: number, col: number): Promise<LSPCompletionList>;
   codeActions(source: string, line: number, col: number, codes?: string[]): Promise<LSPCodeActionsResult>;

--- a/web/src/diagnostics.ts
+++ b/web/src/diagnostics.ts
@@ -1,8 +1,16 @@
+import { StateEffect } from "@codemirror/state";
 import { linter, type Action, type Diagnostic } from "@codemirror/lint";
 import type { EditorView } from "@codemirror/view";
 import type { Text } from "@codemirror/state";
-import type { EditorEnv, LSPTextEdit, WasmDiagnostic } from "./core/types";
+import type { EditorEnv, LSPTextEdit, SpellcheckContext, WasmDiagnostic } from "./core/types";
 import { offsetFromLSP } from "./lsp-offsets";
+import { getSpellDiagnostics, type SpellcheckCallbacks } from "./spellcheck";
+
+// Dispatched by refreshDiagnostics() when spellcheck-related external state
+// changes (warmup completes, user toggles spellcheck, dictionary edited).
+// Picked up by the linter's needsRefresh hook so the linter knows to re-run
+// even though the doc didn't change.
+export const spellcheckRefreshEffect = StateEffect.define<null>();
 
 export function applyLSPEdits(view: EditorView, edits: LSPTextEdit[]) {
   if (!edits.length) return;
@@ -76,13 +84,48 @@ export function toDiagnostics(
   return result;
 }
 
-export function createDownstageLinter(env: EditorEnv) {
+export function createDownstageLinter(
+  env: EditorEnv,
+  spellcheckEnabled: () => boolean,
+  callbacks: SpellcheckCallbacks,
+) {
   return linter(
     async (view) => {
       const source = view.state.doc.toString();
-      const { diagnostics: sourceDiagnostics } = await env.diagnostics(source);
-      return toDiagnostics(env, view.state.doc, sourceDiagnostics);
+      const diagnosticsPromise = env.diagnostics(source);
+      const spellContextPromise = spellcheckEnabled()
+        ? env.spellcheckContext(source)
+        : Promise.resolve<SpellcheckContext>({ allowWords: [], ignoredRanges: [] });
+      const [{ diagnostics: sourceDiagnostics }, spellContext] = await Promise.all([
+        diagnosticsPromise,
+        spellContextPromise,
+      ]);
+      const diagnostics = toDiagnostics(env, view.state.doc, sourceDiagnostics);
+
+      if (!spellcheckEnabled()) {
+        return diagnostics;
+      }
+
+      const spellDiagnostics = await getSpellDiagnostics(view.state.doc, spellContext, callbacks);
+      return diagnostics.concat(spellDiagnostics);
     },
-    { delay: 300 },
+    {
+      delay: 300,
+      // Re-run when our refresh effect lands, even if the doc didn't change.
+      // forceLinting() alone is not enough: it only runs the lint when the
+      // plugin already has work pending. needsRefresh tells the plugin
+      // there IS work to do.
+      needsRefresh: (update) => update.transactions.some((tr) =>
+        tr.effects.some((effect) => effect.is(spellcheckRefreshEffect)),
+      ),
+    },
   );
+}
+
+// Trigger a re-lint when external state (spellcheck toggle, dictionary edit,
+// warmup completion) changed without a doc change. The linter's own `delay`
+// (300ms) coalesces rapid back-to-back refreshes so we don't need a
+// separate debounce here.
+export function refreshDiagnostics(view: EditorView) {
+  view.dispatch({ effects: spellcheckRefreshEffect.of(null) });
 }

--- a/web/src/main.css
+++ b/web/src/main.css
@@ -101,6 +101,12 @@
 .cm-ds-variable { color: #e36209; }
 .dark .cm-ds-variable { color: var(--color-brass-300); }
 
+.cm-lintRange.cm-spellcheckRange {
+  background-image: none !important;
+  text-decoration: underline wavy #d11;
+  text-decoration-skip-ink: none;
+}
+
 /* Custom Scrollbar */
 .custom-scrollbar::-webkit-scrollbar { width: 6px; height: 6px; }
 .custom-scrollbar::-webkit-scrollbar-track { background: transparent; }

--- a/web/src/spellcheck-engine.ts
+++ b/web/src/spellcheck-engine.ts
@@ -1,0 +1,45 @@
+type TypoConstructor = new (dictionary: string, affData?: string, wordsData?: string) => TypoInstance;
+
+interface TypoInstance {
+  check(word: string): boolean;
+  suggest(word: string, limit?: number): string[];
+}
+
+export type SpellDictionary = TypoInstance;
+
+const maxSuggestions = 3;
+
+export async function loadSpellDictionary(): Promise<SpellDictionary> {
+  const [typoModule, affModule, dicModule] = await Promise.all([
+    import("typo-js"),
+    import("typo-js/dictionaries/en_US/en_US.aff?raw"),
+    import("typo-js/dictionaries/en_US/en_US.dic?raw"),
+  ]);
+  const Typo = typoModule.default as TypoConstructor;
+  return new Typo("en_US", affModule.default, dicModule.default);
+}
+
+export function checkWords(dict: SpellDictionary, words: string[]): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  for (const w of words) {
+    if (dict.check(w)) {
+      out[w] = true;
+      continue;
+    }
+    // English possessive constructions like "else's", "someone's",
+    // "everyone's" aren't in the Hunspell dictionary as inflected forms,
+    // but the bare word is. Accept the possessive when the bare word
+    // checks out — same shape as the cue-allowlist possessive handling
+    // in spellcheck.ts, just for the dictionary.
+    if (w.endsWith("'s") && dict.check(w.slice(0, -2))) {
+      out[w] = true;
+      continue;
+    }
+    out[w] = false;
+  }
+  return out;
+}
+
+export function suggestForWord(dict: SpellDictionary, word: string): string[] {
+  return dict.suggest(word, maxSuggestions);
+}

--- a/web/src/spellcheck.ts
+++ b/web/src/spellcheck.ts
@@ -1,0 +1,462 @@
+import { type Action, type Diagnostic } from "@codemirror/lint";
+import type { EditorView } from "@codemirror/view";
+import type { Text } from "@codemirror/state";
+import type { SpellcheckContext } from "./core/types";
+import { offsetFromLSP } from "./lsp-offsets";
+// Type-only import so the engine module (and its mnemonist + typo-js
+// dependencies) doesn't land in the main bundle. The inline fallback below
+// pulls them in via a dynamic import, kept separate so the worker bundle is
+// the only place runtime spellcheck code ships in production.
+import type { SpellDictionary } from "./spellcheck-engine";
+
+interface SpellIssue {
+  from: number;
+  to: number;
+  word: string;
+}
+
+export interface SpellcheckCallbacks {
+  getUserAllowlist: () => string[];
+  addWord: (word: string) => Promise<boolean>;
+}
+
+interface SpellBackend {
+  warmup(): Promise<void>;
+  check(words: string[]): Promise<Record<string, boolean>>;
+  suggest(word: string): Promise<string[]>;
+}
+
+const minWordLength = 3;
+const maxDiagnostics = 100;
+const maxSuggestions = 3;
+
+const checkCache = new Map<string, boolean>();
+const suggestionsCache = new Map<string, string[]>();
+
+let backend: SpellBackend | null = null;
+
+// Apostrophe normalization without lowercasing — used for the value we hand
+// to typo.check(), so KEEPCASE proper nouns ("Liz", "Michael") and
+// capitalized contractions ("I've") aren't lowercased into a check failure.
+function normalizeApostrophes(word: string) {
+  return word.trim().replace(/’/g, "'");
+}
+
+// Lowercased form for case-insensitive lookups: allowlist matching and the
+// SymSpell suggest index (which is built from lowercased dictionary stems).
+function normalizeWord(word: string) {
+  return normalizeApostrophes(word).toLocaleLowerCase();
+}
+
+function alphaLength(word: string) {
+  let count = 0;
+  for (let i = 0; i < word.length; i++) {
+    const ch = word.charCodeAt(i);
+    if ((ch >= 65 && ch <= 90) || (ch >= 97 && ch <= 122)) count++;
+  }
+  return count;
+}
+
+function shouldCheckWord(word: string) {
+  // Count letters only — apostrophes shouldn't push tokens like "M's" or
+  // "I'd" past the minimum length and into the checked set.
+  if (alphaLength(word) < minWordLength) return false;
+  if (/\d/.test(word)) return false;
+  return true;
+}
+
+// Browser-spellchecker convention: skip mid-sentence Title Case words. The
+// vast majority of capitalized words appearing inside a clause are proper
+// nouns the user knows are correct; checking them produces noise far more
+// often than catches a real typo. Sentence-initial Title Case still gets
+// checked so genuine misspellings ("Teh document is...") aren't missed.
+function isLikelyProperNoun(word: string, source: string, index: number) {
+  // Title Case = leading uppercase, at least one trailing lowercase letter,
+  // optional apostrophes. Excludes ALL-CAPS (cues, acronyms) and mixed-case
+  // identifiers like "iPhone".
+  if (!/^[A-Z][a-z'’]+$/.test(word)) return false;
+
+  // Walk back through inline whitespace only. A line break, sentence-ender,
+  // or Downstage structural marker (>, :) means the word is sentence-initial.
+  let i = index - 1;
+  while (i >= 0 && (source[i] === " " || source[i] === "\t")) i--;
+  if (i < 0) return false;
+  const prev = source[i];
+  if (prev === "\n" || prev === "." || prev === "!" || prev === "?" || prev === ">" || prev === ":") {
+    return false;
+  }
+  return true;
+}
+
+function rangeOverlaps(from: number, to: number, ignoredRanges: readonly { from: number; to: number }[]) {
+  for (const range of ignoredRanges) {
+    if (range.to <= from) continue;
+    if (range.from >= to) break;
+    return true;
+  }
+  return false;
+}
+
+function collectAllowlist(words: string[]) {
+  return new Set(
+    words
+      .flatMap((word) => word.match(/\b[A-Za-z][A-Za-z'’]*\b/g) || [])
+      .map((word) => normalizeWord(word)),
+  );
+}
+
+// Match a word against the allowlist, also accepting the bare form of a
+// possessive. Stage directions routinely use "ALICE's hand" — the cue
+// allowlist has ALICE but not its possessive. Strip a trailing "'s" and
+// retry so the bare character name covers both forms.
+function isAllowlisted(word: string, allowlist: Set<string>) {
+  const key = normalizeWord(word);
+  if (allowlist.has(key)) return true;
+  if (key.endsWith("'s") && allowlist.has(key.slice(0, -2))) return true;
+  return false;
+}
+
+function collectSpellIssues(doc: Text, ignoredRanges: readonly { from: number; to: number }[]) {
+  const issues: SpellIssue[] = [];
+  const source = doc.toString();
+  const wordPattern = /\b[A-Za-z][A-Za-z'’]*\b/g;
+
+  for (const match of source.matchAll(wordPattern)) {
+    const word = match[0];
+    const index = match.index;
+    if (index === undefined || !shouldCheckWord(word)) continue;
+    if (isLikelyProperNoun(word, source, index)) continue;
+    const from = index;
+    const to = index + word.length;
+    if (rangeOverlaps(from, to, ignoredRanges)) continue;
+    issues.push({ from, to, word });
+  }
+
+  return issues;
+}
+
+function buildAddWordAction(word: string, callbacks: SpellcheckCallbacks): Action {
+  return {
+    name: `Add "${word}" to this script dictionary`,
+    async apply() {
+      await callbacks.addWord(word);
+    },
+  };
+}
+
+// Worker backend: runs typo-js entirely off the main thread. Dictionary
+// construction no longer blocks the editor; the first lint pass awaits the
+// worker's "ready" signal before producing spell diagnostics.
+//
+// Failure handling: a worker that fails before posting "ready" used to leave
+// the ready promise unresolved forever (silently disabling spellcheck for
+// the session). We now wire `error` and `messageerror` listeners in addition
+// to the `init-error` message, and mark the backend "broken" so subsequent
+// requests fail fast instead of queueing into the void.
+function createWorkerBackend(): SpellBackend {
+  const worker = new Worker(new URL("./spellcheck.worker.ts", import.meta.url), { type: "module" });
+
+  let readyResolve!: () => void;
+  let readyReject!: (err: Error) => void;
+  let resolved = false;
+  const ready = new Promise<void>((resolve, reject) => {
+    readyResolve = () => { resolved = true; resolve(); };
+    readyReject = (err) => { resolved = true; reject(err); };
+  });
+
+  type Pending = { resolve: (value: unknown) => void; reject: (err: Error) => void };
+  const pending = new Map<number, Pending>();
+  let broken = false;
+  let nextId = 0;
+
+  const fail = (err: Error) => {
+    broken = true;
+    if (!resolved) readyReject(err);
+    for (const p of pending.values()) p.reject(err);
+    pending.clear();
+  };
+
+  worker.addEventListener("message", (event: MessageEvent) => {
+    const msg = event.data;
+    if (msg.type === "ready") {
+      readyResolve();
+    } else if (msg.type === "init-error") {
+      fail(new Error(msg.message));
+    } else if (msg.type === "check") {
+      pending.get(msg.id)?.resolve(msg.results);
+      pending.delete(msg.id);
+    } else if (msg.type === "suggest") {
+      pending.get(msg.id)?.resolve(msg.suggestions);
+      pending.delete(msg.id);
+    }
+  });
+
+  worker.addEventListener("error", (event) => {
+    event.preventDefault?.();
+    fail(new Error(`spellcheck worker error: ${event.message || "unknown"}`));
+  });
+
+  worker.addEventListener("messageerror", () => {
+    fail(new Error("spellcheck worker message deserialization failed"));
+  });
+
+  const request = <T>(payload: unknown): Promise<T> => {
+    if (broken) return Promise.reject(new Error("spellcheck worker is unavailable"));
+    const id = ++nextId;
+    return new Promise<T>((resolve, reject) => {
+      pending.set(id, { resolve: resolve as (v: unknown) => void, reject });
+      worker.postMessage({ ...(payload as object), id });
+    });
+  };
+
+  return {
+    warmup: () => ready,
+    check: async (words) => {
+      await ready;
+      return request<Record<string, boolean>>({ type: "check", words });
+    },
+    suggest: async (word) => {
+      await ready;
+      return request<string[]>({ type: "suggest", word });
+    },
+  };
+}
+
+// Inline backend: used when Worker is unavailable (node tests, old browsers).
+// The engine module is dynamically imported so its mnemonist + typo-js
+// dependencies are emitted as a separate chunk that only loads if this
+// path runs — modern browsers go through the worker and never fetch it.
+function createInlineBackend(): SpellBackend {
+  type Engine = typeof import("./spellcheck-engine");
+  let enginePromise: Promise<Engine> | null = null;
+  let dictPromise: Promise<SpellDictionary> | null = null;
+
+  const loadEngine = () => {
+    if (!enginePromise) enginePromise = import("./spellcheck-engine");
+    return enginePromise;
+  };
+
+  const load = () => {
+    if (!dictPromise) {
+      dictPromise = loadEngine()
+        .then((engine) => engine.loadSpellDictionary())
+        .catch((err) => {
+          dictPromise = null;
+          throw err;
+        });
+    }
+    return dictPromise;
+  };
+
+  return {
+    warmup: async () => { await load(); },
+    check: async (words) => {
+      const [engine, dict] = await Promise.all([loadEngine(), load()]);
+      return engine.checkWords(dict, words);
+    },
+    suggest: async (word) => {
+      const [engine, dict] = await Promise.all([loadEngine(), load()]);
+      return engine.suggestForWord(dict, word);
+    },
+  };
+}
+
+function getBackend(): SpellBackend {
+  if (backend) return backend;
+  if (typeof Worker !== "undefined") {
+    try {
+      backend = createWorkerBackend();
+      return backend;
+    } catch (err) {
+      console.warn("spellcheck worker unavailable, falling back to inline:", err);
+    }
+  }
+  backend = createInlineBackend();
+  return backend;
+}
+
+export async function warmSpellDictionary(): Promise<void> {
+  await getBackend().warmup();
+}
+
+function ignoredRangesFromContext(doc: Text, context: SpellcheckContext) {
+  return (context.ignoredRanges ?? [])
+    .map((range) => ({
+      from: offsetFromLSP(doc, range.start.line, range.start.character),
+      to: offsetFromLSP(doc, range.end.line, range.end.character),
+    }))
+    .sort((a, b) => a.from - b.from || a.to - b.to);
+}
+
+function buildReplaceButton(view: EditorView, issue: SpellIssue, suggestion: string) {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  // Reuse the built-in action styling so lint.css + our Editor.vue theme apply.
+  btn.className = "cm-diagnosticAction";
+  btn.textContent = `Replace with "${suggestion}"`;
+  btn.addEventListener("click", () => {
+    view.dispatch({
+      changes: { from: issue.from, to: issue.to, insert: suggestion },
+      selection: { anchor: issue.from + suggestion.length },
+      scrollIntoView: true,
+    });
+  });
+  return btn;
+}
+
+function renderSuggestionButtons(
+  list: HTMLElement,
+  view: EditorView,
+  issue: SpellIssue,
+  suggestions: string[],
+) {
+  const deduped = Array.from(new Set(suggestions)).slice(0, maxSuggestions);
+  list.replaceChildren();
+  if (deduped.length === 0) {
+    const empty = document.createElement("span");
+    empty.className = "cm-spellEmpty";
+    empty.textContent = "No suggestions.";
+    list.appendChild(empty);
+    return;
+  }
+  for (const suggestion of deduped) {
+    list.appendChild(buildReplaceButton(view, issue, suggestion));
+  }
+}
+
+// Project the case shape of `original` onto `suggestion` so a sentence-start
+// typo like "Teh" gets "The" (not "the") and an ALL-CAPS shout like "TEH"
+// gets "THE". typo-js suggestions come back lowercased; without this the
+// replacement buttons silently drop capitalization the user typed.
+export function matchCase(original: string, suggestion: string): string {
+  if (suggestion.length === 0) return suggestion;
+  const trimmed = original.trim();
+  if (trimmed.length >= 2 && trimmed === trimmed.toLocaleUpperCase() && trimmed !== trimmed.toLocaleLowerCase()) {
+    return suggestion.toLocaleUpperCase();
+  }
+  const first = trimmed[0];
+  if (first && first === first.toLocaleUpperCase() && first !== first.toLocaleLowerCase()) {
+    return suggestion[0].toLocaleUpperCase() + suggestion.slice(1);
+  }
+  return suggestion;
+}
+
+function casedSuggestions(original: string, suggestions: string[]): string[] {
+  return suggestions.map((s) => matchCase(original, s));
+}
+
+async function populateSuggestions(list: HTMLElement, view: EditorView, issue: SpellIssue) {
+  const key = normalizeWord(issue.word);
+  let suggestions = suggestionsCache.get(key);
+  if (!suggestions) {
+    try {
+      suggestions = await getBackend().suggest(key);
+    } catch {
+      suggestions = [];
+    }
+    suggestionsCache.set(key, suggestions);
+  }
+  renderSuggestionButtons(list, view, issue, casedSuggestions(issue.word, suggestions));
+}
+
+function renderSpellMessage(view: EditorView, issue: SpellIssue, message: string): Node {
+  const root = document.createElement("div");
+  root.className = "cm-spellMessage";
+
+  const text = document.createElement("div");
+  text.className = "cm-spellText";
+  text.textContent = message;
+  root.appendChild(text);
+
+  const list = document.createElement("div");
+  list.className = "cm-spellSuggestions";
+  root.appendChild(list);
+
+  const key = normalizeWord(issue.word);
+  const cached = suggestionsCache.get(key);
+  if (cached) {
+    renderSuggestionButtons(list, view, issue, casedSuggestions(issue.word, cached));
+    return root;
+  }
+
+  const loading = document.createElement("span");
+  loading.className = "cm-spellLoading";
+  loading.textContent = "Finding suggestions…";
+  list.appendChild(loading);
+
+  void populateSuggestions(list, view, issue);
+  return root;
+}
+
+export async function getSpellDiagnostics(
+  doc: Text,
+  context: SpellcheckContext,
+  callbacks: SpellcheckCallbacks,
+): Promise<Diagnostic[]> {
+  const userAllowlist = callbacks.getUserAllowlist() || [];
+  const allowlist = collectAllowlist([
+    ...(context.allowWords ?? []),
+    ...userAllowlist,
+  ]);
+  const ignoredRanges = ignoredRangesFromContext(doc, context);
+  const issues = collectSpellIssues(doc, ignoredRanges);
+
+  // Drop allowlisted words before any RPC so we don't pay round-trip cost
+  // for cues, user-added words, or structural tokens.
+  const candidates = issues.filter((issue) => !isAllowlisted(issue.word, allowlist));
+
+  // Hand original-case words to typo.check() so KEEPCASE entries (proper
+  // nouns, capitalized contractions) match. Cache by the same checked
+  // string so "Liz" and "liz" stay independent — they have different
+  // correctness verdicts.
+  const checkKeys = new Map<SpellIssue, string>();
+  const needLookup = new Set<string>();
+  for (const issue of candidates) {
+    const key = normalizeApostrophes(issue.word);
+    checkKeys.set(issue, key);
+    if (!checkCache.has(key)) needLookup.add(key);
+  }
+
+  if (needLookup.size > 0) {
+    try {
+      const batch = Array.from(needLookup);
+      const results = await getBackend().check(batch);
+      for (const key of batch) {
+        checkCache.set(key, results[key] ?? false);
+      }
+    } catch {
+      // Backend unavailable for this pass. We deliberately do NOT poison
+      // the cache: writing `true` for every un-checked word would treat
+      // real misspellings as valid for the rest of the session even after
+      // the backend recovers. Instead, leave them out of the cache so the
+      // next lint pass retries, and treat them as "unknown verdict" below
+      // (skip rather than flag — better to miss a typo than to scream
+      // false positives at the user).
+    }
+  }
+
+  const diagnostics: Diagnostic[] = [];
+  for (const issue of candidates) {
+    const key = checkKeys.get(issue)!;
+    // Only flag words we have a definitive `false` for. Unknown verdicts
+    // (cache miss after a failed backend call) are silently passed.
+    if (checkCache.get(key) !== false) continue;
+
+    const message = `"${issue.word}" is not in the English dictionary`;
+    diagnostics.push({
+      from: issue.from,
+      to: issue.to,
+      severity: "warning",
+      // CodeMirror concatenates markClass onto the built-in lint class string.
+      markClass: " cm-spellcheckRange",
+      message,
+      renderMessage: (view) => renderSpellMessage(view, issue, message),
+      source: "spellcheck",
+      actions: [buildAddWordAction(issue.word, callbacks)],
+    });
+
+    if (diagnostics.length >= maxDiagnostics) break;
+  }
+
+  return diagnostics;
+}

--- a/web/src/spellcheck.worker.ts
+++ b/web/src/spellcheck.worker.ts
@@ -1,0 +1,50 @@
+/// <reference lib="webworker" />
+
+import {
+  checkWords,
+  loadSpellDictionary,
+  suggestForWord,
+  type SpellDictionary,
+} from "./spellcheck-engine";
+
+type Request =
+  | { type: "check"; id: number; words: string[] }
+  | { type: "suggest"; id: number; word: string };
+
+type Response =
+  | { type: "ready" }
+  | { type: "init-error"; message: string }
+  | { type: "check"; id: number; results: Record<string, boolean> }
+  | { type: "suggest"; id: number; suggestions: string[] };
+
+const scope = self as unknown as DedicatedWorkerGlobalScope;
+
+let dict: SpellDictionary | null = null;
+
+loadSpellDictionary()
+  .then((loaded) => {
+    dict = loaded;
+    scope.postMessage({ type: "ready" } satisfies Response);
+  })
+  .catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    scope.postMessage({ type: "init-error", message } satisfies Response);
+  });
+
+scope.addEventListener("message", (event: MessageEvent<Request>) => {
+  const msg = event.data;
+  if (!dict) return;
+  if (msg.type === "check") {
+    scope.postMessage({
+      type: "check",
+      id: msg.id,
+      results: checkWords(dict, msg.words),
+    } satisfies Response);
+  } else if (msg.type === "suggest") {
+    scope.postMessage({
+      type: "suggest",
+      id: msg.id,
+      suggestions: suggestForWord(dict, msg.word),
+    } satisfies Response);
+  }
+});

--- a/web/src/types/typo-js.d.ts
+++ b/web/src/types/typo-js.d.ts
@@ -1,0 +1,7 @@
+declare module "typo-js" {
+  export default class Typo {
+    constructor(dictionary: string, affData?: string, wordsData?: string);
+    check(word: string): boolean;
+    suggest(word: string, limit?: number): string[];
+  }
+}

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -1,5 +1,13 @@
 /// <reference types="vite/client" />
 
+import type {
+  ParseError,
+  WasmDiagnostic,
+  LSPCompletionList,
+  LSPCodeActionsResult,
+  SpellcheckContext,
+} from "./core/types";
+
 declare class Go {
   importObject: WebAssembly.Imports;
   run(instance: WebAssembly.Instance): Promise<void>;
@@ -11,6 +19,7 @@ declare global {
     downstage: {
       parse(source: string): { errors: ParseError[] };
       diagnostics(source: string): { diagnostics: WasmDiagnostic[] };
+      spellcheckContext(source: string): SpellcheckContext;
       upgradeV1(source: string): { source: string; changed: boolean };
       completion(source: string, line: number, col: number): LSPCompletionList;
       codeActions(source: string, line: number, col: number, codes?: string[]): LSPCodeActionsResult;
@@ -20,72 +29,6 @@ declare global {
       tokenTypeNames: string[];
     };
   }
-}
-
-export interface ParseError {
-  message: string;
-  line: number;
-  col: number;
-  endLine: number;
-  endCol: number;
-}
-
-export interface WasmDiagnostic {
-  message: string;
-  severity: "error" | "warning" | "info" | "hint";
-  line: number;
-  col: number;
-  endLine: number;
-  endCol: number;
-  code?: string;
-  quickFixes?: string[];
-}
-
-export interface LSPPosition {
-  line: number;
-  character: number;
-}
-
-export interface LSPRange {
-  start: LSPPosition;
-  end: LSPPosition;
-}
-
-export interface LSPTextEdit {
-  range: LSPRange;
-  newText: string;
-}
-
-export interface LSPCompletionItem {
-  label: string;
-  kind?: number;
-  detail?: string;
-  filterText?: string;
-  sortText?: string;
-  insertText?: string;
-  textEdit?: LSPTextEdit;
-}
-
-export interface LSPCompletionList {
-  isIncomplete: boolean;
-  items: LSPCompletionItem[];
-}
-
-export interface LSPWorkspaceEdit {
-  changes?: Record<string, LSPTextEdit[]>;
-}
-
-export interface LSPCodeAction {
-  title: string;
-  kind?: string;
-  isPreferred?: boolean;
-  diagnostics?: unknown[];
-  edit?: LSPWorkspaceEdit;
-}
-
-export interface LSPCodeActionsResult {
-  uri: string;
-  actions: LSPCodeAction[];
 }
 
 import wasmExecUrl from "../build/wasm_exec.js?url";

--- a/web/src/web-app.ts
+++ b/web/src/web-app.ts
@@ -9,6 +9,7 @@ import type {
   WasmDiagnostic,
   LSPCompletionList,
   LSPCodeActionsResult,
+  SpellcheckContext,
 } from "./core/types";
 
 declare const __APP_VERSION__: string;
@@ -23,8 +24,16 @@ function isValidDraft(obj: any): obj is SavedDraft {
     typeof obj.id === "string" &&
     typeof obj.title === "string" &&
     typeof obj.content === "string" &&
-    typeof obj.updatedAt === "string"
+    typeof obj.updatedAt === "string" &&
+    (!("spellAllowlist" in obj) || Array.isArray(obj.spellAllowlist))
   );
+}
+
+function normalizeDraft(draft: SavedDraft): SavedDraft {
+  return {
+    ...draft,
+    spellAllowlist: Array.isArray(draft.spellAllowlist) ? draft.spellAllowlist : [],
+  };
 }
 
 class WebEnv implements EditorEnv {
@@ -38,6 +47,10 @@ class WebEnv implements EditorEnv {
 
   async diagnostics(source: string): Promise<{ diagnostics: WasmDiagnostic[] }> {
     return window.downstage.diagnostics(source);
+  }
+
+  async spellcheckContext(source: string): Promise<SpellcheckContext> {
+    return window.downstage.spellcheckContext(source);
   }
 
   async upgradeV1(source: string): Promise<{ source: string; changed: boolean }> {
@@ -79,7 +92,7 @@ class WebEnv implements EditorEnv {
       if (!raw) return [];
       const parsed = JSON.parse(raw);
       if (!Array.isArray(parsed)) return [];
-      return parsed.filter(isValidDraft);
+      return parsed.filter(isValidDraft).map(normalizeDraft);
     } catch (e) {
       console.warn("failed to load drafts from storage:", e);
       return [];


### PR DESCRIPTION
## Summary
- add English spellcheck to the web editor with CodeMirror diagnostics
- add a per-script dictionary backed by draft state plus Go/WASM spellcheck context
- move dictionary work off the main thread with a worker-backed typo-js integration and lazy suggestion loading
- document the web spellcheck behavior and new `spellcheckContext()` WASM API

## Testing
- env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go test ./internal/lsp/...
- npm test
- npm run build