### PR TITLE
feat(web): add script issues drawer

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -28,6 +28,8 @@
         "vue": "^3.5.32"
       },
       "devDependencies": {
+        "@vue/test-utils": "^2.4.6",
+        "happy-dom": "^20.8.9",
         "typescript": "^5.8.0",
         "vite": "^8.0.8",
         "vitest": "^4.1.4"
@@ -717,6 +719,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -853,6 +873,13 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.124.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
@@ -860,6 +887,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1422,6 +1460,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.5.tgz",
@@ -1667,6 +1732,53 @@
       "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
+      "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^2.0.0"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1713,6 +1825,13 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.18",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
@@ -1723,6 +1842,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/browserslist": {
@@ -1803,6 +1932,47 @@
         "@codemirror/view": "^6.0.0"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1815,6 +1985,21 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1831,11 +2016,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.335",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
       "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -1954,6 +2172,23 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -1981,11 +2216,91 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
+      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -1994,6 +2309,38 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/lightningcss": {
@@ -2245,6 +2592,13 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/lucide-vue-next": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-1.0.0.tgz",
@@ -2261,6 +2615,32 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/nanoid": {
@@ -2287,6 +2667,22 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "license": "MIT"
     },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -2297,6 +2693,40 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2357,6 +2787,13 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
@@ -2390,12 +2827,61 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2419,6 +2905,110 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/style-mod": {
       "version": "4.1.3",
@@ -2514,6 +3104,13 @@
       "resolved": "https://registry.npmjs.org/typo-js/-/typo-js-1.3.1.tgz",
       "integrity": "sha512-elJkpCL6Z77Ghw0Lv0lGnhBAjSTOQ5FhiVOCfOuxhaoTT2xtLVbqikYItK5HHchzPbHEUFAcjOH669T2ZzeCbg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -2733,11 +3330,44 @@
         }
       }
     },
+    "node_modules/vue-component-type-helpers": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
+      "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
@@ -2754,6 +3384,126 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,8 @@
     "vue": "^3.5.32"
   },
   "devDependencies": {
+    "@vue/test-utils": "^2.4.6",
+    "happy-dom": "^20.8.9",
     "typescript": "^5.8.0",
     "vite": "^8.0.8",
     "vitest": "^4.1.4"

--- a/web/src/__tests__/IssuesDrawer.test.ts
+++ b/web/src/__tests__/IssuesDrawer.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import IssuesDrawer from "../components/shared/IssuesDrawer.vue";
+import type { EditorDiagnostic } from "../core/types";
+
+function mk(overrides: Partial<EditorDiagnostic>): EditorDiagnostic {
+  return {
+    from: 0,
+    to: 1,
+    line: 1,
+    col: 1,
+    severity: "warning",
+    message: "example",
+    ...overrides,
+  };
+}
+
+describe("IssuesDrawer", () => {
+  it("shows the empty state when no diagnostics are present and open", () => {
+    const wrapper = mount(IssuesDrawer, {
+      props: { diagnostics: [], open: true },
+    });
+    expect(wrapper.text()).toContain("No script issues");
+    expect(wrapper.findAll("li")).toHaveLength(0);
+  });
+
+  it("renders a row per diagnostic with line:col and message", () => {
+    const diagnostics: EditorDiagnostic[] = [
+      mk({ line: 3, col: 5, severity: "error", message: "bad act heading" }),
+      mk({ line: 7, col: 1, severity: "warning", message: "stray text" }),
+    ];
+
+    const wrapper = mount(IssuesDrawer, {
+      props: { diagnostics, open: true },
+    });
+
+    const rows = wrapper.findAll("li");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].text()).toContain("3:5");
+    expect(rows[0].text()).toContain("bad act heading");
+    expect(rows[1].text()).toContain("7:1");
+    expect(rows[1].text()).toContain("stray text");
+  });
+
+  it("emits jump with the diagnostic when a row is clicked", async () => {
+    const diag = mk({ line: 4, col: 2, message: "click me" });
+    const wrapper = mount(IssuesDrawer, {
+      props: { diagnostics: [diag], open: true },
+    });
+
+    await wrapper.find("li").trigger("click");
+
+    const events = wrapper.emitted("jump");
+    expect(events).toBeTruthy();
+    expect(events?.[0]?.[0]).toEqual(diag);
+  });
+
+  it("emits close when the X button is clicked", async () => {
+    const wrapper = mount(IssuesDrawer, {
+      props: { diagnostics: [], open: true },
+    });
+
+    await wrapper.find('button[aria-label="Close script issues"]').trigger("click");
+
+    expect(wrapper.emitted("close")).toBeTruthy();
+  });
+
+  it("shows severity count pills for errors and warnings", () => {
+    const diagnostics: EditorDiagnostic[] = [
+      mk({ severity: "error" }),
+      mk({ severity: "error" }),
+      mk({ severity: "warning" }),
+    ];
+
+    const wrapper = mount(IssuesDrawer, {
+      props: { diagnostics, open: true },
+    });
+
+    const text = wrapper.text();
+    expect(text).toMatch(/2/);
+    expect(text).toMatch(/1/);
+  });
+
+  it("collapses the section to zero height when closed", () => {
+    const wrapper = mount(IssuesDrawer, {
+      props: { diagnostics: [], open: false },
+    });
+    const section = wrapper.find("section");
+    expect(section.exists()).toBe(true);
+    expect(section.attributes("style")).toContain("height: 0px");
+    expect(section.attributes("aria-hidden")).toBe("true");
+  });
+});

