### PR TITLE
feat(lsp): exempt forced cues from Dramatis Personae check

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -531,6 +531,8 @@ My lord, I came to see your father's funeral.
 
 Without the `@`, `horatio` would be treated as plain text. The `@` is stripped from the name in the AST.
 
+A forced cue also opts the character out of Dramatis Personae membership checks: tooling SHOULD NOT flag a `@name` cue as unknown when the enclosing play has a `## Dramatis Personae` section. This makes `@` a concise way to mark brief character appearances without adding them to the roster. The suppression is scoped to the individual cue — subsequent non-forced uses of the same name are still checked.
+
 ### Forced Heading (`.`)
 
 Prefix text with `.` to force it to be treated as a heading, without needing `#` markup:

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -281,6 +281,12 @@ type Dialogue struct {
 	Range                token.Range
 	nameRange            token.Range
 	parentheticalRange   token.Range
+	// Forced is true when the cue was written with the `@` prefix. The prefix
+	// is stripped from Character, but callers that need to distinguish a
+	// forced cue from a naturally-recognized one (e.g. to suppress the
+	// "unknown character" LSP diagnostic) can read this flag. It is excluded
+	// from JSON so the public `downstage parse` output stays stable.
+	Forced bool `json:"-"`
 }
 
 func (d *Dialogue) NodeRange() token.Range { return d.Range }

--- a/internal/lsp/code_actions.go
+++ b/internal/lsp/code_actions.go
@@ -97,6 +97,20 @@ func computeCodeActions(
 			if character == "" {
 				continue
 			}
+
+			if forceEdit, ok := forceCharacterCueEdit(content, diagnostic.Range); ok {
+				actions = append(actions, protocol.CodeAction{
+					Title:       "Exclude cue from check",
+					Kind:        protocol.QuickFix,
+					Diagnostics: []protocol.Diagnostic{diagnostic},
+					Edit: &protocol.WorkspaceEdit{
+						Changes: map[protocol.DocumentURI][]protocol.TextEdit{
+							uri: {forceEdit},
+						},
+					},
+				})
+			}
+
 			textEdit, hasEdit := dramatisPersonaeInsertEdit(doc, index, content, int(diagnostic.Range.Start.Line))
 			if !hasEdit {
 				continue
@@ -365,6 +379,39 @@ func replaceUnicodeDashEdit(content string, r protocol.Range) *protocol.TextEdit
 		},
 		NewText: replaced,
 	}
+}
+
+// forceCharacterCueEdit builds a TextEdit that prepends `@` to the cue on
+// the diagnostic line, promoting it to a forced character that opts out of
+// the "unknown character" check.
+//
+// The `@` is inserted at the first non-whitespace column so that indented
+// cues (e.g. `  HAMLET`) become `  @HAMLET`, not `@  HAMLET` — the lexer
+// strips leading whitespace when computing the character name, but only
+// after `@` has been consumed, so misplacement would corrupt the parsed
+// character name.
+func forceCharacterCueEdit(content string, r protocol.Range) (protocol.TextEdit, bool) {
+	line, ok := lineAt(content, int(r.Start.Line))
+	if !ok {
+		return protocol.TextEdit{}, false
+	}
+	trimmed := strings.TrimLeft(line, " \t")
+	if trimmed == "" {
+		return protocol.TextEdit{}, false
+	}
+	// Already forced? Nothing to do. The diagnostic shouldn't fire in that
+	// case, but guard so a stale diagnostic can't produce `@@NAME`.
+	if strings.HasPrefix(trimmed, "@") {
+		return protocol.TextEdit{}, false
+	}
+	// Leading whitespace is always ASCII space/tab, so byte length equals
+	// both the column count and the UTF-16 code-unit count.
+	indent := uint32(len(line) - len(trimmed))
+	insertAt := protocol.Position{Line: r.Start.Line, Character: indent}
+	return protocol.TextEdit{
+		Range:   protocol.Range{Start: insertAt, End: insertAt},
+		NewText: "@",
+	}, true
 }
 
 // inlineStandaloneAliasEdit rewrites a `[NAME/ALIAS]` line as the

--- a/internal/lsp/code_actions_test.go
+++ b/internal/lsp/code_actions_test.go
@@ -8,7 +8,7 @@ import (
 	"go.lsp.dev/protocol"
 )
 
