### PR TITLE
feat(web): add outline tab + scroll-sync fixes + FAB polish

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -26,6 +26,7 @@ func main() {
 	ds.Set("upgradeV1", js.FuncOf(upgradeV1))
 	ds.Set("completion", js.FuncOf(completion))
 	ds.Set("codeActions", js.FuncOf(codeActions))
+	ds.Set("documentSymbols", js.FuncOf(documentSymbols))
 	ds.Set("renderHTML", js.FuncOf(renderHTML))
 	ds.Set("renderPDF", js.FuncOf(renderPDF))
 	ds.Set("semanticTokens", js.FuncOf(semanticTokens))
@@ -197,6 +198,18 @@ func codeActions(_ js.Value, args []js.Value) any {
 		"uri":     string(codeActionsURI),
 		"actions": actions,
 	})
+	return js.Global().Get("JSON").Call("parse", string(data))
+}
+
+func documentSymbols(_ js.Value, args []js.Value) any {
+	source := args[0].String()
+	doc, errs := parser.Parse([]byte(source))
+	symbols := lsp.ComputeDocumentSymbols(doc, errs)
+	if symbols == nil {
+		symbols = []protocol.DocumentSymbol{}
+	}
+
+	data, _ := json.Marshal(map[string]any{"symbols": symbols})
 	return js.Global().Get("JSON").Call("parse", string(data))
 }
 

--- a/internal/lsp/handler.go
+++ b/internal/lsp/handler.go
@@ -173,7 +173,7 @@ func (h *handler) handleDocumentSymbol(ctx context.Context, reply jsonrpc2.Repli
 		return reply(ctx, []protocol.DocumentSymbol{}, nil)
 	}
 
-	symbols := computeDocumentSymbols(doc.doc, doc.errors)
+	symbols := ComputeDocumentSymbols(doc.doc, doc.errors)
 	return reply(ctx, symbols, nil)
 }
 

--- a/internal/lsp/symbols.go
+++ b/internal/lsp/symbols.go
@@ -7,8 +7,8 @@ import (
 	"go.lsp.dev/protocol"
 )
 
