### PR TITLE
feat(lsp): add DP and cue hygiene diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ SONG END
   - Hover info on character names (shows description from dramatis personae)
   - Go-to-definition (jump to character's dramatis personae entry)
   - Context-aware completion for character cues
-  - Diagnostics (parse errors, unknown character warnings)
-  - Code actions (quick fixes for unknown characters and unnumbered or
-    misnumbered acts/scenes)
+  - Diagnostics (parse errors, unknown character warnings, Dramatis
+    Personae hygiene, cue hygiene)
+  - Code actions (quick fixes for unknown characters, unnumbered or
+    misnumbered acts/scenes, duplicate DP entries, and inserting a
+    missing Dramatis Personae section)
 - Neovim integration out of the box (0.11+)
 - CLI tools for parsing and validation
 

--- a/internal/lsp/code_actions.go
+++ b/internal/lsp/code_actions.go
@@ -136,6 +136,38 @@ func computeCodeActions(
 					},
 				},
 			})
+		case diagnosticCodeDPDuplicateCharacterName:
+			edit := deleteDuplicateDPEntryEdit(content, diagnostic.Range)
+			if edit == nil {
+				continue
+			}
+			actions = append(actions, protocol.CodeAction{
+				Title:       "Delete duplicate Dramatis Personae entry",
+				Kind:        protocol.QuickFix,
+				Diagnostics: []protocol.Diagnostic{diagnostic},
+				IsPreferred: true,
+				Edit: &protocol.WorkspaceEdit{
+					Changes: map[protocol.DocumentURI][]protocol.TextEdit{
+						uri: {*edit},
+					},
+				},
+			})
+		case diagnosticCodeMissingDramatisPersonae:
+			edit := insertMissingDramatisPersonaeEdit(doc, content, index)
+			if edit == nil {
+				continue
+			}
+			actions = append(actions, protocol.CodeAction{
+				Title:       "Add Dramatis Personae section",
+				Kind:        protocol.QuickFix,
+				Diagnostics: []protocol.Diagnostic{diagnostic},
+				IsPreferred: true,
+				Edit: &protocol.WorkspaceEdit{
+					Changes: map[protocol.DocumentURI][]protocol.TextEdit{
+						uri: {*edit},
+					},
+				},
+			})
 		case diagnosticCodeUnnumberedAct, diagnosticCodeUnnumberedScene,
 			diagnosticCodeMisnumberedAct, diagnosticCodeMisnumberedScene:
 			textEdit := numberingEdit(diagnostic)
@@ -446,4 +478,148 @@ func maxInt(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// deleteDuplicateDPEntryEdit removes an entire duplicate Dramatis Personae
+// row. The diagnostic range covers the entry's character Range, which is
+// typically a single line; the edit consumes the trailing newline so
+// surrounding blank-line conventions survive.
+func deleteDuplicateDPEntryEdit(content string, r protocol.Range) *protocol.TextEdit {
+	startLine := int(r.Start.Line)
+	endLine := int(r.End.Line)
+	if endLine < startLine {
+		return nil
+	}
+	if _, ok := lineAt(content, startLine); !ok {
+		return nil
+	}
+	// Prefer consuming the trailing newline so the row vanishes cleanly.
+	// If we're at EOF (no trailing newline), fall back to consuming the
+	// preceding newline so we don't leave a blank row behind.
+	if _, ok := lineAt(content, endLine+1); ok {
+		return &protocol.TextEdit{
+			Range: protocol.Range{
+				Start: protocol.Position{Line: uint32(startLine), Character: 0},
+				End:   protocol.Position{Line: uint32(endLine + 1), Character: 0},
+			},
+			NewText: "",
+		}
+	}
+	if startLine == 0 {
+		// Only row in the file — just clear it.
+		line, _ := lineAt(content, startLine)
+		return &protocol.TextEdit{
+			Range: protocol.Range{
+				Start: protocol.Position{Line: uint32(startLine), Character: 0},
+				End:   protocol.Position{Line: uint32(endLine), Character: uint32(utf16Len(line))},
+			},
+			NewText: "",
+		}
+	}
+	prev, _ := lineAt(content, startLine-1)
+	endLineText, _ := lineAt(content, endLine)
+	return &protocol.TextEdit{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: uint32(startLine - 1), Character: uint32(utf16Len(prev))},
+			End:   protocol.Position{Line: uint32(endLine), Character: uint32(utf16Len(endLineText))},
+		},
+		NewText: "",
+	}
+}
+
+// insertMissingDramatisPersonaeEdit produces a workspace edit that inserts a
+// fresh Dramatis Personae section seeded with every character observed as a
+// cue in the document. Names are uppercased, deduplicated, and ordered by
+// first appearance.
+func insertMissingDramatisPersonaeEdit(doc *ast.Document, content string, index *documentIndex) *protocol.TextEdit {
+	if doc == nil {
+		return nil
+	}
+	if index == nil {
+		index = newDocumentIndex(doc)
+	}
+
+	names := observedCueNames(index)
+	body := "## Dramatis Personae\n\n"
+	if len(names) == 0 {
+		body += "\n"
+	} else {
+		for _, name := range names {
+			body += name + "\n"
+		}
+		body += "\n"
+	}
+
+	// Insert directly after the first top-level play heading when present so
+	// the DP sits at the conventional position. Otherwise insert at the very
+	// top of the document.
+	if len(index.topLevelSections) > 0 {
+		play := index.topLevelSections[0]
+		line := play.HeadingRange().End.Line + 1
+		// Skip any blank lines immediately after the heading so we land on
+		// the first content line.
+		for {
+			raw, ok := lineAt(content, line)
+			if !ok {
+				break
+			}
+			if strings.TrimSpace(raw) != "" {
+				break
+			}
+			line++
+		}
+		return &protocol.TextEdit{
+			Range: protocol.Range{
+				Start: protocol.Position{Line: uint32(line), Character: 0},
+				End:   protocol.Position{Line: uint32(line), Character: 0},
+			},
+			NewText: body,
+		}
+	}
+
+	return &protocol.TextEdit{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: 0, Character: 0},
+		},
+		NewText: body,
+	}
+}
+
+// observedCueNames returns unique cue character names in first-appearance
+// order. Forced and conjunction-split cues are included; empty cues are
+// skipped.
+func observedCueNames(index *documentIndex) []string {
+	seen := make(map[string]struct{})
+	var names []string
+	add := func(raw string) {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			return
+		}
+		key := strings.ToUpper(trimmed)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		names = append(names, trimmed)
+	}
+	for _, ref := range index.dialogues {
+		if ref.dialogue == nil {
+			continue
+		}
+		if parts := splitConjunctionCue(ref.dialogue.Character); parts != nil {
+			for _, p := range parts {
+				if !collectiveCues[strings.ToUpper(strings.TrimSpace(p))] {
+					add(p)
+				}
+			}
+			continue
+		}
+		if collectiveCues[strings.ToUpper(strings.TrimSpace(ref.dialogue.Character))] {
+			continue
+		}
+		add(ref.dialogue.Character)
+	}
+	return names
 }

--- a/internal/lsp/code_actions.go
+++ b/internal/lsp/code_actions.go
@@ -551,23 +551,14 @@ func insertMissingDramatisPersonaeEdit(doc *ast.Document, content string, index 
 	}
 
 	// Insert directly after the first top-level play heading when present so