--- a/web/src/__tests__/issues.test.ts
+++ b/web/src/__tests__/issues.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { EditorState } from "@codemirror/state";
+import type { Diagnostic } from "@codemirror/lint";
+import { issuesStatus, projectDiagnostics, summarizeIssues } from "../core/issues";
+import type { EditorDiagnostic } from "../core/types";
+
+function docOf(source: string) {
+  return EditorState.create({ doc: source }).doc;
+}
+
+describe("projectDiagnostics", () => {
+  it("converts CodeMirror diagnostics to 1-based line/col", () => {
+    const doc = docOf("first line\nsecond line\nthird line\n");
+    const diagnostics: Diagnostic[] = [
+      { from: 0, to: 5, severity: "error", message: "at start", source: "downstage" },
+      { from: 11, to: 17, severity: "warning", message: "at second line", source: "downstage" },
+    ];
+
+    const projected = projectDiagnostics(doc, diagnostics);
+
+    expect(projected).toHaveLength(2);
+    expect(projected[0]).toMatchObject({ line: 1, col: 1, severity: "error" });
+    expect(projected[1]).toMatchObject({ line: 2, col: 1, severity: "warning" });
+  });
+
+  it("filters out spellcheck diagnostics", () => {
+    const doc = docOf("hello world\n");
+    const diagnostics: Diagnostic[] = [
+      { from: 0, to: 5, severity: "warning", message: "real issue", source: "downstage" },
+      { from: 6, to: 11, severity: "warning", message: "typo", source: "spellcheck" },
+    ];
+
+    const projected = projectDiagnostics(doc, diagnostics);
+
+    expect(projected).toHaveLength(1);
+    expect(projected[0].message).toBe("real issue");
+  });
+
+  it("surfaces the custom code field when present", () => {
+    const doc = docOf("something\n");
+    const diagnostics = [
+      {
+        from: 0,
+        to: 9,
+        severity: "error" as const,
+        message: "outdated",
+        source: "downstage",
+        code: "v1-document",
+      },
+    ];
+
+    const projected = projectDiagnostics(doc, diagnostics as unknown as Diagnostic[]);
+
+    expect(projected[0].code).toBe("v1-document");
+  });
+
+  it("computes col relative to the containing line", () => {
+    const doc = docOf("abcdef\n123456\n");
+    const diagnostics: Diagnostic[] = [
+      { from: 9, to: 11, severity: "info", message: "mid-line", source: "downstage" },
+    ];
+
+    const [projected] = projectDiagnostics(doc, diagnostics);
+
+    expect(projected.line).toBe(2);
+    expect(projected.col).toBe(3);
+  });
+});
+
+describe("summarizeIssues", () => {
+  it("counts severities and total", () => {
+    const items: EditorDiagnostic[] = [
+      mk("error"),
+      mk("error"),
+      mk("warning"),
+      mk("info"),
+      mk("hint"),
+    ];
+
+    expect(summarizeIssues(items)).toEqual({
+      errors: 2,
+      warnings: 1,
+      infos: 1,
+      hints: 1,
+      total: 5,
+    });
+  });
+
+  it("returns zeros for an empty list", () => {
+    expect(summarizeIssues([])).toEqual({
+      errors: 0,
+      warnings: 0,
+      infos: 0,
+      hints: 0,
+      total: 0,
+    });
+  });
+});
+
+describe("issuesStatus", () => {
+  it("reports error when any errors are present", () => {
+    expect(issuesStatus({ errors: 1, warnings: 5, infos: 0, hints: 0, total: 6 })).toBe("error");
+  });
+
+  it("reports warning when only non-error diagnostics exist", () => {
+    expect(issuesStatus({ errors: 0, warnings: 2, infos: 1, hints: 0, total: 3 })).toBe("warning");
+  });
+
+  it("reports clean when nothing is present", () => {
+    expect(issuesStatus({ errors: 0, warnings: 0, infos: 0, hints: 0, total: 0 })).toBe("clean");
+  });
+});
+
+function mk(severity: EditorDiagnostic["severity"]): EditorDiagnostic {
+  return { from: 0, to: 1, line: 1, col: 1, severity, message: severity };
+}

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch, inject, nextTick } from 'vue';
-import { 
-    Bold, Italic, Underline, MessageSquare, ChevronRight, 
+import {
+    Bold, Italic, Underline, MessageSquare, ChevronRight,
     GalleryVerticalEnd, GalleryVertical, FilePlus2, Eye, EyeOff, HelpCircle, X, Music,
-    Sun, Moon, ScrollText, BookOpenText, AlertTriangle, RefreshCw, SpellCheck, Trash2
+    Sun, Moon, ScrollText, BookOpenText, AlertTriangle, AlertCircle, RefreshCw, SpellCheck, Trash2, CheckCircle2
 } from 'lucide-vue-next';
 import { Engine } from '../../core/engine';
+import { issuesStatus, summarizeIssues } from '../../core/issues';
 import type { Store } from '../../core/store';
-import type { EditorEnv } from '../../core/types';
+import type { EditorDiagnostic, EditorEnv } from '../../core/types';
 import PreviewFrame from './PreviewFrame.vue';
 import ToolbarButton from './ToolbarButton.vue';
 import BaseModal from './BaseModal.vue';
+import IssuesDrawer from './IssuesDrawer.vue';
 
 const props = defineProps<{
   env: EditorEnv;
@@ -36,6 +38,10 @@ let engine: Engine | null = null;
 
 const previewVisible = ref(localStorage.getItem("downstage-editor-preview-hidden") !== "true");
 const spellcheckEnabled = ref(localStorage.getItem("downstage-editor-spellcheck-disabled") !== "true");
+const issuesDrawerOpen = ref(false);
+const diagnostics = ref<EditorDiagnostic[]>([]);
+const issuesSummary = computed(() => summarizeIssues(diagnostics.value));
+const issuesStatusValue = computed(() => issuesStatus(issuesSummary.value));
 const showSpellcheckModal = ref(false);
 const dictionaryWord = ref("");
 const spellAllowlist = computed(() => props.getSpellAllowlist());
@@ -100,8 +106,6 @@ async function upgradeV1Document() {
 
         v1DismissedForDraftId.value = null;
         showV1Modal.value = false;
-        // Parent updates props.content; the watch below syncs the engine and
-        // schedules a re-render, so no direct engine/render calls here.
         emit('update:content', result.source);
     } finally {
         isUpgradingV1.value = false;
@@ -128,6 +132,7 @@ onMounted(async () => {
       iframeEl,
       () => props.getSpellAllowlist(),
       (word) => props.addSpellAllowlistWord(word),
+      (next) => { diagnostics.value = next; },
     );
     engine.init(props.content, store.state.isDark, spellcheckEnabled.value);
     scheduleRender(props.content, props.style);
@@ -152,6 +157,8 @@ watch(() => props.content, (newContent) => {
 
 watch(() => store.state.activeDraftId, () => {
   showV1Modal.value = false;
+  diagnostics.value = [];
+  engine?.refreshDiagnostics();
 });
 
 watch(() => props.style, (newStyle) => {
@@ -195,6 +202,10 @@ async function removeDictionaryWord(word: string) {
     if (removed) {
         engine?.refreshDiagnostics();
     }
+}
+
+function jumpToDiagnostic(d: EditorDiagnostic) {
+    engine?.revealDiagnostic(d.from, d.to);
 }
 </script>
 
@@ -276,8 +287,50 @@ async function removeDictionaryWord(word: string) {
     </div>
 
     <div class="flex-1 flex overflow-hidden relative">
-        <div ref="editorContainer" class="flex-1 h-full overflow-hidden border-r border-border bg-[var(--color-page-bg)]"></div>
-        
+        <div class="flex-1 h-full flex flex-col border-r border-border bg-[var(--color-page-bg)]">
+            <div class="flex-1 relative overflow-hidden">
+                <div ref="editorContainer" class="absolute inset-0 overflow-hidden"></div>
+
+                <div
+                    v-if="!issuesDrawerOpen"
+                    class="absolute right-6 bottom-6 z-20 flex flex-col items-end gap-3"
+                >
+                    <button
+                        type="button"
+                        @click="issuesDrawerOpen = true"
+                        class="flex items-center gap-2 rounded-full px-4 h-10 text-sm font-bold shadow-2xl transition-all hover:scale-105"
+                        :class="{
+                            'bg-emerald-500 text-white hover:bg-emerald-600': issuesStatusValue === 'clean',
+                            'bg-amber-500 text-ember-950 hover:bg-amber-400': issuesStatusValue === 'warning',
+                            'bg-red-500 text-white hover:bg-red-600': issuesStatusValue === 'error',
+                        }"
+                        :title="issuesStatusValue === 'clean' ? 'No script issues' : `${issuesSummary.total} script issue${issuesSummary.total === 1 ? '' : 's'}`"
+                    >
+                        <CheckCircle2 v-if="issuesStatusValue === 'clean'" class="w-4 h-4" />
+                        <AlertTriangle v-else-if="issuesStatusValue === 'warning'" class="w-4 h-4" />
+                        <AlertCircle v-else class="w-4 h-4" />
+                        <span>{{ issuesStatusValue === 'clean' ? 'No script issues' : `${issuesSummary.total} script issue${issuesSummary.total === 1 ? '' : 's'}` }}</span>
+                    </button>
+
+                    <button
+                        v-if="!previewVisible"
+                        @click="previewVisible = true"
+                        class="w-12 h-12 rounded-full bg-brass-500 text-ember-950 shadow-2xl flex items-center justify-center hover:bg-brass-400 transition-all transform hover:scale-110"
+                        title="Show Preview"
+                    >
+                        <Eye class="w-6 h-6 text-ember-950" />
+                    </button>
+                </div>
+            </div>
+
+            <IssuesDrawer
+                :diagnostics="diagnostics"
+                :open="issuesDrawerOpen"
+                @close="issuesDrawerOpen = false"
+                @jump="jumpToDiagnostic"
+            />
+        </div>
+
         <div v-show="previewVisible" class="flex-1 h-full bg-[var(--color-page-surface)] flex flex-col min-w-[300px]">
             <div class="px-4 py-2 border-b border-border bg-[var(--color-toolbar-bg)] flex justify-between items-center shadow-sm">
                 <h2 class="text-[10px] uppercase tracking-[0.2em] font-bold text-accent">Live Preview</h2>
@@ -321,14 +374,6 @@ async function removeDictionaryWord(word: string) {
             </div>
         </div>
 
-        <button 
-            v-if="!previewVisible"
-            @click="previewVisible = true"
-            class="absolute right-6 bottom-6 w-12 h-12 rounded-full bg-brass-500 text-ember-950 shadow-2xl flex items-center justify-center hover:bg-brass-400 transition-all transform hover:scale-110 z-20"
-            title="Show Preview"
-        >
-            <Eye class="w-6 h-6 text-ember-950" />
-        </button>
     </div>
   </div>
 

--- a/web/src/components/shared/IssuesDrawer.vue
+++ b/web/src/components/shared/IssuesDrawer.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { AlertCircle, AlertTriangle, CheckCircle2, Info, X } from 'lucide-vue-next';
+import type { EditorDiagnostic } from '../../core/types';
+import { summarizeIssues } from '../../core/issues';
+
+const props = defineProps<{
+  diagnostics: EditorDiagnostic[];
+  open: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'close'): void;
+  (e: 'jump', diagnostic: EditorDiagnostic): void;
+}>();
+
+const summary = computed(() => summarizeIssues(props.diagnostics));
+
+function severityLabel(d: EditorDiagnostic) {
+  if (d.severity === 'error') return 'Error';
+  if (d.severity === 'warning') return 'Warning';
+  if (d.severity === 'info') return 'Info';
+  return 'Hint';
+}
+</script>
+
+<template>
+  <section
+    class="shrink-0 flex flex-col bg-[var(--color-page-surface)] shadow-[0_-8px_24px_rgba(0,0,0,0.12)] overflow-hidden transition-[height,border-color] duration-200 ease-out"
+    :class="open ? 'border-t border-border' : 'border-t border-transparent'"
+    :style="{ height: open ? 'min(40vh, 360px)' : '0px' }"
+    :aria-hidden="!open"
+    role="region"
+    aria-label="Script issues"
+  >
+      <header class="flex items-center justify-between gap-3 border-b border-border bg-[var(--color-toolbar-bg)] px-4 py-2">
+        <div class="flex items-center gap-3">
+          <h2 class="text-[10px] font-bold uppercase tracking-[0.2em] text-accent">Script Issues</h2>
+          <div class="flex items-center gap-2 text-xs font-medium text-text-muted">
+            <span v-if="summary.errors > 0" class="flex items-center gap-1 rounded-full bg-red-500/15 px-2 py-0.5 text-red-600 dark:text-red-400">
+              <AlertCircle class="h-3 w-3" /> {{ summary.errors }}
+            </span>
+            <span v-if="summary.warnings > 0" class="flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-amber-700 dark:text-amber-400">
+              <AlertTriangle class="h-3 w-3" /> {{ summary.warnings }}
+            </span>
+            <span v-if="summary.infos + summary.hints > 0" class="flex items-center gap-1 rounded-full bg-black/5 px-2 py-0.5 dark:bg-white/10">
+              <Info class="h-3 w-3" /> {{ summary.infos + summary.hints }}
+            </span>
+            <span v-if="summary.total === 0" class="text-[10px] uppercase tracking-wider text-text-muted">All clear</span>
+          </div>
+        </div>
+        <button
+          type="button"
+          class="rounded-full p-1.5 text-text-muted transition-colors hover:bg-black/5 hover:text-text-main dark:hover:bg-white/5"
+          aria-label="Close script issues"
+          @click="emit('close')"
+        >
+          <X class="h-4 w-4" />
+        </button>
+      </header>
+
+      <div
+        v-if="diagnostics.length === 0"
+        class="flex flex-1 flex-col items-center justify-center gap-2 text-text-muted"
+      >
+        <div class="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-400">
+          <CheckCircle2 class="h-5 w-5" />
+        </div>
+        <p class="text-sm font-medium text-text-main">No script issues</p>
+        <p class="text-xs">The script is clean.</p>
+      </div>
+
+      <ul v-else class="flex-1 divide-y divide-border overflow-y-auto">
+        <li
+          v-for="(d, index) in diagnostics"
+          :key="`${d.from}-${d.to}-${index}`"
+          class="group cursor-pointer px-4 py-2 transition-colors hover:bg-black/5 dark:hover:bg-white/5"
+          tabindex="0"
+          role="button"
+          :aria-label="`${severityLabel(d)} at line ${d.line}, column ${d.col}: ${d.message}`"
+          @click="emit('jump', d)"
+          @keydown.enter.prevent="emit('jump', d)"
+          @keydown.space.prevent="emit('jump', d)"
+        >
+          <div class="flex items-start gap-3">
+            <span class="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center">
+              <AlertCircle v-if="d.severity === 'error'" class="h-4 w-4 text-red-500" />
+              <AlertTriangle v-else-if="d.severity === 'warning'" class="h-4 w-4 text-amber-500" />
+              <Info v-else class="h-4 w-4 text-text-muted" />
+            </span>
+            <span class="shrink-0 font-mono text-[11px] text-text-muted tabular-nums">{{ d.line }}:{{ d.col }}</span>
+            <span class="flex-1 text-sm leading-snug text-text-main line-clamp-2">{{ d.message }}</span>
+            <span
+              v-if="d.code"
+              class="shrink-0 rounded border border-border bg-black/5 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-text-muted dark:bg-white/5"
+            >{{ d.code }}</span>
+          </div>
+        </li>
+      </ul>
+  </section>
+</template>

--- a/web/src/core/engine.ts
+++ b/web/src/core/engine.ts
@@ -3,12 +3,14 @@ import { EditorState, Compartment } from "@codemirror/state";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { completionKeymap } from "@codemirror/autocomplete";
 import { oneDark } from "@codemirror/theme-one-dark";
+import { forEachDiagnostic, setDiagnosticsEffect, type Diagnostic } from "@codemirror/lint";
 import { createDownstageLinter, refreshDiagnostics } from "../diagnostics";
 import { createDownstageCompletion } from "../completion";
 import { createDownstageHighlighter } from "../downstage-lang";
 import { createScrollSyncPlugin } from "../scroll-sync";
 import { warmSpellDictionary } from "../spellcheck";
-import type { EditorEnv } from "./types";
+import { projectDiagnostics } from "./issues";
+import type { EditorDiagnostic, EditorEnv } from "./types";
 
 const themeCompartment = new Compartment();
 const lintCompartment = new Compartment();
@@ -51,6 +53,7 @@ export class Engine {
     private iframe: HTMLIFrameElement,
     private getUserSpellAllowlist: () => string[],
     private addUserSpellAllowlistWord: (word: string) => Promise<boolean>,
+    private onDiagnosticsChange: (diagnostics: EditorDiagnostic[]) => void = () => {},
   ) {}
 
   init(initialContent: string, isDark: boolean, spellcheckEnabled = false) {
@@ -83,6 +86,12 @@ export class Engine {
           EditorView.updateListener.of((update) => {
             if (update.docChanged) {
               this.onDocChange(update.state.doc.toString());
+            }
+            const lintChanged = update.transactions.some((tr) =>
+              tr.effects.some((effect) => effect.is(setDiagnosticsEffect)),
+            );
+            if (lintChanged) {
+              this.emitDiagnostics();
             }
           }),
         ],
@@ -190,6 +199,31 @@ export class Engine {
     refreshDiagnostics(this.view);
   }
 
+  getDiagnostics(): EditorDiagnostic[] {
+    if (!this.view) return [];
+    const raw: Diagnostic[] = [];
+    forEachDiagnostic(this.view.state, (d) => {
+      raw.push(d);
+    });
+    return projectDiagnostics(this.view.state.doc, raw);
+  }
+
+  revealDiagnostic(from: number, to: number) {
+    if (!this.view) return;
+    const docLength = this.view.state.doc.length;
+    const clampedFrom = Math.max(0, Math.min(from, docLength));
+    const clampedTo = Math.max(clampedFrom, Math.min(to, docLength));
+    this.view.dispatch({
+      selection: { anchor: clampedFrom, head: clampedTo },
+      effects: EditorView.scrollIntoView(clampedFrom, { y: "center" }),
+    });
+    this.view.focus();
+  }
+
+  private emitDiagnostics() {
+    this.onDiagnosticsChange(this.getDiagnostics());
+  }
+
   setContent(content: string) {
     if (!this.view) return;
     if (this.getContent() === content) return;
@@ -234,8 +268,6 @@ export class Engine {
       this.cancelSpellcheckWarmup = null;
       if (cancelled || !this.view || !this.spellcheckEnabled) return;
 
-      // Actually construct the typo-js dictionary here so the first lint
-      // pass doesn't pay the ~50K-line parse cost on the main thread.
       try {
         await warmSpellDictionary();
       } catch {

--- a/web/src/core/issues.ts
+++ b/web/src/core/issues.ts
@@ -1,0 +1,54 @@
+import type { Diagnostic } from "@codemirror/lint";
+import type { Text } from "@codemirror/state";
+import type { EditorDiagnostic } from "./types";
+
+type DiagnosticWithCode = Diagnostic & { code?: string };
+
+export function projectDiagnostics(
+  doc: Text,
+  diagnostics: readonly Diagnostic[],
+): EditorDiagnostic[] {
+  const result: EditorDiagnostic[] = [];
+  for (const d of diagnostics) {
+    if (d.source === "spellcheck") continue;
+    const line = doc.lineAt(d.from);
+    const withCode = d as DiagnosticWithCode;
+    result.push({
+      from: d.from,
+      to: d.to,
+      line: line.number,
+      col: d.from - line.from + 1,
+      severity: d.severity,
+      message: d.message,
+      code: withCode.code,
+    });
+  }
+  return result;
+}
+
+export interface IssuesSummary {
+  errors: number;
+  warnings: number;
+  infos: number;
+  hints: number;
+  total: number;
+}
+
+export function summarizeIssues(items: readonly EditorDiagnostic[]): IssuesSummary {
+  const summary: IssuesSummary = { errors: 0, warnings: 0, infos: 0, hints: 0, total: items.length };
+  for (const d of items) {
+    if (d.severity === "error") summary.errors++;
+    else if (d.severity === "warning") summary.warnings++;
+    else if (d.severity === "info") summary.infos++;
+    else if (d.severity === "hint") summary.hints++;
+  }
+  return summary;
+}
+
+export type IssuesStatus = "clean" | "warning" | "error";
+
+export function issuesStatus(summary: IssuesSummary): IssuesStatus {
+  if (summary.errors > 0) return "error";
+  if (summary.warnings > 0 || summary.infos > 0 || summary.hints > 0) return "warning";
+  return "clean";
+}

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -73,6 +73,16 @@ export interface SpellcheckContext {
   ignoredRanges: SpellcheckRange[];
 }
 
+export interface EditorDiagnostic {
+  from: number;
+  to: number;
+  line: number;
+  col: number;
+  severity: "error" | "warning" | "info" | "hint";
+  message: string;
+  code?: string;
+}
+
 export interface SavedDraft {
   id: string;
   title: string;

--- a/web/src/diagnostics.ts
+++ b/web/src/diagnostics.ts
@@ -6,10 +6,6 @@ import type { EditorEnv, LSPTextEdit, SpellcheckContext, WasmDiagnostic } from "
 import { offsetFromLSP } from "./lsp-offsets";
 import { getSpellDiagnostics, type SpellcheckCallbacks } from "./spellcheck";
 
-// Dispatched by refreshDiagnostics() when spellcheck-related external state
-// changes (warmup completes, user toggles spellcheck, dictionary edited).
-// Picked up by the linter's needsRefresh hook so the linter knows to re-run
-// even though the doc didn't change.
 export const spellcheckRefreshEffect = StateEffect.define<null>();
 
 export function applyLSPEdits(view: EditorView, edits: LSPTextEdit[]) {
@@ -22,9 +18,6 @@ export function applyLSPEdits(view: EditorView, edits: LSPTextEdit[]) {
   view.dispatch({ changes, scrollIntoView: true });
 }
 
-// buildQuickFixActions resolves code actions lazily: on click, we re-query the
-// Go side with the current document so TextEdit ranges reflect any edits the
-// user made since the lint pass that produced this diagnostic.
 function buildQuickFixActions(
   env: EditorEnv,
   code: string,
@@ -61,7 +54,7 @@ export function toDiagnostics(
 ): Diagnostic[] {
   const result: Diagnostic[] = [];
   for (const d of sourceDiagnostics) {
-    const startLine = d.line + 1; // 0-based → 1-based
+    const startLine = d.line + 1;
     const endLine = d.endLine + 1;
     if (startLine > doc.lines || endLine > doc.lines) continue;
 
@@ -78,6 +71,7 @@ export function toDiagnostics(
       severity: d.severity,
       message: d.message,
       source: "downstage",
+      ...(d.code ? { code: d.code } : {}),
       actions,
     });
   }
@@ -111,10 +105,6 @@ export function createDownstageLinter(
     },
     {
       delay: 300,
-      // Re-run when our refresh effect lands, even if the doc didn't change.
-      // forceLinting() alone is not enough: it only runs the lint when the
-      // plugin already has work pending. needsRefresh tells the plugin
-      // there IS work to do.
       needsRefresh: (update) => update.transactions.some((tr) =>
         tr.effects.some((effect) => effect.is(spellcheckRefreshEffect)),
       ),
@@ -122,10 +112,6 @@ export function createDownstageLinter(
   );
 }
 
-// Trigger a re-lint when external state (spellcheck toggle, dictionary edit,
-// warmup completion) changed without a doc change. The linter's own `delay`
-// (300ms) coalesces rapid back-to-back refreshes so we don't need a
-// separate debounce here.
 export function refreshDiagnostics(view: EditorView) {
   view.dispatch({ effects: spellcheckRefreshEffect.of(null) });
 }


### PR DESCRIPTION
## Summary

Adds a bottom-docked "Script Issues" drawer to the web editor that lists all syntax diagnostics for the current script. A floating status pill anchored to the editor pane doubles as an at-a-glance indicator (green check / amber warning / red error) and toggles the drawer — same pattern as the existing Show Preview FAB.

- **Scope**: syntax diagnostics only. Spellcheck warnings stay inline so the badge is not dominated by character names and stage vocabulary. The label "Script Issues" is chosen to make that scope explicit.
- **Layout**: drawer is a flex sibling of the editor area with an animated height, so CodeMirror's viewport shrinks in sync — no post-animation reflow flash.
- **Jump-to-issue**: clicking a row centers the diagnostic in the viewport via \`EditorView.scrollIntoView({ y: "center" })\` so the writer sees surrounding context.
- **Draft safety**: switching drafts clears cached diagnostics and triggers a refresh, so identical-text drafts don't surface the previous draft's issues.
- Adds \`@vue/test-utils\` + \`happy-dom\` as dev deps for the drawer component test; pure helpers (projection, summary, status) are unit tested without a DOM.

## Test plan

- [x] \`npm test\` in \`web/\` — 44 tests pass (typecheck + vitest)
- [x] \`npm run build\` in \`web/\` — clean build
- [x] \`go test ./...\` — unchanged, all green
- [x] Manual: clean script shows green "No script issues"; introducing an error flips the FAB red with a count
- [x] Manual: clicking a row centers the issue in the editor and keeps the drawer open
- [x] Manual: drawer opens/closes smoothly; editor viewport shrinks with the drawer animation
- [x] Manual: drawer and FAB anchor to the editor pane when preview is visible
- [x] Manual: switching drafts refreshes the drawer contents