### PR TITLE
fix(render): use dp heading wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ See [`web/README.md`](web/README.md) for details.
 A Downstage document is organized around top-level `#` sections:
 
 1. **Play Header** — each play starts with `# Title`, followed by optional `Key: Value` metadata lines such as `Author:` or `Draft:`
-2. **Dramatis Personae** — an optional `## Dramatis Personae`, `## Cast of Characters`, or `## Characters` section inside that play, with character entries and optional `###` subgroup headings
+2. **Dramatis Personae** — an optional `## Dramatis Personae`, `## Cast of Characters`, or `## Characters` section inside that play, with character entries and optional `###` subgroup headings; rendered output keeps the chosen wording
 3. **Body** — the play itself: acts (`## ACT`), scenes (`### SCENE`), dialogue (ALL CAPS character name followed by speech text), stage directions (`>` prefixed lines), callouts (`>>` prefixed lines), verse (indented 2+ spaces), songs, and comments
 
 ### Dual Dialogue

--- a/SPEC.md
+++ b/SPEC.md
@@ -131,6 +131,7 @@ The dramatis personae section begins with one of these headings inside a top-lev
 - `## Characters`
 
 Heading matching is case-insensitive.
+Renderers use the author's chosen heading wording.
 
 `## Dramatis Personae` applies only to the enclosing `#` section.
 

--- a/internal/render/html/html.go
+++ b/internal/render/html/html.go
@@ -279,7 +279,7 @@ func (r *htmlRenderer) renderDramatisPersonae(s *ast.Section) error {
 		className += " downstage-dramatis-personae-inline"
 	}
 	fmt.Fprintf(&r.buf, "<section class=\"%s\"%s>\n", className, r.sourceAttr(s.NodeRange()))
-	r.buf.WriteString("<h2>DRAMATIS PERSONAE</h2>\n")
+	fmt.Fprintf(&r.buf, "<h2>%s</h2>\n", html.EscapeString(strings.ToUpper(render.DramatisPersonaeDisplayTitle(s))))
 	r.buf.WriteString("<dl>\n")
 
 	for _, ch := range s.Characters {

--- a/internal/render/pdf/dramatis.go
+++ b/internal/render/pdf/dramatis.go
@@ -1,6 +1,8 @@
 package pdf
 
 import (
+	"strings"
+
 	"github.com/jscaltreto/downstage/internal/ast"
 	"github.com/jscaltreto/downstage/internal/render"
 )
@@ -12,7 +14,7 @@ func renderDramatisPersonae(b *pdfBase, s *ast.Section, charIndent float64) {
 	// Heading
 	b.setStyle("B")
 	b.pdf.Ln(b.lineHeight)
-	b.centeredText("DRAMATIS PERSONAE")
+	b.centeredText(strings.ToUpper(render.DramatisPersonaeDisplayTitle(s)))
 	b.pdf.Ln(b.lineHeight * 2)
 	b.setStyle("")
 

--- a/internal/render/titlepage.go
+++ b/internal/render/titlepage.go
@@ -125,6 +125,17 @@ func SectionDisplayTitle(section *ast.Section) string {
 	return section.Title
 }
 
+// DramatisPersonaeDisplayTitle returns the DP heading text or the default.
+func DramatisPersonaeDisplayTitle(section *ast.Section) string {
+	if section == nil {
+		return "Dramatis Personae"
+	}
+	if title := strings.TrimSpace(section.Title); title != "" {
+		return title
+	}
+	return "Dramatis Personae"
+}
+
 func DocumentTitlePage(doc *ast.Document) *ast.TitlePage {
 	if doc == nil {
 		return nil


### PR DESCRIPTION
Use the authored Dramatis Personae heading wording in HTML and PDF renderers instead of hardcoding the title.

Summary:
- Render the dramatis personae header from the section title.
- Keep the existing title fallback for manually constructed ASTs.
- Update docs to reflect the behavior.

Validation:
- env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go test ./internal/parser ./internal/render/...