-	// the DP sits at the conventional position. Otherwise insert at the very
-	// top of the document.
+	// the DP sits at the conventional position, but *after* any metadata
+	// block attached to the heading — otherwise we'd split the metadata
+	// from its owning heading and the V2 parser would re-classify those
+	// key/value lines as document content. Same precaution applies to the
+	// doc-level fallback when a V1-style top-level TitlePage exists.
 	if len(index.topLevelSections) > 0 {
 		play := index.topLevelSections[0]
-		line := play.HeadingRange().End.Line + 1
-		// Skip any blank lines immediately after the heading so we land on
-		// the first content line.
-		for {
-			raw, ok := lineAt(content, line)
-			if !ok {
-				break
-			}
-			if strings.TrimSpace(raw) != "" {
-				break
-			}
-			line++
-		}
+		line := insertAfterPlayHeader(play, content)
 		return &protocol.TextEdit{
 			Range: protocol.Range{
 				Start: protocol.Position{Line: uint32(line), Character: 0},
@@ -577,12 +568,42 @@ func insertMissingDramatisPersonaeEdit(doc *ast.Document, content string, index 
 		}
 	}
 
+	startLine := 0
+	if doc.TitlePage != nil {
+		startLine = doc.TitlePage.Range.End.Line + 1
+		startLine = skipBlankLines(content, startLine)
+	}
 	return &protocol.TextEdit{
 		Range: protocol.Range{
-			Start: protocol.Position{Line: 0, Character: 0},
-			End:   protocol.Position{Line: 0, Character: 0},
+			Start: protocol.Position{Line: uint32(startLine), Character: 0},
+			End:   protocol.Position{Line: uint32(startLine), Character: 0},
 		},
 		NewText: body,
+	}
+}
+
+// insertAfterPlayHeader returns the line index where new top-level content
+// should be inserted under a play heading: after the heading, past any
+// metadata block attached to it, and past any blank separator lines.
+func insertAfterPlayHeader(play *ast.Section, content string) int {
+	line := play.HeadingRange().End.Line + 1
+	if play.Metadata != nil {
+		line = play.Metadata.Range.End.Line + 1
+	}
+	return skipBlankLines(content, line)
+}
+
+func skipBlankLines(content string, start int) int {
+	line := start
+	for {
+		raw, ok := lineAt(content, line)
+		if !ok {
+			return line
+		}
+		if strings.TrimSpace(raw) != "" {
+			return line
+		}
+		line++
 	}
 }
 

--- a/internal/lsp/code_actions.go
+++ b/internal/lsp/code_actions.go
@@ -550,12 +550,7 @@ func insertMissingDramatisPersonaeEdit(doc *ast.Document, content string, index 
 		body += "\n"
 	}
 
-	// Insert directly after the first top-level play heading when present so
-	// the DP sits at the conventional position, but *after* any metadata
-	// block attached to the heading — otherwise we'd split the metadata
-	// from its owning heading and the V2 parser would re-classify those
-	// key/value lines as document content. Same precaution applies to the
-	// doc-level fallback when a V1-style top-level TitlePage exists.
+	// Insert after the play heading and any attached metadata block.
 	if len(index.topLevelSections) > 0 {
 		play := index.topLevelSections[0]
 		line := insertAfterPlayHeader(play, content)
@@ -582,9 +577,7 @@ func insertMissingDramatisPersonaeEdit(doc *ast.Document, content string, index 
 	}
 }
 
-// insertAfterPlayHeader returns the line index where new top-level content
-// should be inserted under a play heading: after the heading, past any
-// metadata block attached to it, and past any blank separator lines.
+// insertAfterPlayHeader returns the insertion line under a play heading.
 func insertAfterPlayHeader(play *ast.Section, content string) int {
 	line := play.HeadingRange().End.Line + 1
 	if play.Metadata != nil {

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -12,12 +12,18 @@ import (
 )
 
 const (
-	diagnosticCodeUnknownCharacter = "unknown-character"
-	diagnosticCodeUnnumberedAct    = "unnumbered-act"
-	diagnosticCodeUnnumberedScene  = "unnumbered-scene"
-	diagnosticCodeMisnumberedAct   = "misnumbered-act"
-	diagnosticCodeMisnumberedScene = "misnumbered-scene"
-	diagnosticCodeV1Document       = "v1-document"
+	diagnosticCodeUnknownCharacter            = "unknown-character"
+	diagnosticCodeUnnumberedAct               = "unnumbered-act"
+	diagnosticCodeUnnumberedScene             = "unnumbered-scene"
+	diagnosticCodeMisnumberedAct              = "misnumbered-act"
+	diagnosticCodeMisnumberedScene            = "misnumbered-scene"
+	diagnosticCodeV1Document                  = "v1-document"
+	diagnosticCodeMissingDramatisPersonae     = "missing-dramatis-personae"
+	diagnosticCodeDPCharacterNoDialogue       = "dp-character-no-dialogue"
+	diagnosticCodeDPDuplicateCharacterName    = "dp-duplicate-character-name"
+	diagnosticCodeDPDuplicateAlias            = "dp-duplicate-alias"
+	diagnosticCodeCueOrphaned                 = "cue-orphaned"
+	diagnosticCodeCueConsecutiveSameCharacter = "cue-consecutive-same-character"
 )
 
 // collectiveCues are conventional ensemble cue names that should not
@@ -115,6 +121,11 @@ func buildDiagnosticsWithIndex(doc *ast.Document, errors []*parser.ParseError, i
 	if doc != nil {
 		diags = append(diags, checkUnnumberedSections(index)...)
 		diags = append(diags, checkUnknownCharacters(index)...)
+		diags = append(diags, checkMissingDramatisPersonae(doc, index)...)
+		diags = append(diags, checkDPDuplicates(index)...)
+		diags = append(diags, checkDPCharacterNoDialogue(index)...)
+		diags = append(diags, checkOrphanedCues(index)...)
+		diags = append(diags, checkConsecutiveSameCharacterCues(index)...)
 	}
 
 	if diags == nil {

--- a/internal/lsp/diagnostics_test.go
+++ b/internal/lsp/diagnostics_test.go
@@ -150,6 +150,24 @@ Author: William Shakespeare
 	assert.True(t, found, "expected v1-document diagnostic")
 }
 
+// filterDiagnostics returns only diagnostics whose Code matches one of the
+// given values. Lets narrow tests assert on a specific diagnostic class
+// without caring about independent checks that fire on the same fixture
+// (e.g. cue-orphaned on a synthetic Dialogue with no Lines).
+func filterDiagnostics(diags []protocol.Diagnostic, codes ...interface{}) []protocol.Diagnostic {
+	want := make(map[interface{}]struct{}, len(codes))
+	for _, c := range codes {
+		want[c] = struct{}{}
+	}
+	out := make([]protocol.Diagnostic, 0, len(diags))
+	for _, d := range diags {
+		if _, ok := want[d.Code]; ok {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
 func TestBuildDiagnostics_UnknownCharacter(t *testing.T) {
 	doc := &ast.Document{
 		Body: []ast.Node{
@@ -169,7 +187,7 @@ func TestBuildDiagnostics_UnknownCharacter(t *testing.T) {
 		},
 	}
 
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 1 {
 		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
 	}
@@ -228,9 +246,9 @@ func TestBuildDiagnostics_NoDramatisPersonaeSuppressesUnknownCharacter(t *testin
 		},
 	}
 
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 0 {
-		t.Fatalf("expected 0 diagnostics without dramatis personae, got %d", len(diags))
+		t.Fatalf("expected 0 unknown-character diagnostics without dramatis personae, got %d", len(diags))
 	}
 }
 
@@ -292,9 +310,9 @@ func TestBuildDiagnostics_KnownCharacter(t *testing.T) {
 		},
 	}
 
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 0 {
-		t.Errorf("expected 0 diagnostics for known character, got %d", len(diags))
+		t.Errorf("expected 0 unknown-character diagnostics for known character, got %d", len(diags))
 	}
 }
 
@@ -320,9 +338,9 @@ func TestBuildDiagnostics_AliasMatch(t *testing.T) {
 		},
 	}
 
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 0 {
-		t.Errorf("expected 0 diagnostics for alias match, got %d", len(diags))
+		t.Errorf("expected 0 unknown-character diagnostics for alias match, got %d", len(diags))
 	}
 }
 
@@ -443,7 +461,7 @@ func testDocWithCharactersAndDialogue(knownNames []string, dialogueCharacter str
 
 func TestBuildDiagnostics_CollectiveCueAll(t *testing.T) {
 	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "ALL")
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 0 {
 		t.Errorf("expected 0 diagnostics for ALL, got %d", len(diags))
 	}
@@ -451,7 +469,7 @@ func TestBuildDiagnostics_CollectiveCueAll(t *testing.T) {
 
 func TestBuildDiagnostics_CollectiveCueChorus(t *testing.T) {
 	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "CHORUS")
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 0 {
 		t.Errorf("expected 0 diagnostics for CHORUS, got %d", len(diags))
 	}
@@ -459,7 +477,7 @@ func TestBuildDiagnostics_CollectiveCueChorus(t *testing.T) {
 
 func TestBuildDiagnostics_CollectiveCueEnsemble(t *testing.T) {
 	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "ENSEMBLE")
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 0 {
 		t.Errorf("expected 0 diagnostics for ENSEMBLE, got %d", len(diags))
 	}
@@ -467,7 +485,7 @@ func TestBuildDiagnostics_CollectiveCueEnsemble(t *testing.T) {
 
 func TestBuildDiagnostics_CollectiveCueCaseInsensitive(t *testing.T) {
 	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "All")
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 0 {
 		t.Errorf("expected 0 diagnostics for mixed-case All, got %d", len(diags))
 	}
@@ -475,7 +493,7 @@ func TestBuildDiagnostics_CollectiveCueCaseInsensitive(t *testing.T) {
 
 func TestBuildDiagnostics_ConjunctionBothKnown(t *testing.T) {
 	doc := testDocWithCharactersAndDialogue([]string{"BOB", "JANE"}, "BOB AND JANE")
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 0 {
 		t.Errorf("expected 0 diagnostics for conjunction of known characters, got %d", len(diags))
 	}
@@ -483,7 +501,7 @@ func TestBuildDiagnostics_ConjunctionBothKnown(t *testing.T) {
 
 func TestBuildDiagnostics_ConjunctionAmpersandBothKnown(t *testing.T) {
 	doc := testDocWithCharactersAndDialogue([]string{"BOB", "JANE"}, "BOB & JANE")
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 0 {
 		t.Errorf("expected 0 diagnostics for ampersand conjunction of known characters, got %d", len(diags))
 	}
@@ -491,7 +509,7 @@ func TestBuildDiagnostics_ConjunctionAmpersandBothKnown(t *testing.T) {
 
 func TestBuildDiagnostics_ConjunctionOneUnknown(t *testing.T) {
 	doc := testDocWithCharactersAndDialogue([]string{"BOB"}, "BOB AND JANE")
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 1 {
 		t.Fatalf("expected 1 diagnostic for one unknown in conjunction, got %d", len(diags))
 	}
@@ -502,7 +520,7 @@ func TestBuildDiagnostics_ConjunctionOneUnknown(t *testing.T) {
 
 func TestBuildDiagnostics_ConjunctionBothUnknown(t *testing.T) {
 	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "BOB & JANE")
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 2 {
 		t.Fatalf("expected 2 diagnostics for both unknown in conjunction, got %d", len(diags))
 	}
@@ -510,7 +528,7 @@ func TestBuildDiagnostics_ConjunctionBothUnknown(t *testing.T) {
 
 func TestBuildDiagnostics_ConjunctionWithCollective(t *testing.T) {
 	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "BOB AND ALL")
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 1 {
 		t.Fatalf("expected 1 diagnostic (BOB only), got %d", len(diags))
 	}
@@ -521,7 +539,7 @@ func TestBuildDiagnostics_ConjunctionWithCollective(t *testing.T) {
 
 func TestBuildDiagnostics_AllCollectiveConjunction(t *testing.T) {
 	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "ALL AND CHORUS")
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 0 {
 		t.Errorf("expected 0 diagnostics for conjunction of collective cues, got %d", len(diags))
 	}
@@ -529,7 +547,7 @@ func TestBuildDiagnostics_AllCollectiveConjunction(t *testing.T) {
 
 func TestBuildDiagnostics_MultiConjunction(t *testing.T) {
 	doc := testDocWithCharactersAndDialogue([]string{"BOB", "JANE"}, "BOB & JANE & STEVE")
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 1 {
 		t.Fatalf("expected 1 diagnostic for STEVE, got %d", len(diags))
 	}
@@ -540,7 +558,7 @@ func TestBuildDiagnostics_MultiConjunction(t *testing.T) {
 
 func TestBuildDiagnostics_NameContainingAnd(t *testing.T) {
 	doc := testDocWithCharactersAndDialogue([]string{"HAMLET"}, "SANDY")
-	diags := buildDiagnostics(doc, nil)
+	diags := filterDiagnostics(buildDiagnostics(doc, nil), diagnosticCodeUnknownCharacter)
 	if len(diags) != 1 {
 		t.Fatalf("expected 1 diagnostic for SANDY (no split), got %d", len(diags))
 	}

--- a/internal/lsp/dp_cue_code_actions_test.go
+++ b/internal/lsp/dp_cue_code_actions_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jscaltreto/downstage/internal/ast"
 	"github.com/jscaltreto/downstage/internal/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,6 +85,55 @@ Hello.`
 	assert.Contains(t, edits[0].NewText, "BOB")
 	// ALICE should come before BOB (first-appearance order).
 	assert.Less(t, strings.Index(edits[0].NewText, "ALICE"), strings.Index(edits[0].NewText, "BOB"))
+}
+
+func TestComputeCodeActions_InsertMissingDramatisPersonae_AfterPlayMetadata(t *testing.T) {
+	// The first play has a metadata block directly under the heading.
+	// Inserting the DP between the heading and the metadata would turn
+	// valid metadata into content; insertion must land after the block.
+	content := `# My Play
+Author: Jane Doe
+Opened: 2024-01-01
+
+## ACT I
+
+### SCENE 1
+
+ALICE
+Hi.`
+
+	actions := codeActionsFor(t, content)
+
+	var add *protocol.CodeAction
+	for i := range actions {
+		if actions[i].Title == "Add Dramatis Personae section" {
+			add = &actions[i]
+			break
+		}
+	}
+	require.NotNil(t, add)
+
+	edits := add.Edit.Changes[protocol.DocumentURI("file:///test.ds")]
+	require.Len(t, edits, 1)
+	// Metadata ends at line 2 (0-indexed), so insertion should land at
+	// line 3 (the blank) or later after blank-skipping — specifically the
+	// `## ACT I` line at index 4.
+	assert.GreaterOrEqual(t, edits[0].Range.Start.Line, uint32(3))
+	assert.True(t, strings.HasPrefix(edits[0].NewText, "## Dramatis Personae\n"))
+
+	// Apply the edit and re-parse to confirm the metadata survives as
+	// metadata (not as content under the DP heading).
+	lines := strings.Split(content, "\n")
+	insertAt := int(edits[0].Range.Start.Line)
+	merged := strings.Join(lines[:insertAt], "\n") + "\n" + edits[0].NewText + strings.Join(lines[insertAt:], "\n")
+	postDoc, postErrs := parser.Parse([]byte(merged))
+	require.Empty(t, postErrs, "post-edit parse should have no errors")
+	require.NotNil(t, postDoc)
+	require.NotEmpty(t, postDoc.Body)
+	play, ok := postDoc.Body[0].(*ast.Section)
+	require.True(t, ok, "first body node should still be a Section")
+	require.NotNil(t, play.Metadata, "play metadata must still be attached after the edit")
+	assert.NotEmpty(t, play.Metadata.Entries)
 }
 
 func TestComputeCodeActions_InsertMissingDramatisPersonae_NoHeading(t *testing.T) {

--- a/internal/lsp/dp_cue_code_actions_test.go
+++ b/internal/lsp/dp_cue_code_actions_test.go
@@ -1,0 +1,112 @@
+package lsp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+)
+
+func codeActionsFor(t *testing.T, content string) []protocol.CodeAction {
+	t.Helper()
+	doc, errs := parser.Parse([]byte(content))
+	require.Empty(t, errs)
+	diags := buildDiagnostics(doc, errs)
+	return computeCodeActions(doc, content, protocol.DocumentURI("file:///test.ds"), diags, diags)
+}
+
+func TestComputeCodeActions_DeleteDuplicateDPEntry(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+ALICE
+
+## ACT I
+
+ALICE
+Hi.`
+
+	actions := codeActionsFor(t, content)
+
+	var del *protocol.CodeAction
+	for i := range actions {
+		if actions[i].Title == "Delete duplicate Dramatis Personae entry" {
+			del = &actions[i]
+			break
+		}
+	}
+	require.NotNil(t, del, "expected a delete-duplicate action")
+
+	edits := del.Edit.Changes[protocol.DocumentURI("file:///test.ds")]
+	require.Len(t, edits, 1)
+	assert.Equal(t, "", edits[0].NewText)
+	// Deletion should consume through the start of the next line so the
+	// duplicate row vanishes entirely.
+	assert.Equal(t, uint32(4), edits[0].Range.Start.Line)
+	assert.Equal(t, uint32(5), edits[0].Range.End.Line)
+	assert.Equal(t, uint32(0), edits[0].Range.Start.Character)
+	assert.Equal(t, uint32(0), edits[0].Range.End.Character)
+}
+
+func TestComputeCodeActions_InsertMissingDramatisPersonae(t *testing.T) {
+	content := `# Play
+
+## ACT I
+
+### SCENE 1
+
+ALICE
+Hi.
+
+BOB
+Hello.`
+
+	actions := codeActionsFor(t, content)
+
+	var add *protocol.CodeAction
+	for i := range actions {
+		if actions[i].Title == "Add Dramatis Personae section" {
+			add = &actions[i]
+			break
+		}
+	}
+	require.NotNil(t, add, "expected an add-DP-section action")
+
+	edits := add.Edit.Changes[protocol.DocumentURI("file:///test.ds")]
+	require.Len(t, edits, 1)
+
+	assert.True(t, strings.HasPrefix(edits[0].NewText, "## Dramatis Personae\n"), "edit should start with DP heading, got %q", edits[0].NewText)
+	assert.Contains(t, edits[0].NewText, "ALICE")
+	assert.Contains(t, edits[0].NewText, "BOB")
+	// ALICE should come before BOB (first-appearance order).
+	assert.Less(t, strings.Index(edits[0].NewText, "ALICE"), strings.Index(edits[0].NewText, "BOB"))
+}
+
+func TestComputeCodeActions_InsertMissingDramatisPersonae_NoHeading(t *testing.T) {
+	content := `ALICE
+Hi.
+
+BOB
+Hello.`
+
+	actions := codeActionsFor(t, content)
+
+	var add *protocol.CodeAction
+	for i := range actions {
+		if actions[i].Title == "Add Dramatis Personae section" {
+			add = &actions[i]
+			break
+		}
+	}
+	require.NotNil(t, add, "expected an add-DP-section action even without a play heading")
+
+	edits := add.Edit.Changes[protocol.DocumentURI("file:///test.ds")]
+	require.Len(t, edits, 1)
+	// Insertion falls back to the top of the document.
+	assert.Equal(t, uint32(0), edits[0].Range.Start.Line)
+	assert.True(t, strings.HasPrefix(edits[0].NewText, "## Dramatis Personae\n"))
+}

--- a/internal/lsp/dp_cue_diagnostics.go
+++ b/internal/lsp/dp_cue_diagnostics.go
@@ -1,0 +1,285 @@
+package lsp
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jscaltreto/downstage/internal/ast"
+	"go.lsp.dev/protocol"
+)
+
+// checkMissingDramatisPersonae emits a single info diagnostic when a document
+// contains dialogue but no Dramatis Personae section at any level. The
+// diagnostic anchors on the first cue so the author has a visible spot to act
+// on.
+func checkMissingDramatisPersonae(doc *ast.Document, index *documentIndex) []protocol.Diagnostic {
+	if doc == nil || index == nil {
+		return nil
+	}
+	if index.hasDramatisPersonae {
+		return nil
+	}
+	if len(index.dialogues) == 0 {
+		return nil
+	}
+
+	first := index.dialogues[0].dialogue
+	return []protocol.Diagnostic{{
+		Range:    toLSPRange(first.NameRange()),
+		Severity: protocol.DiagnosticSeverityInformation,
+		Code:     diagnosticCodeMissingDramatisPersonae,
+		Source:   "downstage",
+		Message:  "no Dramatis Personae section: add one to document the cast and enable character checks",
+	}}
+}
+
+// checkDPDuplicates flags duplicate entries within a single DP scope. Pure
+// name-vs-name collisions surface as dp-duplicate-character-name; anything
+// involving an alias (alias-vs-alias or alias-vs-name) surfaces as
+// dp-duplicate-alias.
+func checkDPDuplicates(index *documentIndex) []protocol.Diagnostic {
+	if index == nil {
+		return nil
+	}
+
+	var diags []protocol.Diagnostic
+	scopes := collectScopes(index)
+	// Sort the scope traversal by DP line to keep diagnostic order stable
+	// across runs.
+	sort.SliceStable(scopes, func(i, j int) bool {
+		return scopes[i].dp.Range.Start.Line < scopes[j].dp.Range.Start.Line
+	})
+
+	for _, scope := range scopes {
+		nameFlagged := make(map[int]struct{})
+		for key, occurrences := range scope.nameKeyOccurrences {
+			if len(occurrences) < 2 {
+				continue
+			}
+			// First occurrence stays untouched; only 2nd+ are duplicates.
+			for _, entryIdx := range occurrences[1:] {
+				entry := scope.entries[entryIdx]
+				nameFlagged[entryIdx] = struct{}{}
+				diags = append(diags, protocol.Diagnostic{
+					Range:    toLSPRange(entry.character.Range),
+					Severity: protocol.DiagnosticSeverityWarning,
+					Code:     diagnosticCodeDPDuplicateCharacterName,
+					Source:   "downstage",
+					Message:  fmt.Sprintf("duplicate character entry %q in Dramatis Personae", displayName(entry.character.Name, key)),
+					Data: map[string]string{
+						"character": entry.character.Name,
+					},
+				})
+			}
+		}
+
+		for key, occurrences := range scope.aliasKeyOccurrences {
+			if len(occurrences) < 2 {
+				continue
+			}
+			hasAlias := false
+			for _, occ := range occurrences {
+				if occ.aliasIndex >= 0 {
+					hasAlias = true
+					break
+				}
+			}
+			if !hasAlias {
+				// Pure name-vs-name — handled above.
+				continue
+			}
+			for _, occ := range occurrences[1:] {
+				if _, ok := nameFlagged[occ.entryIndex]; ok && occ.aliasIndex == -1 {
+					// Entry's primary name already flagged as a duplicate
+					// character name; don't double-report.
+					continue
+				}
+				entry := scope.entries[occ.entryIndex]
+				label := displayName(entry.character.Name, key)
+				if occ.aliasIndex >= 0 && occ.aliasIndex < len(entry.character.Aliases) {
+					label = entry.character.Aliases[occ.aliasIndex]
+				}
+				diags = append(diags, protocol.Diagnostic{
+					Range:    toLSPRange(entry.character.Range),
+					Severity: protocol.DiagnosticSeverityWarning,
+					Code:     diagnosticCodeDPDuplicateAlias,
+					Source:   "downstage",
+					Message:  fmt.Sprintf("duplicate alias %q collides with another Dramatis Personae entry", label),
+					Data: map[string]string{
+						"alias": label,
+					},
+				})
+			}
+		}
+	}
+
+	return diags
+}
+
+// checkDPCharacterNoDialogue flags DP entries whose name and aliases never
+// appear as a cue within the enclosing play. Info-level, because non-speaking
+// roles are a legitimate authoring pattern.
+func checkDPCharacterNoDialogue(index *documentIndex) []protocol.Diagnostic {
+	if index == nil {
+		return nil
+	}
+
+	var diags []protocol.Diagnostic
+
+	record := func(scope characterScope, used map[string]struct{}) {
+		for _, entry := range scope.entries {
+			if entry.nameKey == "" && len(entry.aliasKeys) == 0 {
+				continue
+			}
+			if hasAnyKey(used, entry.nameKey, entry.aliasKeys) {
+				continue
+			}
+			diags = append(diags, protocol.Diagnostic{
+				Range:    toLSPRange(entry.character.Range),
+				Severity: protocol.DiagnosticSeverityInformation,
+				Code:     diagnosticCodeDPCharacterNoDialogue,
+				Source:   "downstage",
+				Message:  fmt.Sprintf("character %q is in Dramatis Personae but never speaks", entry.character.Name),
+				Data: map[string]string{
+					"character": entry.character.Name,
+				},
+			})
+		}
+	}
+
+	for play, scope := range index.characterScopes {
+		if scope.dp == nil {
+			continue
+		}
+		record(scope, index.usedCharactersByPlay[play])
+	}
+	if index.legacyCharacterScope.dp != nil {
+		// Legacy scope dialogues are bucketed under the nil play key.
+		record(index.legacyCharacterScope, index.usedCharactersByPlay[nil])
+	}
+
+	return diags
+}
+
+// checkOrphanedCues flags character cues that have no dialogue content
+// following them. Covers both the lone orphan at a scene's end and two cues
+// stacked back-to-back with nothing between.
+func checkOrphanedCues(index *documentIndex) []protocol.Diagnostic {
+	if index == nil {
+		return nil
+	}
+
+	var diags []protocol.Diagnostic
+	for _, ref := range index.dialogues {
+		if ref.dialogue == nil {
+			continue
+		}
+		if len(ref.dialogue.Lines) > 0 {
+			continue
+		}
+		diags = append(diags, protocol.Diagnostic{
+			Range:    toLSPRange(ref.dialogue.NameRange()),
+			Severity: protocol.DiagnosticSeverityWarning,
+			Code:     diagnosticCodeCueOrphaned,
+			Source:   "downstage",
+			Message:  fmt.Sprintf("cue %q has no dialogue", ref.dialogue.Character),
+			Data: map[string]string{
+				"character": ref.dialogue.Character,
+			},
+		})
+	}
+	return diags
+}
+
+// checkConsecutiveSameCharacterCues flags two cues for the same character
+// that appear back-to-back within a container (scene, else act, else play)
+// without any intervening structural break (stage direction, callout, song,
+// verse block, page break, dual dialogue, or nested section heading).
+func checkConsecutiveSameCharacterCues(index *documentIndex) []protocol.Diagnostic {
+	if index == nil {
+		return nil
+	}
+
+	// Traverse containers in a stable order so diagnostics are emitted in
+	// document order.
+	containers := make([]*ast.Section, 0, len(index.containerEvents))
+	for container := range index.containerEvents {
+		containers = append(containers, container)
+	}
+	sort.SliceStable(containers, func(i, j int) bool {
+		return containers[i].Range.Start.Line < containers[j].Range.Start.Line
+	})
+
+	var diags []protocol.Diagnostic
+	for _, container := range containers {
+		events := index.containerEvents[container]
+		lastCueKey := ""
+		var lastCueCharacter string
+		for _, ev := range events {
+			switch ev.kind {
+			case containerEventBreak:
+				lastCueKey = ""
+				lastCueCharacter = ""
+			case containerEventCue:
+				key := strings.ToUpper(strings.TrimSpace(ev.character))
+				if key != "" && key == lastCueKey {
+					diags = append(diags, protocol.Diagnostic{
+						Range:    toLSPRange(ev.nameRange),
+						Severity: protocol.DiagnosticSeverityInformation,
+						Code:     diagnosticCodeCueConsecutiveSameCharacter,
+						Source:   "downstage",
+						Message:  fmt.Sprintf("cue %q repeats without an intervening stage direction or break", ev.character),
+						Data: map[string]string{
+							"character":         ev.character,
+							"previousCharacter": lastCueCharacter,
+						},
+					})
+				}
+				lastCueKey = key
+				lastCueCharacter = ev.character
+			}
+		}
+	}
+	return diags
+}
+
+func collectScopes(index *documentIndex) []characterScope {
+	scopes := make([]characterScope, 0, len(index.characterScopes)+1)
+	for _, scope := range index.characterScopes {
+		if scope.dp == nil {
+			continue
+		}
+		scopes = append(scopes, scope)
+	}
+	if index.legacyCharacterScope.dp != nil {
+		scopes = append(scopes, index.legacyCharacterScope)
+	}
+	return scopes
+}
+
+func hasAnyKey(set map[string]struct{}, name string, aliases []string) bool {
+	if set == nil {
+		return false
+	}
+	if name != "" {
+		if _, ok := set[name]; ok {
+			return true
+		}
+	}
+	for _, alias := range aliases {
+		if _, ok := set[alias]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// displayName chooses a readable label for a duplicate diagnostic: the
+// authored name when present, otherwise the uppercase key.
+func displayName(name, fallbackKey string) string {
+	if trimmed := strings.TrimSpace(name); trimmed != "" {
+		return trimmed
+	}
+	return fallbackKey
+}

--- a/internal/lsp/dp_cue_diagnostics.go
+++ b/internal/lsp/dp_cue_diagnostics.go
@@ -9,10 +9,7 @@ import (
 	"go.lsp.dev/protocol"
 )
 
-// checkMissingDramatisPersonae emits a single info diagnostic when a document
-// contains dialogue but no Dramatis Personae section at any level. The
-// diagnostic anchors on the first cue so the author has a visible spot to act
-// on.
+// checkMissingDramatisPersonae reports a document with dialogue but no DP.
 func checkMissingDramatisPersonae(doc *ast.Document, index *documentIndex) []protocol.Diagnostic {
 	if doc == nil || index == nil {
 		return nil
@@ -34,10 +31,7 @@ func checkMissingDramatisPersonae(doc *ast.Document, index *documentIndex) []pro
 	}}
 }
 
-// checkDPDuplicates flags duplicate entries within a single DP scope. Pure
-// name-vs-name collisions surface as dp-duplicate-character-name; anything
-// involving an alias (alias-vs-alias or alias-vs-name) surfaces as
-// dp-duplicate-alias.
+// checkDPDuplicates flags duplicate entries within a single DP scope.
 func checkDPDuplicates(index *documentIndex) []protocol.Diagnostic {
 	if index == nil {
 		return nil
@@ -57,7 +51,6 @@ func checkDPDuplicates(index *documentIndex) []protocol.Diagnostic {
 			if len(occurrences) < 2 {
 				continue
 			}
-			// First occurrence stays untouched; only 2nd+ are duplicates.
 			for _, entryIdx := range occurrences[1:] {
 				entry := scope.entries[entryIdx]
 				nameFlagged[entryIdx] = struct{}{}
@@ -86,13 +79,10 @@ func checkDPDuplicates(index *documentIndex) []protocol.Diagnostic {
 				}
 			}
 			if !hasAlias {
-				// Pure name-vs-name — handled above.
 				continue
 			}
 			for _, occ := range occurrences[1:] {
 				if _, ok := nameFlagged[occ.entryIndex]; ok && occ.aliasIndex == -1 {
-					// Entry's primary name already flagged as a duplicate
-					// character name; don't double-report.
 					continue
 				}
 				entry := scope.entries[occ.entryIndex]
@@ -118,8 +108,7 @@ func checkDPDuplicates(index *documentIndex) []protocol.Diagnostic {
 }
 
 // checkDPCharacterNoDialogue flags DP entries whose name and aliases never
-// appear as a cue within the enclosing play. Info-level, because non-speaking
-// roles are a legitimate authoring pattern.
+// appear as a cue within the enclosing play.
 func checkDPCharacterNoDialogue(index *documentIndex) []protocol.Diagnostic {
 	if index == nil {
 		return nil
@@ -155,9 +144,6 @@ func checkDPCharacterNoDialogue(index *documentIndex) []protocol.Diagnostic {
 		record(scope, index.usedCharactersByPlay[play])
 	}
 	if index.legacyCharacterScope.dp != nil {
-		// A document-level DP covers every dialogue in the file, so union
-		// usage across every play bucket (and the headingless nil bucket)
-		// before deciding whether an entry is unused.
 		union := make(map[string]struct{})
 		for _, bucket := range index.usedCharactersByPlay {
 			for k := range bucket {
@@ -170,9 +156,7 @@ func checkDPCharacterNoDialogue(index *documentIndex) []protocol.Diagnostic {
 	return diags
 }
 
-// checkOrphanedCues flags character cues that have no dialogue content
-// following them. Covers both the lone orphan at a scene's end and two cues
-// stacked back-to-back with nothing between.
+// checkOrphanedCues flags cues that have no dialogue content following them.
 func checkOrphanedCues(index *documentIndex) []protocol.Diagnostic {
 	if index == nil {
 		return nil
@@ -200,17 +184,12 @@ func checkOrphanedCues(index *documentIndex) []protocol.Diagnostic {
 	return diags
 }
 
-// checkConsecutiveSameCharacterCues flags two cues for the same character
-// that appear back-to-back within a container (scene, else act, else play)
-// without any intervening structural break (stage direction, callout, song,
-// verse block, page break, dual dialogue, or nested section heading).
+// checkConsecutiveSameCharacterCues flags repeated cues with no break in between.
 func checkConsecutiveSameCharacterCues(index *documentIndex) []protocol.Diagnostic {
 	if index == nil {
 		return nil
 	}
 
-	// Traverse containers in a stable order so diagnostics are emitted in
-	// document order.
 	containers := make([]*ast.Section, 0, len(index.containerEvents))
 	for container := range index.containerEvents {
 		containers = append(containers, container)

--- a/internal/lsp/dp_cue_diagnostics.go
+++ b/internal/lsp/dp_cue_diagnostics.go
@@ -155,8 +155,16 @@ func checkDPCharacterNoDialogue(index *documentIndex) []protocol.Diagnostic {
 		record(scope, index.usedCharactersByPlay[play])
 	}
 	if index.legacyCharacterScope.dp != nil {
-		// Legacy scope dialogues are bucketed under the nil play key.
-		record(index.legacyCharacterScope, index.usedCharactersByPlay[nil])
+		// A document-level DP covers every dialogue in the file, so union
+		// usage across every play bucket (and the headingless nil bucket)
+		// before deciding whether an entry is unused.
+		union := make(map[string]struct{})
+		for _, bucket := range index.usedCharactersByPlay {
+			for k := range bucket {
+				union[k] = struct{}{}
+			}
+		}
+		record(index.legacyCharacterScope, union)
 	}
 
 	return diags

--- a/internal/lsp/dp_cue_diagnostics_test.go
+++ b/internal/lsp/dp_cue_diagnostics_test.go
@@ -1,0 +1,400 @@
+package lsp
+
+import (
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+)
+
+func parseDoc(t *testing.T, content string) ([]protocol.Diagnostic, []*parser.ParseError) {
+	t.Helper()
+	doc, errs := parser.Parse([]byte(content))
+	return buildDiagnostics(doc, errs), errs
+}
+
+func TestMissingDramatisPersonae_FiresOnceWhenDialogueHasNoDP(t *testing.T) {
+	content := `# Play
+
+## ACT I
+
+### SCENE 1
+
+ALICE
+Hello.
+
+BOB
+Hi.`
+
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+
+	missing := filterDiagnostics(diags, diagnosticCodeMissingDramatisPersonae)
+	require.Len(t, missing, 1, "should fire exactly once even with multiple dialogues")
+	assert.Equal(t, protocol.DiagnosticSeverityInformation, missing[0].Severity)
+}
+
+func TestMissingDramatisPersonae_SuppressedWhenDPPresent(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+
+## ACT I
+
+ALICE
+Hello.`
+
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	missing := filterDiagnostics(diags, diagnosticCodeMissingDramatisPersonae)
+	assert.Empty(t, missing)
+}
+
+func TestMissingDramatisPersonae_SuppressedWhenNoDialogue(t *testing.T) {
+	content := `# Play
+
+Just some prose with no dialogue.
+`
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	missing := filterDiagnostics(diags, diagnosticCodeMissingDramatisPersonae)
+	assert.Empty(t, missing)
+}
+
+func TestDPDuplicateCharacterName_FlagsSecondOccurrence(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+ALICE
+
+## ACT I
+
+ALICE
+Hi.`
+
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	dup := filterDiagnostics(diags, diagnosticCodeDPDuplicateCharacterName)
+	require.Len(t, dup, 1, "only the second ALICE entry should flag")
+	assert.Equal(t, protocol.DiagnosticSeverityWarning, dup[0].Severity)
+	// The flagged line is the second ALICE (0-indexed line 4).
+	assert.Equal(t, uint32(4), dup[0].Range.Start.Line)
+}
+
+func TestDPDuplicateAlias_FlagsAliasVsAlias(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE/AL
+BOB/AL
+
+## ACT I
+
+AL
+Hi.`
+
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	dup := filterDiagnostics(diags, diagnosticCodeDPDuplicateAlias)
+	require.Len(t, dup, 1, "only the second AL alias should flag")
+	assert.Equal(t, protocol.DiagnosticSeverityWarning, dup[0].Severity)
+}
+
+func TestDPDuplicateAlias_FlagsNameCollidingWithAlias(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE/AL
+AL
+
+## ACT I
+
+AL
+Hi.`
+
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	dup := filterDiagnostics(diags, diagnosticCodeDPDuplicateAlias)
+	require.Len(t, dup, 1, "the standalone AL entry should flag as alias collision")
+}
+
+func TestDPDuplicateAlias_NoFalsePositiveOnUnrelatedEntries(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE/AL
+BOB/BEE
+
+## ACT I
+
+AL
+Hi.`
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	dup := filterDiagnostics(diags, diagnosticCodeDPDuplicateAlias, diagnosticCodeDPDuplicateCharacterName)
+	assert.Empty(t, dup)
+}
+
+func TestDPCharacterNoDialogue_InfoOnUnusedDPEntry(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+BOB
+
+## ACT I
+
+ALICE
+Hi.`
+
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	none := filterDiagnostics(diags, diagnosticCodeDPCharacterNoDialogue)
+	require.Len(t, none, 1)
+	assert.Equal(t, protocol.DiagnosticSeverityInformation, none[0].Severity)
+	assert.Contains(t, none[0].Message, "BOB")
+}
+
+func TestDPCharacterNoDialogue_ForcedCueCountsAsUsage(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+
+## ACT I
+
+@ALICE
+Hi.`
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	none := filterDiagnostics(diags, diagnosticCodeDPCharacterNoDialogue)
+	assert.Empty(t, none, "forced cue should satisfy the no-dialogue check")
+}
+
+func TestDPCharacterNoDialogue_AliasSatisfiesCheck(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+PRINCE HAMLET/HAMLET
+
+## ACT I
+
+HAMLET
+Hi.`
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	none := filterDiagnostics(diags, diagnosticCodeDPCharacterNoDialogue)
+	assert.Empty(t, none)
+}
+
+func TestDPCharacterNoDialogue_ScopedPerPlay(t *testing.T) {
+	content := `# First Play
+
+## Dramatis Personae
+ALICE
+
+## ACT I
+
+ALICE
+Hi.
+
+# Second Play
+
+## Dramatis Personae
+ALICE
+
+## ACT I
+
+BOB
+Hi.`
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	none := filterDiagnostics(diags, diagnosticCodeDPCharacterNoDialogue)
+	// Second play's ALICE never speaks.
+	require.Len(t, none, 1)
+	assert.Contains(t, none[0].Message, "ALICE")
+}
+
+func TestCueOrphaned_FlagsCueWithNoLines(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+BOB
+
+## ACT I
+
+### SCENE 1
+
+ALICE
+
+BOB
+Hi.`
+
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	orphans := filterDiagnostics(diags, diagnosticCodeCueOrphaned)
+	require.Len(t, orphans, 1)
+	assert.Equal(t, protocol.DiagnosticSeverityWarning, orphans[0].Severity)
+	assert.Contains(t, orphans[0].Message, "ALICE")
+}
+
+func TestCueOrphaned_SuppressedWhenDialogueFollows(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+
+## ACT I
+
+ALICE
+Hi.`
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	orphans := filterDiagnostics(diags, diagnosticCodeCueOrphaned)
+	assert.Empty(t, orphans)
+}
+
+func TestCueConsecutiveSameCharacter_FlagsRepeatedCue(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+
+## ACT I
+
+### SCENE 1
+
+ALICE
+First line.
+
+ALICE
+Second line.`
+
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	consecutive := filterDiagnostics(diags, diagnosticCodeCueConsecutiveSameCharacter)
+	require.Len(t, consecutive, 1)
+	assert.Equal(t, protocol.DiagnosticSeverityInformation, consecutive[0].Severity)
+}
+
+func TestCueConsecutiveSameCharacter_StageDirectionBreaksChain(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+
+## ACT I
+
+### SCENE 1
+
+ALICE
+First line.
+
+> ALICE paces.
+
+ALICE
+Second line.`
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	consecutive := filterDiagnostics(diags, diagnosticCodeCueConsecutiveSameCharacter)
+	assert.Empty(t, consecutive, "a standalone stage direction between cues should reset the chain")
+}
+
+func TestCueConsecutiveSameCharacter_SceneBoundaryResets(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+
+## ACT I
+
+### SCENE 1
+
+ALICE
+First line.
+
+### SCENE 2
+
+ALICE
+Second line.`
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	consecutive := filterDiagnostics(diags, diagnosticCodeCueConsecutiveSameCharacter)
+	assert.Empty(t, consecutive, "a new scene resets the consecutive-cue check")
+}
+
+func TestCueConsecutiveSameCharacter_DifferentCharactersNotFlagged(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+BOB
+
+## ACT I
+
+### SCENE 1
+
+ALICE
+Hi.
+
+BOB
+Hello.
+
+ALICE
+Hi again.`
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	consecutive := filterDiagnostics(diags, diagnosticCodeCueConsecutiveSameCharacter)
+	assert.Empty(t, consecutive)
+}
+
+func TestCueConsecutiveSameCharacter_PageBreakResets(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+
+## ACT I
+
+### SCENE 1
+
+ALICE
+First line.
+
+===
+
+ALICE
+Second line.`
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	consecutive := filterDiagnostics(diags, diagnosticCodeCueConsecutiveSameCharacter)
+	assert.Empty(t, consecutive, "explicit page break should reset the chain")
+}
+
+func TestCueConsecutiveSameCharacter_CalloutResets(t *testing.T) {
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+
+## ACT I
+
+### SCENE 1
+
+ALICE
+First line.
+
+>> A quick note.
+
+ALICE
+Second line.`
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	consecutive := filterDiagnostics(diags, diagnosticCodeCueConsecutiveSameCharacter)
+	assert.Empty(t, consecutive, ">> note should reset the chain")
+}

--- a/internal/lsp/dp_cue_diagnostics_test.go
+++ b/internal/lsp/dp_cue_diagnostics_test.go
@@ -219,6 +219,35 @@ Hi.`
 	assert.Contains(t, none[0].Message, "ALICE")
 }
 
+func TestDPCharacterNoDialogue_DocLevelDPUnionsUsageAcrossPlays(t *testing.T) {
+	// A V1-style document-level DP with plays declared as top-level
+	// sections. Dialogue gets bucketed under each play, but the DP is
+	// document-wide, so usage must union across all plays — otherwise
+	// every DP entry would get flagged as unused.
+	content := `## Dramatis Personae
+ALICE
+BOB
+
+# First Play
+
+## ACT I
+
+ALICE
+Hi from play one.
+
+# Second Play
+
+## ACT I
+
+BOB
+Hi from play two.`
+
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	none := filterDiagnostics(diags, diagnosticCodeDPCharacterNoDialogue)
+	assert.Empty(t, none, "ALICE and BOB both speak somewhere in the document")
+}
+
 func TestCueOrphaned_FlagsCueWithNoLines(t *testing.T) {
 	content := `# Play
 
@@ -374,6 +403,56 @@ Second line.`
 	require.Empty(t, errs)
 	consecutive := filterDiagnostics(diags, diagnosticCodeCueConsecutiveSameCharacter)
 	assert.Empty(t, consecutive, "explicit page break should reset the chain")
+}
+
+func TestCueConsecutiveSameCharacter_NestedSceneHeadingResets(t *testing.T) {
+	// Act-level container: dialogue before and after a nested scene heading
+	// is structurally separated by the heading, so the chain must reset.
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+
+## ACT I
+
+ALICE
+Outside any scene.
+
+### SCENE 1
+
+ALICE
+Inside the scene.`
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	consecutive := filterDiagnostics(diags, diagnosticCodeCueConsecutiveSameCharacter)
+	assert.Empty(t, consecutive, "a nested scene heading should reset the parent act's consecutive-cue chain")
+}
+
+func TestCueConsecutiveSameCharacter_DualDialogueSameCharacterNotFlagged(t *testing.T) {
+	// Hypothetical but legal: same character on both halves of a dual
+	// block. The author marked simultaneous speech explicitly, so this
+	// should not be treated as back-to-back repeated cues.
+	content := `# Play
+
+## Dramatis Personae
+ALICE
+
+## ACT I
+
+### SCENE 1
+
+ALICE
+First.
+
+ALICE
+Together.
+
+ALICE ^
+Also together.`
+	diags, errs := parseDoc(t, content)
+	require.Empty(t, errs)
+	consecutive := filterDiagnostics(diags, diagnosticCodeCueConsecutiveSameCharacter)
+	assert.Empty(t, consecutive, "dual-dialogue halves must not count as back-to-back repeats")
 }
 
 func TestCueConsecutiveSameCharacter_CalloutResets(t *testing.T) {

--- a/internal/lsp/index.go
+++ b/internal/lsp/index.go
@@ -219,10 +219,15 @@ func newDocumentIndex(doc *ast.Document) *documentIndex {
 		case *ast.DualDialogue:
 			// A DualDialogue breaks the "same character back-to-back" chain
 			// on either side: the author marked simultaneous speech, which
-			// is structurally distinct from a bare consecutive cue.
+			// is structurally distinct from a bare consecutive cue. Also
+			// reset between the two halves so identical left/right cues
+			// (rare but legal) aren't flagged as repeated.
 			container := innerContainer(currentTopLevel, currentAct, currentScene)
 			recordBreak(container, v.Range.Start.Line)
 			walkNode(v.Left, currentTopLevel, currentAct, currentScene)
+			if v.Right != nil {
+				recordBreak(container, v.Right.Range.Start.Line)
+			}
 			walkNode(v.Right, currentTopLevel, currentAct, currentScene)
 			recordBreak(container, v.Range.End.Line)
 		case *ast.StageDirection:
@@ -234,6 +239,14 @@ func newDocumentIndex(doc *ast.Document) *documentIndex {
 		case *ast.VerseBlock:
 			recordBreak(innerContainer(currentTopLevel, currentAct, currentScene), v.Range.Start.Line)
 		case *ast.Section:
+			// Break the parent container's consecutive-cue chain at the
+			// heading line before we descend. Without this, cues bracketing
+			// a nested scene/act heading within the same enclosing
+			// container (e.g. an act that contains dialogue both before
+			// and after a scene it encloses) would chain across the
+			// structural marker.
+			recordBreak(innerContainer(currentTopLevel, currentAct, currentScene), v.Range.Start.Line)
+
 			if v.Level == 1 {
 				currentTopLevel = v
 				currentAct = nil

--- a/internal/lsp/index.go
+++ b/internal/lsp/index.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/jscaltreto/downstage/internal/ast"
+	"github.com/jscaltreto/downstage/internal/token"
 )
 
 type dialogueRef struct {
@@ -16,6 +17,26 @@ type dialogueRef struct {
 type sceneSpeakerCue struct {
 	line int
 	name string
+}
+
+// containerEventKind classifies entries in the per-container event stream
+// used by the cue-consecutive-same-character diagnostic.
+type containerEventKind int
+
+const (
+	containerEventCue containerEventKind = iota
+	// containerEventBreak signals any structural element that severs the
+	// "two cues for the same character, back-to-back" pattern: a standalone
+	// stage direction, callout, song, page break, verse block, or nested
+	// section heading encountered within the container.
+	containerEventBreak
+)
+
+type containerEvent struct {
+	kind      containerEventKind
+	line      int
+	character string
+	nameRange token.Range
 }
 
 type documentIndex struct {
@@ -34,20 +55,31 @@ type documentIndex struct {
 	legacyCharacterScope   characterScope
 	dialogues              []dialogueRef
 	sceneSpeakers          map[*ast.Section][]sceneSpeakerCue
-	hasDramatisPersonae    bool
+	// usedCharactersByPlay maps a top-level play section to the set of
+	// uppercase character keys that appear as cues within it. Populated
+	// during the dialogue walk and consulted by the
+	// dp-character-no-dialogue check. Forced cues count as usage.
+	usedCharactersByPlay map[*ast.Section]map[string]struct{}
+	// containerEvents is an ordered stream of cue + break events keyed by
+	// the nearest enclosing container section (scene, else act, else
+	// top-level play). Drives the cue-consecutive-same-character check.
+	containerEvents     map[*ast.Section][]containerEvent
+	hasDramatisPersonae bool
 }
 
 func newDocumentIndex(doc *ast.Document) *documentIndex {
 	index := &documentIndex{
-		characterCueLines: make(map[int]struct{}),
-		knownCharacters:   make(map[string]struct{}),
-		characterScopes:   make(map[*ast.Section]characterScope),
-		actNumbers:        make(map[*ast.Section]int),
-		sceneSpeakers:     make(map[*ast.Section][]sceneSpeakerCue),
-		sceneActs:         make(map[*ast.Section]*ast.Section),
-		sceneNumbers:      make(map[*ast.Section]int),
-		actPlays:          make(map[*ast.Section]*ast.Section),
-		actsByPlay:        make(map[*ast.Section][]*ast.Section),
+		characterCueLines:    make(map[int]struct{}),
+		knownCharacters:      make(map[string]struct{}),
+		characterScopes:      make(map[*ast.Section]characterScope),
+		actNumbers:           make(map[*ast.Section]int),
+		sceneSpeakers:        make(map[*ast.Section][]sceneSpeakerCue),
+		sceneActs:            make(map[*ast.Section]*ast.Section),
+		sceneNumbers:         make(map[*ast.Section]int),
+		actPlays:             make(map[*ast.Section]*ast.Section),
+		actsByPlay:           make(map[*ast.Section][]*ast.Section),
+		usedCharactersByPlay: make(map[*ast.Section]map[string]struct{}),
+		containerEvents:      make(map[*ast.Section][]containerEvent),
 	}
 	if doc == nil {
 		return index
@@ -107,6 +139,60 @@ func newDocumentIndex(doc *ast.Document) *documentIndex {
 	sceneCountsByAct := make(map[*ast.Section]int)
 	sceneCountsByPlay := make(map[*ast.Section]int)
 
+	// innerContainer picks the most specific container for cue-event
+	// bucketing: scene > act > play. Events in the containerEvents stream
+	// reset at each container boundary by virtue of being keyed per section.
+	innerContainer := func(play, act, scene *ast.Section) *ast.Section {
+		switch {
+		case scene != nil:
+			return scene
+		case act != nil:
+			return act
+		default:
+			return play
+		}
+	}
+
+	// addUsedCharacter records a cue's character name under its enclosing
+	// play. A nil play (dialogue outside any H1) buckets under the nil key,
+	// which the legacy-scope branch of the no-dialogue check consults.
+	addUsedCharacter := func(play *ast.Section, name string) {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			return
+		}
+		key := strings.ToUpper(trimmed)
+		set, ok := index.usedCharactersByPlay[play]
+		if !ok {
+			set = make(map[string]struct{})
+			index.usedCharactersByPlay[play] = set
+		}
+		set[key] = struct{}{}
+	}
+
+	recordBreak := func(container *ast.Section, line int) {
+		if container == nil {
+			return
+		}
+		index.containerEvents[container] = append(index.containerEvents[container], containerEvent{
+			kind: containerEventBreak,
+			line: line,
+		})
+	}
+
+	recordCue := func(container *ast.Section, dlg *ast.Dialogue) {
+		if container == nil {
+			return
+		}
+		nameRange := dlg.NameRange()
+		index.containerEvents[container] = append(index.containerEvents[container], containerEvent{
+			kind:      containerEventCue,
+			line:      nameRange.Start.Line,
+			character: dlg.Character,
+			nameRange: nameRange,
+		})
+	}
+
 	var walkNode func(ast.Node, *ast.Section, *ast.Section, *ast.Section)
 	walkNode = func(node ast.Node, currentTopLevel *ast.Section, currentAct *ast.Section, currentScene *ast.Section) {
 		switch v := node.(type) {
@@ -123,9 +209,30 @@ func newDocumentIndex(doc *ast.Document) *documentIndex {
 					name: v.Character,
 				})
 			}
+			// Track the cue for dp-character-no-dialogue (forced cues count,
+			// per the DP "is the character used in this play" semantic).
+			addUsedCharacter(currentTopLevel, v.Character)
+			for _, part := range splitConjunctionCue(v.Character) {
+				addUsedCharacter(currentTopLevel, part)
+			}
+			recordCue(innerContainer(currentTopLevel, currentAct, currentScene), v)
 		case *ast.DualDialogue:
+			// A DualDialogue breaks the "same character back-to-back" chain
+			// on either side: the author marked simultaneous speech, which
+			// is structurally distinct from a bare consecutive cue.
+			container := innerContainer(currentTopLevel, currentAct, currentScene)
+			recordBreak(container, v.Range.Start.Line)
 			walkNode(v.Left, currentTopLevel, currentAct, currentScene)
 			walkNode(v.Right, currentTopLevel, currentAct, currentScene)
+			recordBreak(container, v.Range.End.Line)
+		case *ast.StageDirection:
+			recordBreak(innerContainer(currentTopLevel, currentAct, currentScene), v.Range.Start.Line)
+		case *ast.Callout:
+			recordBreak(innerContainer(currentTopLevel, currentAct, currentScene), v.Range.Start.Line)
+		case *ast.PageBreak:
+			recordBreak(innerContainer(currentTopLevel, currentAct, currentScene), v.Range.Start.Line)
+		case *ast.VerseBlock:
+			recordBreak(innerContainer(currentTopLevel, currentAct, currentScene), v.Range.Start.Line)
 		case *ast.Section:
 			if v.Level == 1 {
 				currentTopLevel = v
@@ -158,9 +265,15 @@ func newDocumentIndex(doc *ast.Document) *documentIndex {
 				walkNode(child, currentTopLevel, currentAct, currentScene)
 			}
 		case *ast.Song:
+			// A Song is itself a structural container distinct from dialogue
+			// prose, so treat the surrounding boundary as a break but still
+			// descend to track cues inside.
+			container := innerContainer(currentTopLevel, currentAct, currentScene)
+			recordBreak(container, v.Range.Start.Line)
 			for _, child := range v.Content {
 				walkNode(child, currentTopLevel, currentAct, currentScene)
 			}
+			recordBreak(container, v.Range.End.Line)
 		}
 	}
 

--- a/internal/lsp/index.go
+++ b/internal/lsp/index.go
@@ -19,16 +19,10 @@ type sceneSpeakerCue struct {
 	name string
 }
 
-// containerEventKind classifies entries in the per-container event stream
-// used by the cue-consecutive-same-character diagnostic.
 type containerEventKind int
 
 const (
 	containerEventCue containerEventKind = iota
-	// containerEventBreak signals any structural element that severs the
-	// "two cues for the same character, back-to-back" pattern: a standalone
-	// stage direction, callout, song, page break, verse block, or nested
-	// section heading encountered within the container.
 	containerEventBreak
 )
 
@@ -55,16 +49,9 @@ type documentIndex struct {
 	legacyCharacterScope   characterScope
 	dialogues              []dialogueRef
 	sceneSpeakers          map[*ast.Section][]sceneSpeakerCue
-	// usedCharactersByPlay maps a top-level play section to the set of
-	// uppercase character keys that appear as cues within it. Populated
-	// during the dialogue walk and consulted by the
-	// dp-character-no-dialogue check. Forced cues count as usage.
-	usedCharactersByPlay map[*ast.Section]map[string]struct{}
-	// containerEvents is an ordered stream of cue + break events keyed by
-	// the nearest enclosing container section (scene, else act, else
-	// top-level play). Drives the cue-consecutive-same-character check.
-	containerEvents     map[*ast.Section][]containerEvent
-	hasDramatisPersonae bool
+	usedCharactersByPlay   map[*ast.Section]map[string]struct{}
+	containerEvents        map[*ast.Section][]containerEvent
+	hasDramatisPersonae    bool
 }
 
 func newDocumentIndex(doc *ast.Document) *documentIndex {
@@ -139,9 +126,6 @@ func newDocumentIndex(doc *ast.Document) *documentIndex {
 	sceneCountsByAct := make(map[*ast.Section]int)
 	sceneCountsByPlay := make(map[*ast.Section]int)
 
-	// innerContainer picks the most specific container for cue-event
-	// bucketing: scene > act > play. Events in the containerEvents stream
-	// reset at each container boundary by virtue of being keyed per section.
 	innerContainer := func(play, act, scene *ast.Section) *ast.Section {
 		switch {
 		case scene != nil:
@@ -153,9 +137,6 @@ func newDocumentIndex(doc *ast.Document) *documentIndex {
 		}
 	}
 
-	// addUsedCharacter records a cue's character name under its enclosing
-	// play. A nil play (dialogue outside any H1) buckets under the nil key,
-	// which the legacy-scope branch of the no-dialogue check consults.
 	addUsedCharacter := func(play *ast.Section, name string) {
 		trimmed := strings.TrimSpace(name)
 		if trimmed == "" {
@@ -217,11 +198,6 @@ func newDocumentIndex(doc *ast.Document) *documentIndex {
 			}
 			recordCue(innerContainer(currentTopLevel, currentAct, currentScene), v)
 		case *ast.DualDialogue:
-			// A DualDialogue breaks the "same character back-to-back" chain
-			// on either side: the author marked simultaneous speech, which
-			// is structurally distinct from a bare consecutive cue. Also
-			// reset between the two halves so identical left/right cues
-			// (rare but legal) aren't flagged as repeated.
 			container := innerContainer(currentTopLevel, currentAct, currentScene)
 			recordBreak(container, v.Range.Start.Line)
 			walkNode(v.Left, currentTopLevel, currentAct, currentScene)
@@ -239,12 +215,6 @@ func newDocumentIndex(doc *ast.Document) *documentIndex {
 		case *ast.VerseBlock:
 			recordBreak(innerContainer(currentTopLevel, currentAct, currentScene), v.Range.Start.Line)
 		case *ast.Section:
-			// Break the parent container's consecutive-cue chain at the
-			// heading line before we descend. Without this, cues bracketing
-			// a nested scene/act heading within the same enclosing
-			// container (e.g. an act that contains dialogue both before
-			// and after a scene it encloses) would chain across the
-			// structural marker.
 			recordBreak(innerContainer(currentTopLevel, currentAct, currentScene), v.Range.Start.Line)
 
 			if v.Level == 1 {
@@ -278,9 +248,6 @@ func newDocumentIndex(doc *ast.Document) *documentIndex {
 				walkNode(child, currentTopLevel, currentAct, currentScene)
 			}
 		case *ast.Song:
-			// A Song is itself a structural container distinct from dialogue
-			// prose, so treat the surrounding boundary as a break but still
-			// descend to track cues inside.
 			container := innerContainer(currentTopLevel, currentAct, currentScene)
 			recordBreak(container, v.Range.Start.Line)
 			for _, child := range v.Content {

--- a/internal/lsp/scope.go
+++ b/internal/lsp/scope.go
@@ -10,12 +10,40 @@ type characterScope struct {
 	dp    *ast.Section
 	names []string
 	known map[string]struct{}
+	// entries preserves DP entry order with per-entry key data for
+	// duplicate detection and no-dialogue tracking. Each entry corresponds
+	// to one Character row in the DP section.
+	entries []scopeEntry
+	// nameKeyOccurrences maps uppercase name key → entries whose primary
+	// name matches. A second occurrence is a duplicate primary name.
+	nameKeyOccurrences map[string][]int
+	// aliasKeyOccurrences maps uppercase key → entries whose alias (or
+	// primary name) matches. Collisions across entries flag duplicate
+	// aliases, including name-vs-alias collisions.
+	aliasKeyOccurrences map[string][]aliasOccurrence
+}
+
+type scopeEntry struct {
+	character ast.Character
+	// nameKey is the uppercase primary name.
+	nameKey string
+	// aliasKeys are uppercase alias keys (not including the primary name).
+	aliasKeys []string
+}
+
+type aliasOccurrence struct {
+	entryIndex int
+	// aliasIndex is the position of the alias within the entry's Aliases
+	// slice, or -1 when the occurrence is the entry's primary name.
+	aliasIndex int
 }
 
 func newCharacterScope(dp *ast.Section) characterScope {
 	scope := characterScope{
-		dp:    dp,
-		known: make(map[string]struct{}),
+		dp:                  dp,
+		known:               make(map[string]struct{}),
+		nameKeyOccurrences:  make(map[string][]int),
+		aliasKeyOccurrences: make(map[string][]aliasOccurrence),
 	}
 	if dp == nil {
 		return scope
@@ -40,6 +68,26 @@ func newCharacterScope(dp *ast.Section) characterScope {
 		addName(ch.Name)
 		for _, alias := range ch.Aliases {
 			addName(alias)
+		}
+
+		entry := scopeEntry{character: ch}
+		if trimmed := strings.TrimSpace(ch.Name); trimmed != "" {
+			entry.nameKey = strings.ToUpper(trimmed)
+		}
+		for _, alias := range ch.Aliases {
+			if trimmed := strings.TrimSpace(alias); trimmed != "" {
+				entry.aliasKeys = append(entry.aliasKeys, strings.ToUpper(trimmed))
+			}
+		}
+		scope.entries = append(scope.entries, entry)
+
+		entryIdx := len(scope.entries) - 1
+		if entry.nameKey != "" {
+			scope.nameKeyOccurrences[entry.nameKey] = append(scope.nameKeyOccurrences[entry.nameKey], entryIdx)
+			scope.aliasKeyOccurrences[entry.nameKey] = append(scope.aliasKeyOccurrences[entry.nameKey], aliasOccurrence{entryIndex: entryIdx, aliasIndex: -1})
+		}
+		for i, key := range entry.aliasKeys {
+			scope.aliasKeyOccurrences[key] = append(scope.aliasKeyOccurrences[key], aliasOccurrence{entryIndex: entryIdx, aliasIndex: i})
 		}
 	}
 

--- a/web/src/__tests__/IssuesDrawer.test.ts
+++ b/web/src/__tests__/IssuesDrawer.test.ts
@@ -82,6 +82,62 @@ describe("IssuesDrawer", () => {
     expect(text).toMatch(/1/);
   });
 
+  it("emits hidden-severities updates when a pill is clicked; hidden pills fade and filter the list", async () => {
+    const diagnostics: EditorDiagnostic[] = [
+      mk({ severity: "error", message: "boom" }),
+      mk({ severity: "warning", message: "stray text" }),
+      mk({ severity: "info", message: "a hint" }),
+    ];
+
+    const wrapper = mount(IssuesDrawer, {
+      props: { diagnostics, open: true, hiddenSeverities: new Set() },
+    });
+
+    expect(wrapper.findAll("li")).toHaveLength(3);
+
+    const infoPill = wrapper
+      .findAll("button")
+      .find((b) => (b.attributes("title") ?? "").includes("info issue"));
+    expect(infoPill).toBeTruthy();
+    expect(infoPill!.attributes("aria-pressed")).toBe("true");
+
+    await infoPill!.trigger("click");
+
+    const updates = wrapper.emitted("update:hiddenSeverities") as Array<[Set<string>]>;
+    expect(updates).toBeTruthy();
+    const nextSet = updates[updates.length - 1][0];
+    expect(Array.from(nextSet)).toEqual(["info"]);
+
+    // Simulate the parent applying the new value.
+    await wrapper.setProps({ hiddenSeverities: nextSet });
+
+    expect(infoPill!.attributes("aria-pressed")).toBe("false");
+    expect(infoPill!.classes()).toContain("opacity-40");
+    const rowsText = wrapper.findAll("li").map((li) => li.text());
+    expect(rowsText.some((t) => t.includes("a hint"))).toBe(false);
+    expect(rowsText.some((t) => t.includes("boom"))).toBe(true);
+    expect(rowsText.some((t) => t.includes("stray text"))).toBe(true);
+
+    // Clicking again clears the set.
+    await infoPill!.trigger("click");
+    const allEmits = wrapper.emitted("update:hiddenSeverities") as Array<[Set<string>]>;
+    const nextNext = allEmits[allEmits.length - 1][0];
+    expect(Array.from(nextNext)).toEqual([]);
+    await wrapper.setProps({ hiddenSeverities: nextNext });
+    expect(infoPill!.attributes("aria-pressed")).toBe("true");
+    expect(wrapper.findAll("li")).toHaveLength(3);
+  });
+
+  it("shows a 'all matching issues hidden' state when every pill is toggled off", async () => {
+    const diagnostics: EditorDiagnostic[] = [mk({ severity: "warning", message: "x" })];
+    const wrapper = mount(IssuesDrawer, {
+      props: { diagnostics, open: true, hiddenSeverities: new Set(["warning"]) },
+    });
+
+    expect(wrapper.findAll("li")).toHaveLength(0);
+    expect(wrapper.text()).toContain("All matching issues hidden");
+  });
+
   it("collapses the section to zero height when closed", () => {
     const wrapper = mount(IssuesDrawer, {
       props: { diagnostics: [], open: false },

--- a/web/src/__tests__/issues.test.ts
+++ b/web/src/__tests__/issues.test.ts
@@ -102,8 +102,13 @@ describe("issuesStatus", () => {
     expect(issuesStatus({ errors: 1, warnings: 5, infos: 0, hints: 0, total: 6 })).toBe("error");
   });
 
-  it("reports warning when only non-error diagnostics exist", () => {
+  it("reports warning when warnings are present without errors", () => {
     expect(issuesStatus({ errors: 0, warnings: 2, infos: 1, hints: 0, total: 3 })).toBe("warning");
+  });
+
+  it("reports info when only infos or hints are present", () => {
+    expect(issuesStatus({ errors: 0, warnings: 0, infos: 1, hints: 0, total: 1 })).toBe("info");
+    expect(issuesStatus({ errors: 0, warnings: 0, infos: 0, hints: 2, total: 2 })).toBe("info");
   });
 
   it("reports clean when nothing is present", () => {

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -3,10 +3,11 @@ import { computed, onMounted, onUnmounted, ref, watch, inject, nextTick } from '
 import {
     Bold, Italic, Underline, MessageSquare, ChevronRight,
     GalleryVerticalEnd, GalleryVertical, FilePlus2, Eye, EyeOff, HelpCircle, X, Music,
-    Sun, Moon, ScrollText, BookOpenText, AlertTriangle, AlertCircle, RefreshCw, SpellCheck, Trash2, CheckCircle2
+    Sun, Moon, ScrollText, BookOpenText, AlertTriangle, AlertCircle, Info, RefreshCw, SpellCheck, Trash2, CheckCircle2
 } from 'lucide-vue-next';
 import { Engine } from '../../core/engine';
 import { issuesStatus, summarizeIssues } from '../../core/issues';
+import type { FilterSeverity } from '../../core/issues';
 import type { Store } from '../../core/store';
 import type { EditorDiagnostic, EditorEnv } from '../../core/types';
 import PreviewFrame from './PreviewFrame.vue';
@@ -40,8 +41,29 @@ const previewVisible = ref(localStorage.getItem("downstage-editor-preview-hidden
 const spellcheckEnabled = ref(localStorage.getItem("downstage-editor-spellcheck-disabled") !== "true");
 const issuesDrawerOpen = ref(false);
 const diagnostics = ref<EditorDiagnostic[]>([]);
-const issuesSummary = computed(() => summarizeIssues(diagnostics.value));
+const hiddenSeverities = ref<ReadonlySet<FilterSeverity>>(new Set());
+// FAB-facing summary: drop diagnostics the author has hidden so the badge
+// and color reflect what's actually surfaced in the editor. The drawer
+// still gets the full list for its pill counts.
+const visibleDiagnostics = computed(() =>
+  diagnostics.value.filter((d) => {
+    if (d.severity === 'error') return !hiddenSeverities.value.has('error');
+    if (d.severity === 'warning') return !hiddenSeverities.value.has('warning');
+    return !hiddenSeverities.value.has('info');
+  }),
+);
+const issuesSummary = computed(() => summarizeIssues(visibleDiagnostics.value));
 const issuesStatusValue = computed(() => issuesStatus(issuesSummary.value));
+// Class list applied to the editor container so CSS can hide CM markers
+// and tooltips for severities the author toggled off. Keeping the
+// unfiltered diagnostics in CM state preserves accurate pill counts.
+const editorHideClasses = computed(() => {
+  const classes: string[] = [];
+  if (hiddenSeverities.value.has('error')) classes.push('cm-hide-error');
+  if (hiddenSeverities.value.has('warning')) classes.push('cm-hide-warning');
+  if (hiddenSeverities.value.has('info')) classes.push('cm-hide-info');
+  return classes;
+});
 const showSpellcheckModal = ref(false);
 const dictionaryWord = ref("");
 const spellAllowlist = computed(() => props.getSpellAllowlist());
@@ -289,7 +311,7 @@ function jumpToDiagnostic(d: EditorDiagnostic) {
     <div class="flex-1 flex overflow-hidden relative">
         <div class="flex-1 h-full flex flex-col border-r border-border bg-[var(--color-page-bg)]">
             <div class="flex-1 relative overflow-hidden">
-                <div ref="editorContainer" class="absolute inset-0 overflow-hidden"></div>
+                <div ref="editorContainer" :class="['absolute inset-0 overflow-hidden', ...editorHideClasses]"></div>
 
                 <div
                     v-if="!issuesDrawerOpen"
@@ -301,12 +323,14 @@ function jumpToDiagnostic(d: EditorDiagnostic) {
                         class="flex items-center gap-2 rounded-full px-4 h-10 text-sm font-bold shadow-2xl transition-all hover:scale-105"
                         :class="{
                             'bg-emerald-500 text-white hover:bg-emerald-600': issuesStatusValue === 'clean',
+                            'bg-purple-200 text-purple-950 hover:bg-purple-300': issuesStatusValue === 'info',
                             'bg-amber-500 text-ember-950 hover:bg-amber-400': issuesStatusValue === 'warning',
                             'bg-red-500 text-white hover:bg-red-600': issuesStatusValue === 'error',
                         }"
                         :title="issuesStatusValue === 'clean' ? 'No script issues' : `${issuesSummary.total} script issue${issuesSummary.total === 1 ? '' : 's'}`"
                     >
                         <CheckCircle2 v-if="issuesStatusValue === 'clean'" class="w-4 h-4" />
+                        <Info v-else-if="issuesStatusValue === 'info'" class="w-4 h-4" />
                         <AlertTriangle v-else-if="issuesStatusValue === 'warning'" class="w-4 h-4" />
                         <AlertCircle v-else class="w-4 h-4" />
                         <span>{{ issuesStatusValue === 'clean' ? 'No script issues' : `${issuesSummary.total} script issue${issuesSummary.total === 1 ? '' : 's'}` }}</span>
@@ -326,8 +350,10 @@ function jumpToDiagnostic(d: EditorDiagnostic) {
             <IssuesDrawer
                 :diagnostics="diagnostics"
                 :open="issuesDrawerOpen"
+                :hidden-severities="hiddenSeverities"
                 @close="issuesDrawerOpen = false"
                 @jump="jumpToDiagnostic"
+                @update:hidden-severities="hiddenSeverities = $event"
             />
         </div>
 

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -42,9 +42,6 @@ const spellcheckEnabled = ref(localStorage.getItem("downstage-editor-spellcheck-
 const issuesDrawerOpen = ref(false);
 const diagnostics = ref<EditorDiagnostic[]>([]);
 const hiddenSeverities = ref<ReadonlySet<FilterSeverity>>(new Set());
-// FAB-facing summary: drop diagnostics the author has hidden so the badge
-// and color reflect what's actually surfaced in the editor. The drawer
-// still gets the full list for its pill counts.
 const visibleDiagnostics = computed(() =>
   diagnostics.value.filter((d) => {
     if (d.severity === 'error') return !hiddenSeverities.value.has('error');
@@ -54,9 +51,6 @@ const visibleDiagnostics = computed(() =>
 );
 const issuesSummary = computed(() => summarizeIssues(visibleDiagnostics.value));
 const issuesStatusValue = computed(() => issuesStatus(issuesSummary.value));
-// Class list applied to the editor container so CSS can hide CM markers
-// and tooltips for severities the author toggled off. Keeping the
-// unfiltered diagnostics in CM state preserves accurate pill counts.
 const editorHideClasses = computed(() => {
   const classes: string[] = [];
   if (hiddenSeverities.value.has('error')) classes.push('cm-hide-error');

--- a/web/src/components/shared/IssuesDrawer.vue
+++ b/web/src/components/shared/IssuesDrawer.vue
@@ -22,8 +22,6 @@ const emit = defineEmits<{
 
 const summary = computed(() => summarizeIssues(props.diagnostics));
 
-// Pills drive a parent-held "hidden severities" set. Clicking a pill emits
-// the updated set so the parent can also filter CM markers.
 function isHidden(kind: FilterSeverity): boolean {
   return props.hiddenSeverities.has(kind);
 }
@@ -54,7 +52,6 @@ const visibleDiagnostics = computed(() =>
   props.diagnostics.filter((d) => {
     if (d.severity === 'error') return !isHidden('error');
     if (d.severity === 'warning') return !isHidden('warning');
-    // Info + hint share a pill, so they share a filter toggle.
     return !isHidden('info');
   }),
 );

--- a/web/src/components/shared/IssuesDrawer.vue
+++ b/web/src/components/shared/IssuesDrawer.vue
@@ -3,18 +3,61 @@ import { computed } from 'vue';
 import { AlertCircle, AlertTriangle, CheckCircle2, Info, X } from 'lucide-vue-next';
 import type { EditorDiagnostic } from '../../core/types';
 import { summarizeIssues } from '../../core/issues';
+import type { FilterSeverity } from '../../core/issues';
 
-const props = defineProps<{
-  diagnostics: EditorDiagnostic[];
-  open: boolean;
-}>();
+const props = withDefaults(
+  defineProps<{
+    diagnostics: EditorDiagnostic[];
+    open: boolean;
+    hiddenSeverities?: ReadonlySet<FilterSeverity>;
+  }>(),
+  { hiddenSeverities: () => new Set() },
+);
 
 const emit = defineEmits<{
   (e: 'close'): void;
   (e: 'jump', diagnostic: EditorDiagnostic): void;
+  (e: 'update:hiddenSeverities', next: ReadonlySet<FilterSeverity>): void;
 }>();
 
 const summary = computed(() => summarizeIssues(props.diagnostics));
+
+// Pills drive a parent-held "hidden severities" set. Clicking a pill emits
+// the updated set so the parent can also filter CM markers.
+function isHidden(kind: FilterSeverity): boolean {
+  return props.hiddenSeverities.has(kind);
+}
+
+function toggleSeverity(kind: FilterSeverity) {
+  const next = new Set(props.hiddenSeverities);
+  if (next.has(kind)) next.delete(kind);
+  else next.add(kind);
+  emit('update:hiddenSeverities', next);
+}
+
+function pluralize(n: number, label: string): string {
+  return `${n} ${label}${n === 1 ? '' : 's'}`;
+}
+
+const errorTitle = computed(() =>
+  `${pluralize(summary.value.errors, 'error')} — click to ${isHidden('error') ? 'show' : 'hide'}`,
+);
+const warningTitle = computed(() =>
+  `${pluralize(summary.value.warnings, 'warning')} — click to ${isHidden('warning') ? 'show' : 'hide'}`,
+);
+const infoTitle = computed(() => {
+  const count = summary.value.infos + summary.value.hints;
+  return `${pluralize(count, 'info issue')} — click to ${isHidden('info') ? 'show' : 'hide'}`;
+});
+
+const visibleDiagnostics = computed(() =>
+  props.diagnostics.filter((d) => {
+    if (d.severity === 'error') return !isHidden('error');
+    if (d.severity === 'warning') return !isHidden('warning');
+    // Info + hint share a pill, so they share a filter toggle.
+    return !isHidden('info');
+  }),
+);
 
 function severityLabel(d: EditorDiagnostic) {
   if (d.severity === 'error') return 'Error';
@@ -37,15 +80,39 @@ function severityLabel(d: EditorDiagnostic) {
         <div class="flex items-center gap-3">
           <h2 class="text-[10px] font-bold uppercase tracking-[0.2em] text-accent">Script Issues</h2>
           <div class="flex items-center gap-2 text-xs font-medium text-text-muted">
-            <span v-if="summary.errors > 0" class="flex items-center gap-1 rounded-full bg-red-500/15 px-2 py-0.5 text-red-600 dark:text-red-400">
+            <button
+              v-if="summary.errors > 0"
+              type="button"
+              class="flex items-center gap-1 rounded-full bg-red-500/15 px-2 py-0.5 text-red-600 transition-opacity hover:opacity-100 dark:text-red-400"
+              :class="{ 'opacity-40': isHidden('error') }"
+              :title="errorTitle"
+              :aria-pressed="!isHidden('error')"
+              @click="toggleSeverity('error')"
+            >
               <AlertCircle class="h-3 w-3" /> {{ summary.errors }}
-            </span>
-            <span v-if="summary.warnings > 0" class="flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-amber-700 dark:text-amber-400">
+            </button>
+            <button
+              v-if="summary.warnings > 0"
+              type="button"
+              class="flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-amber-700 transition-opacity hover:opacity-100 dark:text-amber-400"
+              :class="{ 'opacity-40': isHidden('warning') }"
+              :title="warningTitle"
+              :aria-pressed="!isHidden('warning')"
+              @click="toggleSeverity('warning')"
+            >
               <AlertTriangle class="h-3 w-3" /> {{ summary.warnings }}
-            </span>
-            <span v-if="summary.infos + summary.hints > 0" class="flex items-center gap-1 rounded-full bg-black/5 px-2 py-0.5 dark:bg-white/10">
+            </button>
+            <button
+              v-if="summary.infos + summary.hints > 0"
+              type="button"
+              class="flex items-center gap-1 rounded-full bg-purple-500/15 px-2 py-0.5 text-purple-700 transition-opacity hover:opacity-100 dark:text-purple-300"
+              :class="{ 'opacity-40': isHidden('info') }"
+              :title="infoTitle"
+              :aria-pressed="!isHidden('info')"
+              @click="toggleSeverity('info')"
+            >
               <Info class="h-3 w-3" /> {{ summary.infos + summary.hints }}
-            </span>
+            </button>
             <span v-if="summary.total === 0" class="text-[10px] uppercase tracking-wider text-text-muted">All clear</span>
           </div>
         </div>
@@ -70,9 +137,9 @@ function severityLabel(d: EditorDiagnostic) {
         <p class="text-xs">The script is clean.</p>
       </div>
 
-      <ul v-else class="flex-1 divide-y divide-border overflow-y-auto">
+      <ul v-else-if="visibleDiagnostics.length > 0" class="flex-1 divide-y divide-border overflow-y-auto">
         <li
-          v-for="(d, index) in diagnostics"
+          v-for="(d, index) in visibleDiagnostics"
           :key="`${d.from}-${d.to}-${index}`"
           class="group cursor-pointer px-4 py-2 transition-colors hover:bg-black/5 dark:hover:bg-white/5"
           tabindex="0"
@@ -86,7 +153,7 @@ function severityLabel(d: EditorDiagnostic) {
             <span class="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center">
               <AlertCircle v-if="d.severity === 'error'" class="h-4 w-4 text-red-500" />
               <AlertTriangle v-else-if="d.severity === 'warning'" class="h-4 w-4 text-amber-500" />
-              <Info v-else class="h-4 w-4 text-text-muted" />
+              <Info v-else class="h-4 w-4 text-purple-600 dark:text-purple-300" />
             </span>
             <span class="shrink-0 font-mono text-[11px] text-text-muted tabular-nums">{{ d.line }}:{{ d.col }}</span>
             <span class="flex-1 text-sm leading-snug text-text-main line-clamp-2">{{ d.message }}</span>
@@ -97,5 +164,13 @@ function severityLabel(d: EditorDiagnostic) {
           </div>
         </li>
       </ul>
+
+      <div
+        v-else
+        class="flex flex-1 flex-col items-center justify-center gap-1 px-6 text-center text-text-muted"
+      >
+        <p class="text-sm font-medium text-text-main">All matching issues hidden</p>
+        <p class="text-xs">Click a pill to show its issues.</p>
+      </div>
   </section>
 </template>

--- a/web/src/core/issues.ts
+++ b/web/src/core/issues.ts
@@ -45,10 +45,16 @@ export function summarizeIssues(items: readonly EditorDiagnostic[]): IssuesSumma
   return summary;
 }
 
-export type IssuesStatus = "clean" | "warning" | "error";
+export type IssuesStatus = "clean" | "info" | "warning" | "error";
+
+// FilterSeverity is the set of severities the IssuesDrawer pills can toggle.
+// Info and hint diagnostics share a single pill (and therefore a single
+// filter bucket), so there's no separate "hint" here.
+export type FilterSeverity = "error" | "warning" | "info";
 
 export function issuesStatus(summary: IssuesSummary): IssuesStatus {
   if (summary.errors > 0) return "error";
-  if (summary.warnings > 0 || summary.infos > 0 || summary.hints > 0) return "warning";
+  if (summary.warnings > 0) return "warning";
+  if (summary.infos > 0 || summary.hints > 0) return "info";
   return "clean";
 }

--- a/web/src/main.css
+++ b/web/src/main.css
@@ -107,8 +107,6 @@
   text-decoration-skip-ink: none;
 }
 
-/* Info-severity squiggly: saturated purple, distinct from the muted
-   purple used on the FAB and pill. */
 .cm-lintRange.cm-lintRange-info {
   background-image: none !important;
   text-decoration: underline wavy #7c3aed;
@@ -119,8 +117,6 @@
   text-decoration-skip-ink: none;
 }
 
-/* Match info severity in the lint tooltip panel: CodeMirror's default
-   sets a grey border-left on .cm-diagnostic-info. */
 .cm-diagnostic-info {
   border-left-color: #7c3aed !important;
 }
@@ -128,14 +124,6 @@
   border-left-color: #a78bfa !important;
 }
 
-/* Severity-hide classes: applied to the editor host div by the Vue layer
-   when the author toggles a pill off. CSS strips the underline and
-   pointer-events so the marker vanishes and its tooltip never opens,
-   without removing the diagnostic from CodeMirror state (so pill counts
-   stay accurate). */
-/* cm-spellcheckRange excluded from the warning-hide rule: spellcheck uses
-   severity=warning but is semantically independent from Downstage lint
-   warnings and should stay visible when the author hides warnings. */
 .cm-hide-error .cm-lintRange-error,
 .cm-hide-warning .cm-lintRange-warning:not(.cm-spellcheckRange),
 .cm-hide-info .cm-lintRange-info,
@@ -144,12 +132,6 @@
   text-decoration: none !important;
   pointer-events: none !important;
 }
-/* Tooltip hide rules: pointer-events:none on the marker already prevents
-   hover on hidden-only ranges, so these only matter for ranges that
-   overlap a visible diagnostic. We intentionally do NOT hide the warning
-   tooltip when warnings are hidden, because CodeMirror's tooltip LIs
-   don't carry the markClass and we can't distinguish spellcheck from
-   lint here. */
 .cm-hide-error .cm-diagnostic-error,
 .cm-hide-info .cm-diagnostic-info,
 .cm-hide-info .cm-diagnostic-hint {

--- a/web/src/main.css
+++ b/web/src/main.css
@@ -107,6 +107,55 @@
   text-decoration-skip-ink: none;
 }
 
+/* Info-severity squiggly: saturated purple, distinct from the muted
+   purple used on the FAB and pill. */
+.cm-lintRange.cm-lintRange-info {
+  background-image: none !important;
+  text-decoration: underline wavy #7c3aed;
+  text-decoration-skip-ink: none;
+}
+.dark .cm-lintRange.cm-lintRange-info {
+  text-decoration: underline wavy #a78bfa;
+  text-decoration-skip-ink: none;
+}
+
+/* Match info severity in the lint tooltip panel: CodeMirror's default
+   sets a grey border-left on .cm-diagnostic-info. */
+.cm-diagnostic-info {
+  border-left-color: #7c3aed !important;
+}
+.dark .cm-diagnostic-info {
+  border-left-color: #a78bfa !important;
+}
+
+/* Severity-hide classes: applied to the editor host div by the Vue layer
+   when the author toggles a pill off. CSS strips the underline and
+   pointer-events so the marker vanishes and its tooltip never opens,
+   without removing the diagnostic from CodeMirror state (so pill counts
+   stay accurate). */
+/* cm-spellcheckRange excluded from the warning-hide rule: spellcheck uses
+   severity=warning but is semantically independent from Downstage lint
+   warnings and should stay visible when the author hides warnings. */
+.cm-hide-error .cm-lintRange-error,
+.cm-hide-warning .cm-lintRange-warning:not(.cm-spellcheckRange),
+.cm-hide-info .cm-lintRange-info,
+.cm-hide-info .cm-lintRange-hint {
+  background-image: none !important;
+  text-decoration: none !important;
+  pointer-events: none !important;
+}
+/* Tooltip hide rules: pointer-events:none on the marker already prevents
+   hover on hidden-only ranges, so these only matter for ranges that
+   overlap a visible diagnostic. We intentionally do NOT hide the warning
+   tooltip when warnings are hidden, because CodeMirror's tooltip LIs
+   don't carry the markClass and we can't distinguish spellcheck from
+   lint here. */
+.cm-hide-error .cm-diagnostic-error,
+.cm-hide-info .cm-diagnostic-info,
+.cm-hide-info .cm-diagnostic-hint {
+  display: none !important;
+}
+
 /* Custom Scrollbar */
 .custom-scrollbar::-webkit-scrollbar { width: 6px; height: 6px; }
 .custom-scrollbar::-webkit-scrollbar-track { background: transparent; }


### PR DESCRIPTION
## Summary

Implements the diagnostic coverage proposed in #145 and surfaces the new info tier in the web editor.

### New LSP diagnostics (scoped per top-level play)

- \`missing-dramatis-personae\` (info)
- \`dp-character-no-dialogue\` (info)
- \`dp-duplicate-character-name\` (warning)
- \`dp-duplicate-alias\` (warning)
- \`cue-orphaned\` (warning)
- \`cue-consecutive-same-character\` (info)

Forced cues count as usage for the no-dialogue check, matching the spec's forced-cue semantics. The consecutive-cue chain resets on stage directions, callouts, songs, page breaks, verse blocks, dual-dialogue blocks (and between their halves), and nested section headings.

### New code actions

- Delete a duplicate Dramatis Personae row
- Insert a \`## Dramatis Personae\` section seeded from observed cues, placed after any existing metadata block so title-page / play metadata stays attached to its heading

Judgment-heavy diagnostics (consecutive same-character, unused DP entry, orphaned cue, duplicate alias) are diagnostic-only per the issue's guidance.

### Web editor UX

- Issues drawer pills are now toggles with tooltips and aria-pressed state; clicking fades a pill and hides its severity from the drawer list, CM markers/tooltips (via \`cm-hide-*\` classes on the editor host), and the FAB summary.
- New \`info\` tier in \`issuesStatus\` so info-only diagnostics surface a pastel-purple FAB and info icon instead of piling into \`warning\`.
- Uniform purple coloring for info across FAB, pill, list icon, squiggly, and tooltip border (squiggly saturated, FAB muted).
- Spellcheck squigglies excluded from warning-hide via \`:not(.cm-spellcheckRange)\` so toggling warnings off doesn't hide typos.
- \`IssuesDrawer\` is now a controlled component; \`hiddenSeverities\` lives in \`Editor.vue\`.

## Test plan

- [x] \`go test ./...\` (focused on \`internal/lsp\`, plus full suite)
- [x] \`npm --prefix web test\`
- [ ] Manual smoke in the web editor: toggle pills, verify CM markers/tooltips respect the hidden set, confirm spellcheck squigglies stay visible when warnings are hidden
- [ ] Manual smoke of each quick fix (add missing DP, delete duplicate entry)

Closes #145.