### PR TITLE
fix(web): avoid caret misplacement on wrapped lintRange lines

### DIFF
--- a/web/src/main.css
+++ b/web/src/main.css
@@ -101,20 +101,23 @@
 .cm-ds-variable { color: #e36209; }
 .dark .cm-ds-variable { color: var(--color-brass-300); }
 
+/* @codemirror/lint adds `padding-bottom: 0.7px` to .cm-lintRange to make
+   room for its wavy underline. On wrapped lines that 0.7px inflates
+   getClientRects() output enough to push CM's posAtCoords onto the visual
+   row above the click. Zero the padding; the SVG wavy still renders. */
+.cm-lintRange { padding-bottom: 0 !important; }
+
+/* Spellcheck uses severity "warning" for issues-drawer bucketing, but we
+   paint it red to distinguish from LSP warnings (which stay orange). */
 .cm-lintRange.cm-spellcheckRange {
-  background-image: none !important;
-  text-decoration: underline wavy #d11;
-  text-decoration-skip-ink: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='6' height='3'%3E%3Cpath d='m0 3 l2 -2 l1 0 l2 2 l1 0' stroke='%23d11' fill='none' stroke-width='.7'/%3E%3C/svg%3E") !important;
 }
 
 .cm-lintRange.cm-lintRange-info {
-  background-image: none !important;
-  text-decoration: underline wavy #7c3aed;
-  text-decoration-skip-ink: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='6' height='3'%3E%3Cpath d='m0 3 l2 -2 l1 0 l2 2 l1 0' stroke='%237c3aed' fill='none' stroke-width='.7'/%3E%3C/svg%3E") !important;
 }
 .dark .cm-lintRange.cm-lintRange-info {
-  text-decoration: underline wavy #a78bfa;
-  text-decoration-skip-ink: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='6' height='3'%3E%3Cpath d='m0 3 l2 -2 l1 0 l2 2 l1 0' stroke='%23a78bfa' fill='none' stroke-width='.7'/%3E%3C/svg%3E") !important;
 }
 
 .cm-diagnostic-info {


### PR DESCRIPTION
## Summary
- Clicking past the end of a long wrapped line was dropping the caret one visual row too high whenever the line contained spellcheck or lint diagnostic decorations.
- Traced to `@codemirror/lint`'s default `.cm-lintRange` rule adding `padding-bottom: 0.7px` to make room for its wavy underline. That tiny padding inflates `getClientRects()` output enough on wrapped lines to push CM's `posAtCoords` / `scan()` onto the visual row above the click.
- Zero the padding, and render the wavy underline via inline-SVG `background-image` instead of `text-decoration`, which leaves text cluster rects unperturbed.
- Preserves the previous three-way color distinction: red spellcheck, orange LSP warnings (CM default), purple info.


## Test plan
- [x] In Chrome, open a long wrapped paragraph that contains spell-check diagnostics and click past the end of the trailing wrapped segment — caret should land at end of line, not one row above.
- [x] Spellcheck underlines still render red.
- [x] LSP warnings still render orange.
- [x] Info-level diagnostics still render purple (light) / lavender (dark).
- [x] No regression on unwrapped lines or non-diagnostic ranges.