-func TestComputeCodeActions_AddUnknownCharacterToDramatisPersonae(t *testing.T) {
+func TestComputeCodeActions_UnknownCharacterOffersForceAndAddToDP(t *testing.T) {
 	content := `# Play
 
 ## Dramatis Personae
@@ -26,30 +26,49 @@ Boo.`
 
 	diagnostics := buildDiagnostics(doc, errs)
 	actions := computeCodeActions(doc, content, protocol.DocumentURI("file:///test.ds"), diagnostics, diagnostics)
-	if len(actions) != 1 {
-		t.Fatalf("expected 1 code action, got %d", len(actions))
+	if len(actions) != 2 {
+		t.Fatalf("expected 2 code actions (force cue + add to DP), got %d", len(actions))
 	}
 
-	action := actions[0]
-	if action.Title != "Add GHOST to Dramatis Personae" {
-		t.Fatalf("unexpected title: %q", action.Title)
+	var forceAction, addAction *protocol.CodeAction
+	for i := range actions {
+		switch {
+		case actions[i].Title == "Exclude cue from check":
+			forceAction = &actions[i]
+		case actions[i].Title == "Add GHOST to Dramatis Personae":
+			addAction = &actions[i]
+		}
 	}
-	if action.Kind != protocol.QuickFix {
-		t.Fatalf("expected quick fix kind, got %q", action.Kind)
+	if forceAction == nil {
+		t.Fatal("expected a Force-cue code action")
 	}
-	if action.Edit == nil {
-		t.Fatal("expected workspace edit")
+	if addAction == nil {
+		t.Fatal("expected an Add-to-DP code action")
 	}
 
-	edits := action.Edit.Changes[protocol.DocumentURI("file:///test.ds")]
-	if len(edits) != 1 {
-		t.Fatalf("expected 1 text edit, got %d", len(edits))
+	forceEdits := forceAction.Edit.Changes[protocol.DocumentURI("file:///test.ds")]
+	if len(forceEdits) != 1 {
+		t.Fatalf("expected 1 force text edit, got %d", len(forceEdits))
 	}
-	if edits[0].NewText != "GHOST\n" {
-		t.Fatalf("expected insertion for character entry, got %q", edits[0].NewText)
+	if forceEdits[0].NewText != "@" {
+		t.Fatalf("expected Force edit to insert `@`, got %q", forceEdits[0].NewText)
 	}
-	if edits[0].Range.Start.Line != 4 {
-		t.Fatalf("expected insert on line 2, got %d", edits[0].Range.Start.Line)
+	if forceEdits[0].Range.Start.Line != 7 || forceEdits[0].Range.End.Line != 7 {
+		t.Fatalf("expected force edit on cue line 7, got %+v", forceEdits[0].Range)
+	}
+	if forceEdits[0].Range.Start.Character != forceEdits[0].Range.End.Character {
+		t.Fatalf("expected zero-length insertion, got %+v", forceEdits[0].Range)
+	}
+
+	addEdits := addAction.Edit.Changes[protocol.DocumentURI("file:///test.ds")]
+	if len(addEdits) != 1 {
+		t.Fatalf("expected 1 DP text edit, got %d", len(addEdits))
+	}
+	if addEdits[0].NewText != "GHOST\n" {
+		t.Fatalf("expected insertion for character entry, got %q", addEdits[0].NewText)
+	}
+	if addEdits[0].Range.Start.Line != 4 {
+		t.Fatalf("expected insert on line 4, got %d", addEdits[0].Range.Start.Line)
 	}
 }
 
@@ -181,17 +200,84 @@ Boo.`
 	}
 
 	actions := computeCodeActions(doc, content, protocol.DocumentURI("file:///test.ds"), diagnostics, diagnostics)
-	if len(actions) != 1 {
-		t.Fatalf("expected 1 code action, got %d", len(actions))
+	if len(actions) != 2 {
+		t.Fatalf("expected 2 code actions (force + add to DP), got %d", len(actions))
 	}
 
-	edits := actions[0].Edit.Changes[protocol.DocumentURI("file:///test.ds")]
-	if edits[0].NewText != "\nGHOST\n" {
-		t.Fatalf("expected spaced insertion for empty dramatis personae, got %q", edits[0].NewText)
+	var addEdit *protocol.TextEdit
+	for i := range actions {
+		if actions[i].Title == "Add GHOST to Dramatis Personae" {
+			edits := actions[i].Edit.Changes[protocol.DocumentURI("file:///test.ds")]
+			if len(edits) == 1 {
+				addEdit = &edits[0]
+			}
+		}
+	}
+	if addEdit == nil {
+		t.Fatal("expected an Add-to-DP action with a single edit")
+	}
+	if addEdit.NewText != "\nGHOST\n" {
+		t.Fatalf("expected spaced insertion for empty dramatis personae, got %q", addEdit.NewText)
 	}
 }
 
-func TestComputeCodeActions_NoDramatisPersonaeReturnsNothing(t *testing.T) {
+func TestForceCharacterCueEdit_SkipsLeadingWhitespace(t *testing.T) {
+	// The lexer anchors character-token ranges at column 0 of the raw line
+	// regardless of leading whitespace, so the quick fix must target the
+	// first non-whitespace column. Otherwise an indented cue like
+	// "\tHAMLET" would become "@\tHAMLET" and the parser would record the
+	// character name as "\tHAMLET" instead of "HAMLET".
+	cases := []struct {
+		name         string
+		line         string
+		wantInsertAt uint32
+	}{
+		{name: "no indent", line: "GHOST", wantInsertAt: 0},
+		{name: "single space", line: " GHOST", wantInsertAt: 1},
+		{name: "tab indent", line: "\tGHOST", wantInsertAt: 1},
+		{name: "mixed tabs and spaces", line: " \t GHOST", wantInsertAt: 3},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := tc.line + "\n"
+			// The diagnostic's range has no effect on the column choice —
+			// the helper derives it from the line contents — but pass in
+			// column 0 to mirror what the lexer actually produces.
+			r := protocol.Range{
+				Start: protocol.Position{Line: 0, Character: 0},
+				End:   protocol.Position{Line: 0, Character: uint32(len(tc.line))},
+			}
+			edit, ok := forceCharacterCueEdit(content, r)
+			if !ok {
+				t.Fatal("expected an edit")
+			}
+			if edit.NewText != "@" {
+				t.Fatalf("expected NewText=@, got %q", edit.NewText)
+			}
+			if edit.Range.Start.Character != tc.wantInsertAt || edit.Range.End.Character != tc.wantInsertAt {
+				t.Fatalf("expected insertion at column %d, got %+v", tc.wantInsertAt, edit.Range)
+			}
+		})
+	}
+}
+
+func TestForceCharacterCueEdit_AlreadyForced(t *testing.T) {
+	// Defensive: a stale diagnostic on an already-forced cue should not
+	// produce a double-`@`.
+	_, ok := forceCharacterCueEdit("@ghost\n", protocol.Range{
+		Start: protocol.Position{Line: 0, Character: 0},
+		End:   protocol.Position{Line: 0, Character: 6},
+	})
+	if ok {
+		t.Fatal("expected no edit for already-forced cue")
+	}
+}
+
+func TestComputeCodeActions_NoDramatisPersonaeOffersOnlyForce(t *testing.T) {
+	// Without a Dramatis Personae the "unknown character" diagnostic does
+	// not fire in practice. If a stale diagnostic is still present, the
+	// force-cue fix is still valid because there is no DP section to edit.
 	content := `# Play
 
 GHOST
@@ -205,6 +291,10 @@ Boo.`
 	diagnostics := []protocol.Diagnostic{
 		{
 			Code: diagnosticCodeUnknownCharacter,
+			Range: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 0},
+				End:   protocol.Position{Line: 2, Character: 5},
+			},
 			Data: map[string]interface{}{
 				"character": "GHOST",
 			},
@@ -212,8 +302,11 @@ Boo.`
 	}
 
 	actions := computeCodeActions(doc, content, protocol.DocumentURI("file:///test.ds"), diagnostics, diagnostics)
-	if len(actions) != 0 {
-		t.Fatalf("expected 0 code actions, got %d", len(actions))
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 code action (force cue only), got %d", len(actions))
+	}
+	if actions[0].Title != "Exclude cue from check" {
+		t.Fatalf("unexpected title: %q", actions[0].Title)
 	}
 }
 

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -167,6 +167,13 @@ func checkUnknownCharacters(index *documentIndex) []protocol.Diagnostic {
 			continue
 		}
 
+		// Forced cues (`@name`) opt out of DP membership checks. The `@`
+		// marks the cue as intentional even when the character is not
+		// listed in Dramatis Personae.
+		if ref.dialogue.Forced {
+			continue
+		}
+
 		name := strings.ToUpper(ref.dialogue.Character)
 		if name == "" {
 			continue

--- a/internal/lsp/diagnostics_test.go
+++ b/internal/lsp/diagnostics_test.go
@@ -181,6 +181,40 @@ func TestBuildDiagnostics_UnknownCharacter(t *testing.T) {
 	}
 }
 
+func TestBuildDiagnostics_ForcedCueSuppressesUnknownCharacter(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+HAMLET - Prince
+
+## ACT I
+
+### SCENE 1
+
+HAMLET
+Hello.
+
+@GUARD
+Who goes there?
+
+GHOST
+Whoo.`
+
+	doc, errs := parser.Parse([]byte(content))
+	require.Empty(t, errs)
+
+	diags := buildDiagnostics(doc, errs)
+	var unknown []protocol.Diagnostic
+	for _, diag := range diags {
+		if diag.Code == diagnosticCodeUnknownCharacter {
+			unknown = append(unknown, diag)
+		}
+	}
+
+	require.Len(t, unknown, 1, "only the non-forced GHOST cue should warn; @GUARD is suppressed")
+	assert.Equal(t, "unknown character: GHOST (add to Dramatis Personae)", unknown[0].Message)
+}
+
 func TestBuildDiagnostics_NoDramatisPersonaeSuppressesUnknownCharacter(t *testing.T) {
 	doc := &ast.Document{
 		Body: []ast.Node{

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -925,6 +925,7 @@ func (p *parser) parseDialogue() *ast.Dialogue {
 		(nameTok.Type == token.DualDialogueChar && strings.HasPrefix(nameTok.Literal, "@")) {
 		dlg.Character = strings.TrimPrefix(nameTok.Literal, "@")
 		dlg.SetNameRange(shiftRangeStart(nameTok.Range, 1, 1))
+		dlg.Forced = true
 	}
 
 	// Check for parenthetical right after character name: (text)

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -337,6 +337,22 @@ Once upon a time.`
 	findDialogue(doc.Body, &dlg)
 	require.NotNil(t, dlg)
 	assert.Equal(t, "narrator", dlg.Character)
+	assert.True(t, dlg.Forced, "forced cue should record the `@` prefix on the Dialogue node")
+}
+
+func TestNaturalCharacterNotForced(t *testing.T) {
+	input := `# Play
+
+NARRATOR
+Once upon a time.`
+
+	doc, errs := Parse([]byte(input))
+	require.Empty(t, errs)
+
+	var dlg *ast.Dialogue
+	findDialogue(doc.Body, &dlg)
+	require.NotNil(t, dlg)
+	assert.False(t, dlg.Forced, "naturally-recognized cue should not be marked forced")
 }
 
 func TestDualDialogue(t *testing.T) {
@@ -409,7 +425,9 @@ Hello.`
 	dual, ok := play.Children[0].(*ast.DualDialogue)
 	require.True(t, ok, "expected DualDialogue node")
 	assert.Equal(t, "BRICK", dual.Left.Character)
+	assert.False(t, dual.Left.Forced)
 	assert.Equal(t, "narrator", dual.Right.Character)
+	assert.True(t, dual.Right.Forced, "`@` prefix on a dual-dialogue cue should mark it forced")
 }
 
 func TestDualDialogueInScene(t *testing.T) {

--- a/site/content/syntax/13-forced-elements.md
+++ b/site/content/syntax/13-forced-elements.md
@@ -16,5 +16,11 @@ examplePairs:
     label: downstage
     code: |-
       .The Next Evening
+  - text: A forced cue also opts the character out of the Dramatis Personae check for brief appearances you do not want to list.
+    lang: downstage
+    label: downstage
+    code: |-
+      @GUARD 2
+      Who goes there?
 ---
 When the parser would otherwise classify a line incorrectly, force it.


### PR DESCRIPTION
## Summary

- A forced character cue (`@name`) already signals that the writer knows what they're doing. Extend that signal so the LSP's "unknown character" diagnostic also ignores the cue — giving writers a concise way to mark one-off walk-ons without rostering them in the Dramatis Personae.
- Suppression is scoped to the individual cue; other non-forced uses of the same name still warn, so typo-catching isn't silenced globally.
- Unknown-character diagnostics now expose a second quick fix, **Exclude cue from check**, alongside **Add NAME to Dramatis Personae**. The `@` is inserted after any leading whitespace to avoid corrupting the parsed character name (the lexer anchors cue ranges at column 0 regardless of indent).

## Notable details

- `ast.Dialogue.Forced` is tagged `json:"-"` so the public `downstage parse` output is unchanged for downstream tooling.
- SPEC §14 Forced Character documents the DP-check opt-out and its per-cue scope. The syntax site's forced-elements page gains an example for the walk-on use case.

## Test plan

- [x] `go test ./...`
- [x] Parser: `Dialogue.Forced` set for `@name` and for `@name ^` (dual dialogue); unset for naturally-recognized cues.
- [x] Diagnostics: `@GUARD` suppressed; a subsequent non-forced `GHOST` still warns.
- [x] Code actions: table-driven coverage of the force quick-fix across no indent, single space, tab, and mixed-whitespace cues; already-forced guard prevents `@@NAME`; empty DP and no-DP paths both still behave.
- [x] Golden parser snapshots regenerated and verified no diff (JSON output shape unchanged).