-// computeDocumentSymbols builds a hierarchical document outline from the AST.
-func computeDocumentSymbols(doc *ast.Document, _ []*parser.ParseError) []protocol.DocumentSymbol {
+// ComputeDocumentSymbols builds a hierarchical document outline from the AST.
+func ComputeDocumentSymbols(doc *ast.Document, _ []*parser.ParseError) []protocol.DocumentSymbol {
 	if doc == nil {
 		return nil
 	}
@@ -129,30 +129,39 @@ func sectionSymbolName(s *ast.Section) string {
 		return "Section"
 	}
 
-	if s.Title != "" {
-		return s.Title
-	}
-
-	if s.Number != "" {
-		switch s.Kind {
-		case ast.SectionAct:
-			return "Act " + s.Number
-		case ast.SectionScene:
-			return "Scene " + s.Number
-		default:
-			return s.Number
-		}
-	}
-
 	switch s.Kind {
 	case ast.SectionAct:
-		return "Act"
+		return joinNumberAndTitle("Act", s.Number, s.Title)
 	case ast.SectionScene:
-		return "Scene"
+		return joinNumberAndTitle("Scene", s.Number, s.Title)
 	case ast.SectionDramatisPersonae:
+		if s.Title != "" {
+			return s.Title
+		}
 		return "Dramatis Personae"
 	default:
+		if s.Title != "" {
+			return s.Title
+		}
+		if s.Number != "" {
+			return s.Number
+		}
 		return "Section"
+	}
+}
+
+// joinNumberAndTitle formats an Act/Scene label, keeping the number when both
+// a number and title are present (e.g. "Act I: The Beginning").
+func joinNumberAndTitle(prefix, number, title string) string {
+	switch {
+	case number != "" && title != "":
+		return prefix + " " + number + ": " + title
+	case number != "":
+		return prefix + " " + number
+	case title != "":
+		return title
+	default:
+		return prefix
 	}
 }
 

--- a/internal/lsp/symbols_test.go
+++ b/internal/lsp/symbols_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestComputeDocumentSymbols_Nil(t *testing.T) {
-	symbols := computeDocumentSymbols(nil, nil)
+	symbols := ComputeDocumentSymbols(nil, nil)
 	if symbols != nil {
 		t.Errorf("expected nil for nil doc, got %v", symbols)
 	}
@@ -19,12 +19,14 @@ func TestComputeDocumentSymbols_Act(t *testing.T) {
 	doc := &ast.Document{
 		Body: []ast.Node{
 			&ast.Section{
-				Kind:  ast.SectionAct,
-				Title: "Act I",
+				Kind:   ast.SectionAct,
+				Number: "I",
+				Title:  "The Beginning",
 				Children: []ast.Node{
 					&ast.Section{
-						Kind:  ast.SectionScene,
-						Title: "Scene 1",
+						Kind:   ast.SectionScene,
+						Number: "1",
+						Title:  "The Garden",
 						Children: []ast.Node{
 							&ast.Dialogue{
 								Character: "HAMLET",
@@ -48,14 +50,14 @@ func TestComputeDocumentSymbols_Act(t *testing.T) {
 		},
 	}
 
-	symbols := computeDocumentSymbols(doc, nil)
+	symbols := ComputeDocumentSymbols(doc, nil)
 	if len(symbols) != 1 {
 		t.Fatalf("expected 1 top-level symbol, got %d", len(symbols))
 	}
 
 	actSym := symbols[0]
-	if actSym.Name != "Act I" {
-		t.Errorf("expected act name %q, got %q", "Act I", actSym.Name)
+	if actSym.Name != "Act I: The Beginning" {
+		t.Errorf("expected act name %q, got %q", "Act I: The Beginning", actSym.Name)
 	}
 	if actSym.Kind != protocol.SymbolKindNamespace {
 		t.Errorf("expected kind Namespace, got %v", actSym.Kind)
@@ -65,8 +67,8 @@ func TestComputeDocumentSymbols_Act(t *testing.T) {
 	}
 
 	sceneSym := actSym.Children[0]
-	if sceneSym.Name != "Scene 1" {
-		t.Errorf("expected scene name %q, got %q", "Scene 1", sceneSym.Name)
+	if sceneSym.Name != "Scene 1: The Garden" {
+		t.Errorf("expected scene name %q, got %q", "Scene 1: The Garden", sceneSym.Name)
 	}
 	if sceneSym.Kind != protocol.SymbolKindClass {
 		t.Errorf("expected kind Class, got %v", sceneSym.Kind)
@@ -76,6 +78,39 @@ func TestComputeDocumentSymbols_Act(t *testing.T) {
 	}
 	if sceneSym.Children[0].Name != "HAMLET" {
 		t.Errorf("expected character name %q, got %q", "HAMLET", sceneSym.Children[0].Name)
+	}
+}
+
+func TestComputeDocumentSymbols_ActSceneNumberedOnly(t *testing.T) {
+	doc := &ast.Document{
+		Body: []ast.Node{
+			&ast.Section{
+				Kind:   ast.SectionAct,
+				Number: "II",
+				Children: []ast.Node{
+					&ast.Section{
+						Kind:   ast.SectionScene,
+						Number: "3",
+						Range: token.Range{
+							Start: token.Position{Line: 3, Column: 0},
+							End:   token.Position{Line: 5, Column: 0},
+						},
+					},
+				},
+				Range: token.Range{
+					Start: token.Position{Line: 1, Column: 0},
+					End:   token.Position{Line: 10, Column: 0},
+				},
+			},
+		},
+	}
+
+	symbols := ComputeDocumentSymbols(doc, nil)
+	if symbols[0].Name != "Act II" {
+		t.Errorf("expected %q, got %q", "Act II", symbols[0].Name)
+	}
+	if symbols[0].Children[0].Name != "Scene 3" {
+		t.Errorf("expected %q, got %q", "Scene 3", symbols[0].Children[0].Name)
 	}
 }
 
@@ -92,7 +127,7 @@ func TestComputeDocumentSymbols_FlatDialogue(t *testing.T) {
 		},
 	}
 
-	symbols := computeDocumentSymbols(doc, nil)
+	symbols := ComputeDocumentSymbols(doc, nil)
 	if len(symbols) != 1 {
 		t.Fatalf("expected 1 symbol, got %d", len(symbols))
 	}
@@ -140,7 +175,7 @@ func TestComputeDocumentSymbols_DualDialogueInSection(t *testing.T) {
 		},
 	}
 
-	symbols := computeDocumentSymbols(doc, nil)
+	symbols := ComputeDocumentSymbols(doc, nil)
 	if len(symbols) != 1 {
 		t.Fatalf("expected 1 top-level symbol, got %d", len(symbols))
 	}
@@ -168,7 +203,7 @@ func TestComputeDocumentSymbols_UsesFallbackNameForUntitledScene(t *testing.T) {
 		},
 	}
 
-	symbols := computeDocumentSymbols(doc, nil)
+	symbols := ComputeDocumentSymbols(doc, nil)
 	if len(symbols) != 1 {
 		t.Fatalf("expected 1 symbol, got %d", len(symbols))
 	}

--- a/internal/render/html/html.go
+++ b/internal/render/html/html.go
@@ -107,30 +107,35 @@ func (r *htmlRenderer) EndDocument(_ *ast.Document) error {
 // --- Front matter ---
 
 func (r *htmlRenderer) RenderTitlePage(tp *ast.TitlePage) error {
-	title, subtitle, authors, other := partitionHTMLTitlePageEntries(tp)
+	titleKV, subtitleKV, authorKVs, other := partitionHTMLTitlePageKVs(tp)
+
+	titleText := ""
+	if titleKV != nil {
+		titleText = titleKV.Value
+	}
 
 	r.hasTitlePage = true
-	r.titlePageTitle = title
+	r.titlePageTitle = titleText
 
 	fmt.Fprintf(&r.buf, "<header class=\"downstage-title-page\"%s>\n", r.sourceAttr(tp.NodeRange()))
 
-	if title != "" {
-		fmt.Fprintf(&r.buf, "<h1>%s</h1>\n", html.EscapeString(title))
+	if titleKV != nil && titleKV.Value != "" {
+		fmt.Fprintf(&r.buf, "<h1%s>%s</h1>\n", r.sourceAttr(titleKV.Range), html.EscapeString(titleKV.Value))
 	}
-	if subtitle != "" {
-		fmt.Fprintf(&r.buf, "<p class=\"subtitle\">%s</p>\n", html.EscapeString(subtitle))
+	if subtitleKV != nil && subtitleKV.Value != "" {
+		fmt.Fprintf(&r.buf, "<p class=\"subtitle\"%s>%s</p>\n", r.sourceAttr(subtitleKV.Range), html.EscapeString(subtitleKV.Value))
 	}
-	if len(authors) > 0 {
-		r.buf.WriteString("<p class=\"author\">by</p>\n")
-		for _, author := range authors {
-			fmt.Fprintf(&r.buf, "<p class=\"author\">%s</p>\n", html.EscapeString(author))
+	if len(authorKVs) > 0 {
+		fmt.Fprintf(&r.buf, "<p class=\"author\"%s>by</p>\n", r.sourceAttr(authorKVs[0].Range))
+		for _, kv := range authorKVs {
+			fmt.Fprintf(&r.buf, "<p class=\"author\"%s>%s</p>\n", r.sourceAttr(kv.Range), html.EscapeString(kv.Value))
 		}
 	}
 
 	if len(other) > 0 {
 		r.buf.WriteString("<dl class=\"metadata\">\n")
 		for _, kv := range other {
-			r.buf.WriteString("<div>")
+			fmt.Fprintf(&r.buf, "<div%s>", r.sourceAttr(kv.Range))
 			fmt.Fprintf(&r.buf, "<dt>%s</dt>", html.EscapeString(kv.Key))
 			fmt.Fprintf(&r.buf, "<dd>%s</dd>", html.EscapeString(kv.Value))
 			r.buf.WriteString("</div>\n")
@@ -170,7 +175,7 @@ func (r *htmlRenderer) BeginSection(s *ast.Section) error {
 			r.pushSection(true)
 			fmt.Fprintf(&r.buf, "<section class=\"downstage-subplay\"%s>\n", r.sourceAttr(s.NodeRange()))
 			r.buf.WriteString("<header class=\"downstage-subplay-header\">\n")
-			fmt.Fprintf(&r.buf, "<h1>%s</h1>\n", html.EscapeString(render.SectionDisplayTitle(s)))
+			fmt.Fprintf(&r.buf, "<h1%s>%s</h1>\n", r.sourceAttr(s.HeadingRange()), html.EscapeString(render.SectionDisplayTitle(s)))
 			r.renderSubplayMetadata(s.Metadata)
 			r.buf.WriteString("</header>\n")
 			return nil
@@ -185,7 +190,7 @@ func (r *htmlRenderer) BeginSection(s *ast.Section) error {
 		fmt.Fprintf(&r.buf, "<section class=\"downstage-section\"%s>\n", r.sourceAttr(s.NodeRange()))
 		if s.Title != "" {
 			tag := headingTag(s.Level)
-			fmt.Fprintf(&r.buf, "<%s>%s</%s>\n", tag, html.EscapeString(strings.ToUpper(s.Title)), tag)
+			fmt.Fprintf(&r.buf, "<%s%s>%s</%s>\n", tag, r.sourceAttr(s.HeadingRange()), html.EscapeString(strings.ToUpper(s.Title)), tag)
 		}
 		return nil
 	}
@@ -250,7 +255,7 @@ func (r *htmlRenderer) beginAct(s *ast.Section) error {
 		heading = s.Title
 	}
 
-	fmt.Fprintf(&r.buf, "<h2>%s</h2>\n", html.EscapeString(strings.ToUpper(heading)))
+	fmt.Fprintf(&r.buf, "<h2%s>%s</h2>\n", r.sourceAttr(s.HeadingRange()), html.EscapeString(strings.ToUpper(heading)))
 	return nil
 }
 
@@ -268,7 +273,7 @@ func (r *htmlRenderer) beginScene(s *ast.Section) error {
 		heading = s.Title
 	}
 
-	fmt.Fprintf(&r.buf, "<h3>%s</h3>\n", html.EscapeString(strings.ToUpper(heading)))
+	fmt.Fprintf(&r.buf, "<h3%s>%s</h3>\n", r.sourceAttr(s.HeadingRange()), html.EscapeString(strings.ToUpper(heading)))
 	return nil
 }
 
@@ -350,6 +355,36 @@ func partitionHTMLTitlePageEntries(tp *ast.TitlePage) (title string, subtitle st
 		case "author":
 			if strings.TrimSpace(kv.Value) != "" {
 				authors = append(authors, kv.Value)
+			}
+		default:
+			other = append(other, kv)
+		}
+	}
+	return title, subtitle, authors, other
+}
+
+// partitionHTMLTitlePageKVs mirrors partitionHTMLTitlePageEntries but preserves
+// the source range of each entry so the title-page render can emit anchors.
+func partitionHTMLTitlePageKVs(tp *ast.TitlePage) (title *ast.KeyValue, subtitle *ast.KeyValue, authors []ast.KeyValue, other []ast.KeyValue) {
+	if tp == nil {
+		return nil, nil, nil, nil
+	}
+	for i := range tp.Entries {
+		kv := tp.Entries[i]
+		switch strings.ToLower(strings.TrimSpace(kv.Key)) {
+		case "title":
+			if title == nil {
+				c := kv
+				title = &c
+			}
+		case "subtitle":
+			if subtitle == nil {
+				c := kv
+				subtitle = &c
+			}
+		case "author":
+			if strings.TrimSpace(kv.Value) != "" {
+				authors = append(authors, kv)
 			}
 		default:
 			other = append(other, kv)

--- a/internal/render/html/html.go
+++ b/internal/render/html/html.go
@@ -107,7 +107,7 @@ func (r *htmlRenderer) EndDocument(_ *ast.Document) error {
 // --- Front matter ---
 
 func (r *htmlRenderer) RenderTitlePage(tp *ast.TitlePage) error {
-	titleKV, subtitleKV, authorKVs, other := partitionHTMLTitlePageKVs(tp)
+	titleKV, subtitleKV, authorKVs, other := partitionHTMLTitlePageEntries(tp)
 
 	titleText := ""
 	if titleKV != nil {
@@ -327,14 +327,16 @@ func (r *htmlRenderer) renderMetadata(className string, tp *ast.TitlePage) {
 }
 
 func (r *htmlRenderer) renderSubplayMetadata(tp *ast.TitlePage) {
-	_, subtitle, authors, other := partitionHTMLTitlePageEntries(tp)
-	if s := strings.TrimSpace(subtitle); s != "" {
-		fmt.Fprintf(&r.buf, "<p class=\"downstage-subplay-subtitle\">%s</p>\n", html.EscapeString(s))
+	_, subtitleKV, authorKVs, other := partitionHTMLTitlePageEntries(tp)
+	if subtitleKV != nil {
+		if s := strings.TrimSpace(subtitleKV.Value); s != "" {
+			fmt.Fprintf(&r.buf, "<p class=\"downstage-subplay-subtitle\">%s</p>\n", html.EscapeString(s))
+		}
 	}
-	if len(authors) > 0 {
+	if len(authorKVs) > 0 {
 		r.buf.WriteString("<p class=\"downstage-subplay-author-label\">by</p>\n")
-		for _, author := range authors {
-			fmt.Fprintf(&r.buf, "<p class=\"downstage-subplay-author\">%s</p>\n", html.EscapeString(author))
+		for _, kv := range authorKVs {
+			fmt.Fprintf(&r.buf, "<p class=\"downstage-subplay-author\">%s</p>\n", html.EscapeString(kv.Value))
 		}
 	}
 	if len(other) > 0 {
@@ -342,30 +344,11 @@ func (r *htmlRenderer) renderSubplayMetadata(tp *ast.TitlePage) {
 	}
 }
 
-func partitionHTMLTitlePageEntries(tp *ast.TitlePage) (title string, subtitle string, authors []string, other []ast.KeyValue) {
-	if tp == nil {
-		return "", "", nil, nil
-	}
-	for _, kv := range tp.Entries {
-		switch strings.ToLower(strings.TrimSpace(kv.Key)) {
-		case "title":
-			title = kv.Value
-		case "subtitle":
-			subtitle = kv.Value
-		case "author":
-			if strings.TrimSpace(kv.Value) != "" {
-				authors = append(authors, kv.Value)
-			}
-		default:
-			other = append(other, kv)
-		}
-	}
-	return title, subtitle, authors, other
-}
-
-// partitionHTMLTitlePageKVs mirrors partitionHTMLTitlePageEntries but preserves
-// the source range of each entry so the title-page render can emit anchors.
-func partitionHTMLTitlePageKVs(tp *ast.TitlePage) (title *ast.KeyValue, subtitle *ast.KeyValue, authors []ast.KeyValue, other []ast.KeyValue) {
+// partitionHTMLTitlePageEntries splits a title page into the slots the HTML
+// renderer cares about, preserving source ranges so callers can emit anchors.
+// Duplicate Title/Subtitle entries follow last-wins semantics, matching the
+// PDF renderer.
+func partitionHTMLTitlePageEntries(tp *ast.TitlePage) (title *ast.KeyValue, subtitle *ast.KeyValue, authors []ast.KeyValue, other []ast.KeyValue) {
 	if tp == nil {
 		return nil, nil, nil, nil
 	}
@@ -373,15 +356,11 @@ func partitionHTMLTitlePageKVs(tp *ast.TitlePage) (title *ast.KeyValue, subtitle
 		kv := tp.Entries[i]
 		switch strings.ToLower(strings.TrimSpace(kv.Key)) {
 		case "title":
-			if title == nil {
-				c := kv
-				title = &c
-			}
+			c := kv
+			title = &c
 		case "subtitle":
-			if subtitle == nil {
-				c := kv
-				subtitle = &c
-			}
+			c := kv
+			subtitle = &c
 		case "author":
 			if strings.TrimSpace(kv.Value) != "" {
 				authors = append(authors, kv)
@@ -680,12 +659,13 @@ func titlePageTitle(tp *ast.TitlePage) string {
 	if tp == nil {
 		return ""
 	}
+	var title string
 	for _, entry := range tp.Entries {
 		if strings.EqualFold(strings.TrimSpace(entry.Key), "title") {
-			return strings.TrimSpace(entry.Value)
+			title = strings.TrimSpace(entry.Value)
 		}
 	}
-	return ""
+	return title
 }
 
 func (r *htmlRenderer) closeParagraph() {

--- a/internal/render/html/html_test.go
+++ b/internal/render/html/html_test.go
@@ -65,6 +65,26 @@ func TestRender_TitlePage(t *testing.T) {
 	assert.Contains(t, out, "</header>")
 }
 
+func TestRender_TitlePageDuplicateTitleSubtitleUsesLastWins(t *testing.T) {
+	doc := &ast.Document{
+		TitlePage: &ast.TitlePage{
+			Entries: []ast.KeyValue{
+				{Key: "Title", Value: "First Title"},
+				{Key: "Title", Value: "Final Title"},
+				{Key: "Subtitle", Value: "First Subtitle"},
+				{Key: "Subtitle", Value: "Final Subtitle"},
+			},
+		},
+	}
+	out := renderHTML(t, doc)
+
+	assert.Contains(t, out, "<h1>Final Title</h1>")
+	assert.NotContains(t, out, "<h1>First Title</h1>")
+	assert.Contains(t, out, "<p class=\"subtitle\">Final Subtitle</p>")
+	assert.NotContains(t, out, "<p class=\"subtitle\">First Subtitle</p>")
+	assert.Contains(t, out, "<title>Final Title</title>")
+}
+
 func TestRender_TitlePageSupportsMultipleAuthors(t *testing.T) {
 	doc := &ast.Document{
 		TitlePage: &ast.TitlePage{

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -208,11 +208,13 @@ onMounted(async () => {
     engine = new Engine(
       editorContainer.value,
       props.env,
-      async (content) => {
+      async (content, info) => {
         emit('update:content', content);
         scheduleRender(content, props.style);
         scheduleOutlineRefresh(content);
-        markTyping();
+        if (info.userInput) {
+          markTyping();
+        }
       },
       iframeEl,
       () => props.getSpellAllowlist(),

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -3,20 +3,21 @@ import { computed, onMounted, onUnmounted, ref, watch, inject, nextTick } from '
 import {
     Bold, Italic, Underline, MessageSquare, ChevronRight,
     GalleryVerticalEnd, GalleryVertical, FilePlus2, Eye, EyeOff, HelpCircle, X, Music,
-    Sun, Moon, ScrollText, BookOpenText, AlertTriangle, AlertCircle, Info, RefreshCw, SpellCheck, Trash2, CheckCircle2, Search
+    Sun, Moon, ScrollText, BookOpenText, AlertTriangle, AlertCircle, Info, RefreshCw, SpellCheck, Trash2, Search, ListTree
 } from 'lucide-vue-next';
 import { Engine, type SearchMode, type SearchSummary } from '../../core/engine';
 import type { SearchMatch, SearchOptions } from '../../core/search';
 import { issuesStatus, summarizeIssues } from '../../core/issues';
 import type { FilterSeverity } from '../../core/issues';
 import type { Store } from '../../core/store';
-import type { EditorDiagnostic, EditorEnv } from '../../core/types';
+import type { DocumentSymbol, EditorDiagnostic, EditorEnv } from '../../core/types';
 import PreviewFrame from './PreviewFrame.vue';
 import ToolbarButton from './ToolbarButton.vue';
 import BaseModal from './BaseModal.vue';
 import WorkbenchDrawer, { type WorkbenchTab } from './WorkbenchDrawer.vue';
 import IssuesTab from './IssuesTab.vue';
 import FindReplaceTab from './FindReplaceTab.vue';
+import OutlineTab from './OutlineTab.vue';
 
 const props = defineProps<{
   env: EditorEnv;
@@ -51,6 +52,18 @@ const searchInitialQuery = ref('');
 const searchFocusReplace = ref(false);
 const searchFocusNonce = ref(0);
 const diagnostics = ref<EditorDiagnostic[]>([]);
+const outlineSymbols = ref<DocumentSymbol[]>([]);
+const isTyping = ref(false);
+let typingTimer: number | null = null;
+
+function markTyping() {
+    isTyping.value = true;
+    if (typingTimer) window.clearTimeout(typingTimer);
+    typingTimer = window.setTimeout(() => {
+        isTyping.value = false;
+        typingTimer = null;
+    }, 1500);
+}
 const hiddenSeverities = ref<ReadonlySet<FilterSeverity>>(new Set());
 const visibleDiagnostics = computed(() =>
   diagnostics.value.filter((d) => {
@@ -78,7 +91,26 @@ const isUpgradingV1 = ref(false);
 
 let lastRenderRequestId = 0;
 let renderTimer: number | null = null;
+let outlineRequestId = 0;
+let outlineTimer: number | null = null;
 const v1DiagnosticCode = "v1-document";
+
+function scheduleOutlineRefresh(content: string) {
+    if (outlineTimer) window.clearTimeout(outlineTimer);
+    outlineTimer = window.setTimeout(async () => {
+        outlineTimer = null;
+        const requestId = ++outlineRequestId;
+        try {
+            const { symbols } = await props.env.documentSymbols(content);
+            if (requestId !== outlineRequestId) return;
+            outlineSymbols.value = symbols;
+        } catch (err) {
+            if (requestId !== outlineRequestId) return;
+            outlineSymbols.value = [];
+            console.warn("failed to compute document outline:", err);
+        }
+    }, 300);
+}
 
 function setV1DocumentDetected(detected: boolean) {
     v1DocumentDetected.value = detected;
@@ -179,6 +211,8 @@ onMounted(async () => {
       async (content) => {
         emit('update:content', content);
         scheduleRender(content, props.style);
+        scheduleOutlineRefresh(content);
+        markTyping();
       },
       iframeEl,
       () => props.getSpellAllowlist(),
@@ -189,12 +223,15 @@ onMounted(async () => {
     );
     engine.init(props.content, store.state.isDark, spellcheckEnabled.value);
     scheduleRender(props.content, props.style);
+    scheduleOutlineRefresh(props.content);
   }
 });
 
 onUnmounted(() => {
   engine?.destroy();
   if (renderTimer) window.clearTimeout(renderTimer);
+  if (outlineTimer) window.clearTimeout(outlineTimer);
+  if (typingTimer) window.clearTimeout(typingTimer);
 });
 
 watch(() => store.state.isDark, (isDark) => {
@@ -266,8 +303,22 @@ function jumpToDiagnostic(d: EditorDiagnostic) {
     engine?.revealDiagnostic(d.from, d.to);
 }
 
+function jumpToSymbol(symbol: DocumentSymbol) {
+    const start = symbol.selectionRange?.start ?? symbol.range.start;
+    engine?.revealPosition(start.line, start.character);
+}
+
 function openIssuesTab() {
     drawerTab.value = 'issues';
+    drawerOpen.value = true;
+}
+
+function toggleOutline() {
+    if (drawerOpen.value && drawerTab.value === 'outline') {
+        closeDrawer();
+        return;
+    }
+    drawerTab.value = 'outline';
     drawerOpen.value = true;
 }
 
@@ -322,6 +373,14 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
 
             <ToolbarButton @click="toggleSearch" title="Find &amp; Replace (Ctrl/Cmd+F)">
                 <template #icon><Search class="w-4 h-4" /></template>
+            </ToolbarButton>
+
+            <ToolbarButton
+                @click="toggleOutline"
+                :active="drawerOpen && drawerTab === 'outline'"
+                title="Outline"
+            >
+                <template #icon><ListTree class="w-4 h-4" /></template>
             </ToolbarButton>
         </div>
 
@@ -378,24 +437,26 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
                     v-if="!drawerOpen"
                     class="absolute right-6 bottom-6 z-20 flex flex-col items-end gap-3"
                 >
-                    <button
-                        type="button"
-                        @click="openIssuesTab"
-                        class="flex items-center gap-2 rounded-full px-4 h-10 text-sm font-bold shadow-2xl transition-all hover:scale-105"
-                        :class="{
-                            'bg-emerald-500 text-white hover:bg-emerald-600': issuesStatusValue === 'clean',
-                            'bg-purple-200 text-purple-950 hover:bg-purple-300': issuesStatusValue === 'info',
-                            'bg-amber-500 text-ember-950 hover:bg-amber-400': issuesStatusValue === 'warning',
-                            'bg-red-500 text-white hover:bg-red-600': issuesStatusValue === 'error',
-                        }"
-                        :title="issuesStatusValue === 'clean' ? 'No script issues' : `${issuesSummary.total} script issue${issuesSummary.total === 1 ? '' : 's'}`"
-                    >
-                        <CheckCircle2 v-if="issuesStatusValue === 'clean'" class="w-4 h-4" />
-                        <Info v-else-if="issuesStatusValue === 'info'" class="w-4 h-4" />
-                        <AlertTriangle v-else-if="issuesStatusValue === 'warning'" class="w-4 h-4" />
-                        <AlertCircle v-else class="w-4 h-4" />
-                        <span>{{ issuesStatusValue === 'clean' ? 'No script issues' : `${issuesSummary.total} script issue${issuesSummary.total === 1 ? '' : 's'}` }}</span>
-                    </button>
+                    <Transition name="fab-fade" :css="true">
+                        <button
+                            v-if="issuesStatusValue !== 'clean' && !isTyping"
+                            type="button"
+                            @click="openIssuesTab"
+                            class="issue-fab flex items-center justify-center gap-1.5 rounded-full h-10 px-3 min-w-10 text-sm font-bold shadow-2xl hover:scale-105"
+                            :class="{
+                                'bg-purple-200 text-purple-950 hover:bg-purple-300': issuesStatusValue === 'info',
+                                'bg-amber-500 text-ember-950 hover:bg-amber-400': issuesStatusValue === 'warning',
+                                'bg-red-500 text-white hover:bg-red-600': issuesStatusValue === 'error',
+                            }"
+                            :aria-label="`${issuesSummary.total} script issue${issuesSummary.total === 1 ? '' : 's'}`"
+                            :title="`${issuesSummary.total} script issue${issuesSummary.total === 1 ? '' : 's'}`"
+                        >
+                            <Info v-if="issuesStatusValue === 'info'" class="w-4 h-4" />
+                            <AlertTriangle v-else-if="issuesStatusValue === 'warning'" class="w-4 h-4" />
+                            <AlertCircle v-else class="w-4 h-4" />
+                            <span class="tabular-nums">{{ issuesSummary.total }}</span>
+                        </button>
+                    </Transition>
 
                     <button
                         v-if="!previewVisible"
@@ -438,6 +499,12 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
                         @replace="onReplaceOne"
                         @replace-all="onReplaceAll"
                         @jump="onJumpMatch"
+                    />
+                </template>
+                <template #outline>
+                    <OutlineTab
+                        :symbols="outlineSymbols"
+                        @jump="jumpToSymbol"
                     />
                 </template>
             </WorkbenchDrawer>
@@ -614,6 +681,19 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
 </template>
 
 <style>
+.issue-fab { transition: transform 150ms ease-out; }
+.issue-fab:hover { transition: transform 150ms ease-out; }
+
+.fab-fade-enter-active {
+    transition: opacity 500ms ease-out;
+}
+.fab-fade-enter-from {
+    opacity: 0;
+}
+.fab-fade-enter-to {
+    opacity: 1;
+}
+
 .cm-editor { height: 100%; outline: none !important; }
 .cm-gutters {
     background-color: transparent !important;

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -55,6 +55,8 @@ const diagnostics = ref<EditorDiagnostic[]>([]);
 const outlineSymbols = ref<DocumentSymbol[]>([]);
 const isTyping = ref(false);
 let typingTimer: number | null = null;
+const outlineDebounceMs = 300;
+const typingIndicatorMs = 1500;
 
 function markTyping() {
     isTyping.value = true;
@@ -62,7 +64,7 @@ function markTyping() {
     typingTimer = window.setTimeout(() => {
         isTyping.value = false;
         typingTimer = null;
-    }, 1500);
+    }, typingIndicatorMs);
 }
 const hiddenSeverities = ref<ReadonlySet<FilterSeverity>>(new Set());
 const visibleDiagnostics = computed(() =>
@@ -104,12 +106,11 @@ function scheduleOutlineRefresh(content: string) {
             const { symbols } = await props.env.documentSymbols(content);
             if (requestId !== outlineRequestId) return;
             outlineSymbols.value = symbols;
-        } catch (err) {
+        } catch {
             if (requestId !== outlineRequestId) return;
             outlineSymbols.value = [];
-            console.warn("failed to compute document outline:", err);
         }
-    }, 300);
+    }, outlineDebounceMs);
 }
 
 function setV1DocumentDetected(detected: boolean) {
@@ -245,6 +246,7 @@ watch(() => props.content, (newContent) => {
     engine.setContent(newContent);
   }
   scheduleRender(newContent, props.style);
+  scheduleOutlineRefresh(newContent);
 });
 
 watch(() => store.state.activeDraftId, () => {
@@ -439,12 +441,12 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
                     v-if="!drawerOpen"
                     class="absolute right-6 bottom-6 z-20 flex flex-col items-end gap-3"
                 >
-                    <Transition name="fab-fade" :css="true">
+                    <Transition name="fab-fade">
                         <button
                             v-if="issuesStatusValue !== 'clean' && !isTyping"
                             type="button"
                             @click="openIssuesTab"
-                            class="issue-fab flex items-center justify-center gap-1.5 rounded-full h-10 px-3 min-w-10 text-sm font-bold shadow-2xl hover:scale-105"
+                            class="flex items-center justify-center gap-1.5 rounded-full h-10 px-3 min-w-10 text-sm font-bold shadow-2xl transition-transform duration-150 ease-out hover:scale-105"
                             :class="{
                                 'bg-purple-200 text-purple-950 hover:bg-purple-300': issuesStatusValue === 'info',
                                 'bg-amber-500 text-ember-950 hover:bg-amber-400': issuesStatusValue === 'warning',
@@ -683,9 +685,6 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
 </template>
 
 <style>
-.issue-fab { transition: transform 150ms ease-out; }
-.issue-fab:hover { transition: transform 150ms ease-out; }
-
 .fab-fade-enter-active {
     transition: opacity 500ms ease-out;
 }

--- a/web/src/components/shared/OutlineTab.vue
+++ b/web/src/components/shared/OutlineTab.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { GalleryVerticalEnd, GalleryVertical, Users, Music, Drama, ListTree } from 'lucide-vue-next';
+import type { DocumentSymbol } from '../../core/types';
+import { SymbolKind } from '../../core/types';
+
+interface FlatSymbol {
+  symbol: DocumentSymbol;
+  depth: number;
+  key: string;
+}
+
+const props = defineProps<{
+  symbols: DocumentSymbol[];
+}>();
+
+const emit = defineEmits<{
+  (e: 'jump', symbol: DocumentSymbol): void;
+}>();
+
+function isSong(symbol: DocumentSymbol): boolean {
+  return (
+    symbol.kind === SymbolKind.Function &&
+    (symbol.name.endsWith(' (song)') || symbol.name === 'Song')
+  );
+}
+
+function shouldInclude(symbol: DocumentSymbol): boolean {
+  // Exclude character dialogue leaves; keep everything else (acts, scenes, DP, songs, generic).
+  return symbol.kind !== SymbolKind.Function || isSong(symbol);
+}
+
+const flat = computed<FlatSymbol[]>(() => {
+  const out: FlatSymbol[] = [];
+  const walk = (nodes: DocumentSymbol[], depth: number, prefix: string) => {
+    nodes.forEach((symbol, index) => {
+      if (!shouldInclude(symbol)) return;
+      const key = `${prefix}${index}:${symbol.range.start.line}:${symbol.range.start.character}`;
+      out.push({ symbol, depth, key });
+      if (symbol.children && symbol.children.length > 0) {
+        walk(symbol.children, depth + 1, `${key}/`);
+      }
+    });
+  };
+  walk(props.symbols, 0, '');
+  return out;
+});
+
+function iconFor(kind: number) {
+  switch (kind) {
+    case SymbolKind.Namespace:
+      return GalleryVerticalEnd;
+    case SymbolKind.Class:
+      return GalleryVertical;
+    case SymbolKind.Struct:
+      return Users;
+    case SymbolKind.File:
+      return Drama;
+    default:
+      return Drama;
+  }
+}
+
+function iconColor(kind: number) {
+  switch (kind) {
+    case SymbolKind.Namespace:
+      return 'text-brass-500';
+    case SymbolKind.Class:
+      return 'text-accent';
+    case SymbolKind.Struct:
+      return 'text-purple-600 dark:text-purple-300';
+    default:
+      return 'text-text-muted';
+  }
+}
+
+function resolveIcon(symbol: DocumentSymbol) {
+  if (isSong(symbol)) {
+    return Music;
+  }
+  return iconFor(symbol.kind);
+}
+
+function paddingFor(depth: number): string {
+  const pl = 16 + depth * 16;
+  return `${pl}px`;
+}
+</script>
+
+<template>
+  <div class="flex flex-1 flex-col overflow-hidden">
+    <div
+      v-if="flat.length === 0"
+      class="flex flex-1 flex-col items-center justify-center gap-2 text-text-muted"
+    >
+      <div class="flex h-10 w-10 items-center justify-center rounded-full bg-black/5 text-text-muted dark:bg-white/5">
+        <ListTree class="h-5 w-5" />
+      </div>
+      <p class="text-sm font-medium text-text-main">No structure yet</p>
+      <p class="text-xs">Add a heading (e.g. <code class="font-mono">## ACT I</code>) to build an outline.</p>
+    </div>
+
+    <ul v-else class="flex-1 overflow-y-auto py-1">
+      <li v-for="entry in flat" :key="entry.key">
+        <button
+          type="button"
+          class="group flex w-full items-center gap-2 pr-4 py-1 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/5"
+          :style="{ paddingLeft: paddingFor(entry.depth) }"
+          :title="`Jump to ${entry.symbol.name} (line ${entry.symbol.range.start.line + 1})`"
+          @click="emit('jump', entry.symbol)"
+        >
+          <component
+            :is="resolveIcon(entry.symbol)"
+            class="shrink-0"
+            :class="[
+              entry.depth === 0 ? 'h-3.5 w-3.5' : 'h-3 w-3',
+              iconColor(entry.symbol.kind),
+            ]"
+          />
+          <span
+            class="flex-1 truncate"
+            :class="entry.depth === 0 ? 'text-sm font-medium text-text-main' : 'text-xs text-text-main'"
+          >{{ entry.symbol.name }}</span>
+          <span class="shrink-0 font-mono text-[10px] text-text-muted tabular-nums">{{ entry.symbol.range.start.line + 1 }}</span>
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/web/src/components/shared/OutlineTab.vue
+++ b/web/src/components/shared/OutlineTab.vue
@@ -18,23 +18,22 @@ const emit = defineEmits<{
   (e: 'jump', symbol: DocumentSymbol): void;
 }>();
 
-function isSong(symbol: DocumentSymbol): boolean {
+function isSongSymbol(symbol: DocumentSymbol): boolean {
   return (
     symbol.kind === SymbolKind.Function &&
     (symbol.name.endsWith(' (song)') || symbol.name === 'Song')
   );
 }
 
-function shouldInclude(symbol: DocumentSymbol): boolean {
-  // Exclude character dialogue leaves; keep everything else (acts, scenes, DP, songs, generic).
-  return symbol.kind !== SymbolKind.Function || isSong(symbol);
+function isRenderableSymbol(symbol: DocumentSymbol): boolean {
+  return symbol.kind !== SymbolKind.Function || isSongSymbol(symbol);
 }
 
 const flat = computed<FlatSymbol[]>(() => {
   const out: FlatSymbol[] = [];
   const walk = (nodes: DocumentSymbol[], depth: number, prefix: string) => {
     nodes.forEach((symbol, index) => {
-      if (!shouldInclude(symbol)) return;
+      if (!isRenderableSymbol(symbol)) return;
       const key = `${prefix}${index}:${symbol.range.start.line}:${symbol.range.start.character}`;
       out.push({ symbol, depth, key });
       if (symbol.children && symbol.children.length > 0) {
@@ -75,7 +74,7 @@ function iconColor(kind: number) {
 }
 
 function resolveIcon(symbol: DocumentSymbol) {
-  if (isSong(symbol)) {
+  if (isSongSymbol(symbol)) {
     return Music;
   }
   return iconFor(symbol.kind);

--- a/web/src/components/shared/WorkbenchDrawer.vue
+++ b/web/src/components/shared/WorkbenchDrawer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { X, AlertTriangle, Search } from 'lucide-vue-next';
+import { X, AlertTriangle, Search, ListTree } from 'lucide-vue-next';
 
-export type WorkbenchTab = 'issues' | 'find';
+export type WorkbenchTab = 'issues' | 'find' | 'outline';
 
 defineProps<{
   open: boolean;
@@ -30,6 +30,19 @@ function switchTab(tab: WorkbenchTab) {
   >
     <header class="flex items-center justify-between gap-3 border-b border-border bg-[var(--color-toolbar-bg)] px-4">
       <div class="flex items-center gap-1" role="tablist">
+        <button
+          type="button"
+          role="tab"
+          :aria-selected="activeTab === 'outline'"
+          class="flex items-center gap-2 px-3 py-2.5 text-[10px] font-bold uppercase tracking-[0.2em] border-b-2 transition-colors"
+          :class="activeTab === 'outline'
+            ? 'border-brass-500 text-accent'
+            : 'border-transparent text-text-muted hover:text-text-main'"
+          @click="switchTab('outline')"
+        >
+          <ListTree class="h-3.5 w-3.5" />
+          <span>Outline</span>
+        </button>
         <button
           type="button"
           role="tab"
@@ -77,6 +90,9 @@ function switchTab(tab: WorkbenchTab) {
       </div>
       <div v-show="activeTab === 'find'" class="flex h-full min-w-0 flex-col overflow-hidden">
         <slot name="find" />
+      </div>
+      <div v-show="activeTab === 'outline'" class="flex h-full min-w-0 flex-col overflow-hidden">
+        <slot name="outline" />
       </div>
     </div>
   </section>

--- a/web/src/core/engine.ts
+++ b/web/src/core/engine.ts
@@ -284,6 +284,19 @@ export class Engine {
     this.view.focus();
   }
 
+  revealPosition(line: number, character: number) {
+    if (!this.view) return;
+    const doc = this.view.state.doc;
+    const lineNumber = Math.max(1, Math.min(line + 1, doc.lines));
+    const lineInfo = doc.line(lineNumber);
+    const offset = Math.min(lineInfo.from + Math.max(0, character), lineInfo.to);
+    this.view.dispatch({
+      selection: { anchor: offset, head: offset },
+      effects: EditorView.scrollIntoView(offset, { y: "center" }),
+    });
+    this.view.focus();
+  }
+
   private emitDiagnostics() {
     this.onDiagnosticsChange(this.getDiagnostics());
   }

--- a/web/src/core/engine.ts
+++ b/web/src/core/engine.ts
@@ -1,5 +1,5 @@
 import { EditorView, keymap, lineNumbers } from "@codemirror/view";
-import { EditorState, Compartment } from "@codemirror/state";
+import { EditorState, Compartment, Transaction } from "@codemirror/state";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { completionKeymap } from "@codemirror/autocomplete";
 import { oneDark } from "@codemirror/theme-one-dark";
@@ -71,7 +71,7 @@ export class Engine {
   constructor(
     private parent: HTMLElement,
     private env: EditorEnv,
-    private onDocChange: (content: string) => void,
+    private onDocChange: (content: string, info: { userInput: boolean }) => void,
     private iframe: HTMLIFrameElement,
     private getUserSpellAllowlist: () => string[],
     private addUserSpellAllowlistWord: (word: string) => Promise<boolean>,
@@ -148,7 +148,11 @@ export class Engine {
           EditorView.lineWrapping,
           EditorView.updateListener.of((update) => {
             if (update.docChanged) {
-              this.onDocChange(update.state.doc.toString());
+              const userInput = update.transactions.some((tr) => {
+                const evt = tr.annotation(Transaction.userEvent);
+                return typeof evt === "string" && (evt.startsWith("input") || evt.startsWith("delete"));
+              });
+              this.onDocChange(update.state.doc.toString(), { userInput });
             }
             const lintChanged = update.transactions.some((tr) =>
               tr.effects.some((effect) => effect.is(setDiagnosticsEffect)),

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -63,6 +63,28 @@ export interface LSPCodeActionsResult {
   actions: LSPCodeAction[];
 }
 
+// Mirrors go.lsp.dev/protocol SymbolKind values used by the outline.
+export const SymbolKind = {
+  File: 1,
+  Namespace: 3,
+  Class: 5,
+  Function: 12,
+  Struct: 23,
+} as const;
+export type SymbolKindValue = (typeof SymbolKind)[keyof typeof SymbolKind] | number;
+
+export interface DocumentSymbol {
+  name: string;
+  kind: SymbolKindValue;
+  range: LSPRange;
+  selectionRange: LSPRange;
+  children?: DocumentSymbol[];
+}
+
+export interface DocumentSymbolsResult {
+  symbols: DocumentSymbol[];
+}
+
 export interface SpellcheckRange {
   start: LSPPosition;
   end: LSPPosition;
@@ -99,6 +121,7 @@ export interface EditorEnv {
   upgradeV1(source: string): Promise<{ source: string; changed: boolean }>;
   completion(source: string, line: number, col: number): Promise<LSPCompletionList>;
   codeActions(source: string, line: number, col: number, codes?: string[]): Promise<LSPCodeActionsResult>;
+  documentSymbols(source: string): Promise<DocumentSymbolsResult>;
   semanticTokens(source: string): Promise<Uint32Array>;
   tokenTypeNames(): Promise<string[]>;
 

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -71,11 +71,10 @@ export const SymbolKind = {
   Function: 12,
   Struct: 23,
 } as const;
-export type SymbolKindValue = (typeof SymbolKind)[keyof typeof SymbolKind] | number;
 
 export interface DocumentSymbol {
   name: string;
-  kind: SymbolKindValue;
+  kind: number;
   range: LSPRange;
   selectionRange: LSPRange;
   children?: DocumentSymbol[];

--- a/web/src/scroll-sync.ts
+++ b/web/src/scroll-sync.ts
@@ -18,6 +18,11 @@ export function createScrollSyncPlugin(iframe: HTMLIFrameElement) {
   let lastSyncMode: SyncMode | null = null;
   let lastDocument: Document | null = null;
 
+  function topLineAtScroll(view: EditorView): number {
+    const topBlock = view.elementAtHeight(view.scrollDOM.scrollTop);
+    return view.state.doc.lineAt(topBlock.from).number;
+  }
+
   function syncToLine(view: EditorView, lineNumber: number, mode: SyncMode) {
     let idoc: Document | null = null;
     try {
@@ -89,11 +94,8 @@ export function createScrollSyncPlugin(iframe: HTMLIFrameElement) {
         const resyncTop = () => {
           if (rafId) cancelAnimationFrame(rafId);
           rafId = requestAnimationFrame(() => {
-            const topBlock = view.elementAtHeight(view.scrollDOM.scrollTop);
-            const topLine = view.state.doc.lineAt(topBlock.from).number;
-            // Force re-sync after a viewport resize even if the top line hasn't changed,
-            // because the preview's viewport may have shrunk (e.g., drawer opening) and
-            // its scrollTop needs to be recomputed.
+            const topLine = topLineAtScroll(view);
+            // Force a re-sync after a viewport resize so the preview's scrollTop is recomputed.
             lastSyncLine = -1;
             lastSyncMode = null;
             syncToLine(view, topLine, 'top');
@@ -104,8 +106,7 @@ export function createScrollSyncPlugin(iframe: HTMLIFrameElement) {
         this.scrollHandler = () => {
           if (rafId) cancelAnimationFrame(rafId);
           rafId = requestAnimationFrame(() => {
-            const topBlock = view.elementAtHeight(view.scrollDOM.scrollTop);
-            const topLine = view.state.doc.lineAt(topBlock.from).number;
+            const topLine = topLineAtScroll(view);
             syncToLine(view, topLine, 'top');
             rafId = null;
           });

--- a/web/src/scroll-sync.ts
+++ b/web/src/scroll-sync.ts
@@ -81,10 +81,26 @@ export function createScrollSyncPlugin(iframe: HTMLIFrameElement) {
     class {
       private scrollHandler: () => void;
       private scrollDOM: HTMLElement;
+      private resizeObserver: ResizeObserver | null = null;
 
       constructor(private view: EditorView) {
         this.scrollDOM = view.scrollDOM;
-        
+
+        const resyncTop = () => {
+          if (rafId) cancelAnimationFrame(rafId);
+          rafId = requestAnimationFrame(() => {
+            const topBlock = view.elementAtHeight(view.scrollDOM.scrollTop);
+            const topLine = view.state.doc.lineAt(topBlock.from).number;
+            // Force re-sync after a viewport resize even if the top line hasn't changed,
+            // because the preview's viewport may have shrunk (e.g., drawer opening) and
+            // its scrollTop needs to be recomputed.
+            lastSyncLine = -1;
+            lastSyncMode = null;
+            syncToLine(view, topLine, 'top');
+            rafId = null;
+          });
+        };
+
         this.scrollHandler = () => {
           if (rafId) cancelAnimationFrame(rafId);
           rafId = requestAnimationFrame(() => {
@@ -98,6 +114,11 @@ export function createScrollSyncPlugin(iframe: HTMLIFrameElement) {
         this.scrollDOM.addEventListener("scroll", this.scrollHandler, {
           passive: true,
         });
+
+        if (typeof ResizeObserver !== 'undefined') {
+          this.resizeObserver = new ResizeObserver(() => resyncTop());
+          this.resizeObserver.observe(this.scrollDOM);
+        }
       }
 
       update(update: ViewUpdate) {
@@ -110,6 +131,8 @@ export function createScrollSyncPlugin(iframe: HTMLIFrameElement) {
 
       destroy() {
         this.scrollDOM.removeEventListener("scroll", this.scrollHandler);
+        this.resizeObserver?.disconnect();
+        this.resizeObserver = null;
         if (rafId) cancelAnimationFrame(rafId);
       }
     },

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -6,6 +6,7 @@ import type {
   LSPCompletionList,
   LSPCodeActionsResult,
   SpellcheckContext,
+  DocumentSymbolsResult,
 } from "./core/types";
 
 declare class Go {
@@ -23,6 +24,7 @@ declare global {
       upgradeV1(source: string): { source: string; changed: boolean };
       completion(source: string, line: number, col: number): LSPCompletionList;
       codeActions(source: string, line: number, col: number, codes?: string[]): LSPCodeActionsResult;
+      documentSymbols(source: string): DocumentSymbolsResult;
       renderHTML(source: string, style?: string): string;
       renderPDF(source: string, style?: string): Uint8Array;
       semanticTokens(source: string): Uint32Array;

--- a/web/src/web-app.ts
+++ b/web/src/web-app.ts
@@ -10,6 +10,7 @@ import type {
   LSPCompletionList,
   LSPCodeActionsResult,
   SpellcheckContext,
+  DocumentSymbolsResult,
 } from "./core/types";
 
 declare const __APP_VERSION__: string;
@@ -68,6 +69,10 @@ class WebEnv implements EditorEnv {
     codes?: string[],
   ): Promise<LSPCodeActionsResult> {
     return window.downstage.codeActions(source, line, col, codes);
+  }
+
+  async documentSymbols(source: string): Promise<DocumentSymbolsResult> {
+    return window.downstage.documentSymbols(source);
   }
 
   async semanticTokens(source: string): Promise<Uint32Array> {


### PR DESCRIPTION
## Summary

- **Document outline** — new tab in the workbench drawer for jumping to acts, scenes, dramatis personae, and songs. Backed by the existing LSP symbol provider (`ComputeDocumentSymbols`), exposed to the web editor via a new `documentSymbols` WASM bridge. Act/Scene labels now include both number and title when present (e.g. "Act I: The Beginning"), which also flows through to the VS Code outline.
- **Scroll-sync fixes** discovered while building the outline:
  - Title-page inner elements (`<h1>`, subtitle, authors, metadata entries) now carry per-entry `data-source-line` anchors, so scrolling the front matter no longer rockets the preview through 80vh per source line.
  - Act/scene/generic section headings get their own anchor via `HeadingRange()`, so clicking a scene heading centers the heading instead of landing mid-scene.
  - `ResizeObserver` on the editor's `scrollDOM` re-triggers the sync when the drawer opens/closes or the panes resize.
- **Workbench UX**:
  - Outline tab is first; Issues remains the default selection (keeps the FAB semantics intact).
  - Issues FAB is icon + count only, with the full label in the tooltip. Hidden entirely when clean, and fades in 1.5s after the last keystroke so diagnostics don't distract mid-flow. "Typing" is gated on real CodeMirror `input`/`delete` user-event transactions, so programmatic changes (search & replace, V1 upgrade, draft switch) don't hide the FAB.
- **Consolidation**: HTML title-page partitioning is now a single helper (returns `*KeyValue`/`[]KeyValue`) with last-wins semantics, matching the PDF renderer — fixes a latent bug where duplicate `Title:`/`Subtitle:` entries would render different values in HTML vs. PDF.

## Test plan

- [x] `go test ./...` passes (incl. new `TestRender_TitlePageDuplicateTitleSubtitleUsesLastWins`, `TestComputeDocumentSymbols_ActSceneNumberedOnly`, updated `TestComputeDocumentSymbols_Act`)
- [x] `cd web && npm run test` passes (typecheck + 54 vitest cases)
- [x] `make wasm` rebuilds clean
- [x] `cd web && npm run build` clean
- [ ] Load a multi-act script in the browser:
  - [ ] Toggle outline from toolbar button and drawer tab
  - [ ] Click acts/scenes/DP/songs and confirm preview centers the heading
  - [ ] Edit a heading, outline updates within ~300 ms
  - [ ] Empty document shows the outline empty state
  - [ ] Drawer open/close re-aligns the preview scroll
  - [ ] Scroll through title page — preview tracks smoothly
  - [ ] FAB fades in only on real typing idle; stays put during search/replace and draft switches