### PR TITLE
feat(lexer): require blank line before cue

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -57,7 +57,7 @@ The following older patterns are no longer part of the preferred model:
 
 - document-level `Key: Value` frontmatter before the first `#` heading
 - document-level `# Dramatis Personae`
-- ALL-CAPS lines recognised as cues without a preceding blank line (a cue must now follow a blank line or the start of the document; comments with a blank line above them are transparent; use `@NAME` to force a cue in tight positions)
+- ALL-CAPS cues without a preceding blank line (cues need a blank line or the start of the document; use `@NAME` to force one)
 
 Instead:
 
@@ -276,40 +276,18 @@ In a multi-play file, act and scene numbering is scoped to the enclosing top-lev
 
 ## 7. Dialogue
 
-Dialogue is the primary content type. A dialogue block consists of:
+Dialogue is the primary content type. A dialogue block consists of a cue, an optional parenthetical, and one or more lines of dialogue text.
 
-1. A **character name** on its own line (ALL CAPS)
-2. An optional **parenthetical** on the next line
-3. One or more lines of **dialogue text**
-
-An ALL-CAPS line is only recognised as a cue when it is preceded by a blank line or is the first line of the document. Comments are transparent: a line comment or block comment above an ALL-CAPS line counts as the cue's preceding context, provided the comment itself has a blank line (or the start of the document) before it.
-
-This means an ALL-CAPS line that appears on the line directly after another cue, a parenthetical, or dialogue body text is treated as shouted dialogue, not as a new cue:
+An ALL-CAPS line is only a cue at the start of a document or after a blank line. Comments do not reset cue context. So `WHAT` under `JIM` stays dialogue, not a new character.
 
 ```
 JIM
 WHAT
 ```
 
-Here `WHAT` is Jim's line, not a new character. The same applies when a parenthetical sits between the cue and the shouted line:
+A parenthetical between the cue and the shouted line does not change this.
 
-```
-JIM
-(angrily)
-WHAT
-```
-
-A comment with a blank line before it keeps the cue recognisable:
-
-```
-// note: make jim meaner
-JIM
-I am angry
-```
-
-Structural elements that are not followed by a blank line do **not** start a cue. An ALL-CAPS line immediately after a heading, page break, or stage direction falls through to the implicit-stage-direction rule (Section 8) and renders as italic text. Writers should put a blank line before every cue.
-
-When a cue is needed without a preceding blank line, use the forced-cue form `@NAME` (see Section 14). Forced cues are always recognised regardless of what came before them.
+Use `@NAME` when you need a cue without a blank line (see Section 14).
 
 ```
 HAMLET

--- a/SPEC.md
+++ b/SPEC.md
@@ -57,6 +57,7 @@ The following older patterns are no longer part of the preferred model:
 
 - document-level `Key: Value` frontmatter before the first `#` heading
 - document-level `# Dramatis Personae`
+- ALL-CAPS lines recognised as cues without a preceding block boundary (a cue must now follow a blank line or other structural marker; use `@NAME` to force a cue in tight positions)
 
 Instead:
 
@@ -280,6 +281,25 @@ Dialogue is the primary content type. A dialogue block consists of:
 1. A **character name** on its own line (ALL CAPS)
 2. An optional **parenthetical** on the next line
 3. One or more lines of **dialogue text**
+
+A character name is only recognised as a cue when it appears at a **block boundary** — the start of the document, the line immediately after a blank line, or the line immediately after a structural element such as a heading, page break, stage direction, callout, or `SONG` / `SONG END` marker. Line and block comments are transparent for this rule: a comment between a dialogue body line and a following ALL-CAPS line does not reopen a cue.
+
+This means an ALL-CAPS line that appears on the line directly after another cue, a parenthetical, or dialogue body text is treated as shouted dialogue, not as a new cue:
+
+```
+JIM
+WHAT
+```
+
+Here `WHAT` is Jim's line, not a new character. The same applies when a parenthetical sits between the cue and the shouted line:
+
+```
+JIM
+(angrily)
+WHAT
+```
+
+When an author truly needs a cue without a preceding blank line, use the forced-cue form `@NAME` (see Section 14). Forced cues are always recognised regardless of what came before them.
 
 ```
 HAMLET

--- a/SPEC.md
+++ b/SPEC.md
@@ -57,7 +57,7 @@ The following older patterns are no longer part of the preferred model:
 
 - document-level `Key: Value` frontmatter before the first `#` heading
 - document-level `# Dramatis Personae`
-- ALL-CAPS lines recognised as cues without a preceding block boundary (a cue must now follow a blank line or other structural marker; use `@NAME` to force a cue in tight positions)
+- ALL-CAPS lines recognised as cues without a preceding blank line (a cue must now follow a blank line or the start of the document; comments with a blank line above them are transparent; use `@NAME` to force a cue in tight positions)
 
 Instead:
 
@@ -282,7 +282,7 @@ Dialogue is the primary content type. A dialogue block consists of:
 2. An optional **parenthetical** on the next line
 3. One or more lines of **dialogue text**
 
-A character name is only recognised as a cue when it appears at a **block boundary** — the start of the document, the line immediately after a blank line, or the line immediately after a structural element such as a heading, page break, stage direction, callout, or `SONG` / `SONG END` marker. Line and block comments are transparent for this rule: a comment between a dialogue body line and a following ALL-CAPS line does not reopen a cue.
+An ALL-CAPS line is only recognised as a cue when it is preceded by a blank line or is the first line of the document. Comments are transparent: a line comment or block comment above an ALL-CAPS line counts as the cue's preceding context, provided the comment itself has a blank line (or the start of the document) before it.
 
 This means an ALL-CAPS line that appears on the line directly after another cue, a parenthetical, or dialogue body text is treated as shouted dialogue, not as a new cue:
 
@@ -299,7 +299,17 @@ JIM
 WHAT
 ```
 
-When an author truly needs a cue without a preceding blank line, use the forced-cue form `@NAME` (see Section 14). Forced cues are always recognised regardless of what came before them.
+A comment with a blank line before it keeps the cue recognisable:
+
+```
+// note: make jim meaner
+JIM
+I am angry
+```
+
+Structural elements that are not followed by a blank line do **not** start a cue. An ALL-CAPS line immediately after a heading, page break, or stage direction falls through to the implicit-stage-direction rule (Section 8) and renders as italic text. Writers should put a blank line before every cue.
+
+When a cue is needed without a preceding blank line, use the forced-cue form `@NAME` (see Section 14). Forced cues are always recognised regardless of what came before them.
 
 ```
 HAMLET

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -238,7 +238,9 @@ func (l *lexer) classifyBodyLine(line, trimmed string, lineNum, lineLen int) {
 	// ALL CAPS character name: must be preceded by a blank line (or the start
 	// of the document) so that shouted dialogue ("WHAT") following a cue line
 	// isn't misread as a new cue. Comments are transparent. Use `@NAME` to
-	// force a cue without a blank line.
+	// force a cue without a blank line. When the rule fails the line falls
+	// through to Text; the parser promotes it to an implicit stage direction
+	// in leaf generic sections (see IsCharacterName).
 	if isCharacterName(trimmed) && l.cueAllowed {
 		l.emit(token.CharacterName, trimmed, line, lineNum, 0, lineLen)
 		return
@@ -272,6 +274,13 @@ func (l *lexer) emit(typ token.Type, literal, sourceLine string, line, colStart,
 	}
 	l.cueAllowed = typ == token.Blank
 }
+
+// IsCharacterName reports whether s looks like an ALL CAPS character name.
+// Exposed so the parser can recognise ALL-CAPS lines that were demoted to
+// Text by the strict cue rule and promote them to implicit stage directions
+// in contexts (like leaf generic sections) where plain text otherwise
+// becomes prose.
+func IsCharacterName(s string) bool { return isCharacterName(s) }
 
 // isCharacterName returns true if s looks like an ALL CAPS character name.
 // Must be 1+ characters, contain at least one letter, and consist only of

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -38,11 +38,7 @@ type lexer struct {
 	offset  int // byte offset of the current line start
 	tokens  []token.Token
 	inBlock bool // inside a block comment
-	// cueAllowed is true when the current line can start a cue: the previous
-	// non-comment line was blank, or the line is the start of the document.
-	// Comments (line and block) are transparent — they don't change the flag,
-	// so a comment with a blank line before it still allows the following line
-	// to be a cue.
+	// cueAllowed reports whether the current line may start a cue.
 	cueAllowed bool
 }
 
@@ -170,8 +166,6 @@ func (l *lexer) lex() {
 
 func (l *lexer) classifyBodyLine(line, trimmed string, lineNum, lineLen int) {
 	// Dual dialogue: character name or forced character ending with ^.
-	// A ^-marked cue still needs a block boundary before it — unless it's an
-	// @-forced name, which always wins.
 	if strings.HasSuffix(trimmed, " ^") || strings.HasSuffix(trimmed, "\t^") {
 		name := strings.TrimSpace(trimmed[:len(trimmed)-2])
 		if strings.HasPrefix(name, "@") && len(name) > 1 {
@@ -184,8 +178,7 @@ func (l *lexer) classifyBodyLine(line, trimmed string, lineNum, lineLen int) {
 		}
 	}
 
-	// Forced character: @TEXT. Always recognised — this is the escape hatch for
-	// cues that can't have a blank line before them.
+	// Forced character: @TEXT.
 	if strings.HasPrefix(trimmed, "@") && len(trimmed) > 1 {
 		l.emit(token.ForcedCharacter, trimmed, line, lineNum, 0, lineLen)
 		return
@@ -235,12 +228,7 @@ func (l *lexer) classifyBodyLine(line, trimmed string, lineNum, lineLen int) {
 		return
 	}
 
-	// ALL CAPS character name: must be preceded by a blank line (or the start
-	// of the document) so that shouted dialogue ("WHAT") following a cue line
-	// isn't misread as a new cue. Comments are transparent. Use `@NAME` to
-	// force a cue without a blank line. When the rule fails the line falls
-	// through to Text; the parser promotes it to an implicit stage direction
-	// in leaf generic sections (see IsCharacterName).
+	// ALL CAPS character name: requires a blank line or document start.
 	if isCharacterName(trimmed) && l.cueAllowed {
 		l.emit(token.CharacterName, trimmed, line, lineNum, 0, lineLen)
 		return
@@ -261,10 +249,7 @@ func (l *lexer) emit(typ token.Type, literal, sourceLine string, line, colStart,
 			End:   token.Position{Line: line, Column: endColumn, Offset: l.offset + colEnd},
 		},
 	})
-	// Comments are transparent for cue-context tracking: a comment between a
-	// blank line and a cue preserves cueAllowed, and a comment between a
-	// dialogue body line and a shouted ALL-CAPS line does not reopen a cue.
-	// Block-comment body lines (emitted while inBlock) are likewise invisible.
+	// Comments do not change cue context.
 	switch typ {
 	case token.LineComment, token.BlockCommentStart, token.BlockCommentEnd:
 		return
@@ -276,10 +261,6 @@ func (l *lexer) emit(typ token.Type, literal, sourceLine string, line, colStart,
 }
 
 // IsCharacterName reports whether s looks like an ALL CAPS character name.
-// Exposed so the parser can recognise ALL-CAPS lines that were demoted to
-// Text by the strict cue rule and promote them to implicit stage directions
-// in contexts (like leaf generic sections) where plain text otherwise
-// becomes prose.
 func IsCharacterName(s string) bool { return isCharacterName(s) }
 
 // isCharacterName returns true if s looks like an ALL CAPS character name.

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -25,6 +25,7 @@ func Lex(input []byte) []token.Token {
 		offset:  0,
 		tokens:  make([]token.Token, 0, 256),
 		inBlock: false,
+		prev:    token.Blank,
 	}
 	l.lex()
 	return l.tokens
@@ -37,6 +38,11 @@ type lexer struct {
 	offset  int // byte offset of the current line start
 	tokens  []token.Token
 	inBlock bool // inside a block comment
+	// prev is the last emitted non-comment token type. It's used to decide
+	// whether a cue is allowed on the current line: a cue must be preceded by
+	// a block boundary (blank line, heading, page break, etc.), not by dialogue
+	// body content. Initialized to Blank so start-of-document allows a cue.
+	prev token.Type
 }
 
 func (l *lexer) lex() {
@@ -162,20 +168,23 @@ func (l *lexer) lex() {
 }
 
 func (l *lexer) classifyBodyLine(line, trimmed string, lineNum, lineLen int) {
-	// Dual dialogue: character name or forced character ending with ^
+	// Dual dialogue: character name or forced character ending with ^.
+	// A ^-marked cue still needs a block boundary before it — unless it's an
+	// @-forced name, which always wins.
 	if strings.HasSuffix(trimmed, " ^") || strings.HasSuffix(trimmed, "\t^") {
 		name := strings.TrimSpace(trimmed[:len(trimmed)-2])
 		if strings.HasPrefix(name, "@") && len(name) > 1 {
 			l.emit(token.DualDialogueChar, name, line, lineNum, 0, len(name))
 			return
 		}
-		if isCharacterName(name) {
+		if isCharacterName(name) && canStartCue(l.prev) {
 			l.emit(token.DualDialogueChar, name, line, lineNum, 0, len(name))
 			return
 		}
 	}
 
-	// Forced character: @TEXT
+	// Forced character: @TEXT. Always recognised — this is the escape hatch for
+	// cues that can't have a blank line before them.
 	if strings.HasPrefix(trimmed, "@") && len(trimmed) > 1 {
 		l.emit(token.ForcedCharacter, trimmed, line, lineNum, 0, lineLen)
 		return
@@ -225,8 +234,10 @@ func (l *lexer) classifyBodyLine(line, trimmed string, lineNum, lineLen int) {
 		return
 	}
 
-	// ALL CAPS character name: 2+ chars, only uppercase letters, digits, spaces, and punctuation
-	if isCharacterName(trimmed) {
+	// ALL CAPS character name: must be preceded by a block boundary so that
+	// shouted dialogue ("WHAT") following a cue line isn't misread as a new
+	// cue. Use `@NAME` to force a cue without a blank line.
+	if isCharacterName(trimmed) && canStartCue(l.prev) {
 		l.emit(token.CharacterName, trimmed, line, lineNum, 0, lineLen)
 		return
 	}
@@ -246,6 +257,34 @@ func (l *lexer) emit(typ token.Type, literal, sourceLine string, line, colStart,
 			End:   token.Position{Line: line, Column: endColumn, Offset: l.offset + colEnd},
 		},
 	})
+	// Comments are transparent for cue-context tracking: a comment between a
+	// cue line and its dialogue body shouldn't re-enable a cue on the next
+	// line. Block-comment body lines (emitted while inBlock) are likewise
+	// invisible.
+	switch typ {
+	case token.LineComment, token.BlockCommentStart, token.BlockCommentEnd:
+		return
+	}
+	if l.inBlock {
+		return
+	}
+	l.prev = typ
+}
+
+// canStartCue reports whether a cue (CharacterName or non-forced
+// DualDialogueChar) is allowed on the current line, given the last meaningful
+// token type. A cue must follow a block boundary so that ALL-CAPS dialogue
+// content doesn't get misread as a new cue.
+func canStartCue(prev token.Type) bool {
+	switch prev {
+	case token.Text,
+		token.Verse,
+		token.CharacterName,
+		token.ForcedCharacter,
+		token.DualDialogueChar:
+		return false
+	}
+	return true
 }
 
 // isCharacterName returns true if s looks like an ALL CAPS character name.

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -19,13 +19,13 @@ const (
 // Lex tokenizes the input bytes into a slice of tokens.
 func Lex(input []byte) []token.Token {
 	l := &lexer{
-		input:   input,
-		lines:   bytes.Split(input, []byte("\n")),
-		ctx:     ctxTitlePage,
-		offset:  0,
-		tokens:  make([]token.Token, 0, 256),
-		inBlock: false,
-		prev:    token.Blank,
+		input:      input,
+		lines:      bytes.Split(input, []byte("\n")),
+		ctx:        ctxTitlePage,
+		offset:     0,
+		tokens:     make([]token.Token, 0, 256),
+		inBlock:    false,
+		cueAllowed: true,
 	}
 	l.lex()
 	return l.tokens
@@ -38,11 +38,12 @@ type lexer struct {
 	offset  int // byte offset of the current line start
 	tokens  []token.Token
 	inBlock bool // inside a block comment
-	// prev is the last emitted non-comment token type. It's used to decide
-	// whether a cue is allowed on the current line: a cue must be preceded by
-	// a block boundary (blank line, heading, page break, etc.), not by dialogue
-	// body content. Initialized to Blank so start-of-document allows a cue.
-	prev token.Type
+	// cueAllowed is true when the current line can start a cue: the previous
+	// non-comment line was blank, or the line is the start of the document.
+	// Comments (line and block) are transparent — they don't change the flag,
+	// so a comment with a blank line before it still allows the following line
+	// to be a cue.
+	cueAllowed bool
 }
 
 func (l *lexer) lex() {
@@ -177,7 +178,7 @@ func (l *lexer) classifyBodyLine(line, trimmed string, lineNum, lineLen int) {
 			l.emit(token.DualDialogueChar, name, line, lineNum, 0, len(name))
 			return
 		}
-		if isCharacterName(name) && canStartCue(l.prev) {
+		if isCharacterName(name) && l.cueAllowed {
 			l.emit(token.DualDialogueChar, name, line, lineNum, 0, len(name))
 			return
 		}
@@ -234,10 +235,11 @@ func (l *lexer) classifyBodyLine(line, trimmed string, lineNum, lineLen int) {
 		return
 	}
 
-	// ALL CAPS character name: must be preceded by a block boundary so that
-	// shouted dialogue ("WHAT") following a cue line isn't misread as a new
-	// cue. Use `@NAME` to force a cue without a blank line.
-	if isCharacterName(trimmed) && canStartCue(l.prev) {
+	// ALL CAPS character name: must be preceded by a blank line (or the start
+	// of the document) so that shouted dialogue ("WHAT") following a cue line
+	// isn't misread as a new cue. Comments are transparent. Use `@NAME` to
+	// force a cue without a blank line.
+	if isCharacterName(trimmed) && l.cueAllowed {
 		l.emit(token.CharacterName, trimmed, line, lineNum, 0, lineLen)
 		return
 	}
@@ -258,9 +260,9 @@ func (l *lexer) emit(typ token.Type, literal, sourceLine string, line, colStart,
 		},
 	})
 	// Comments are transparent for cue-context tracking: a comment between a
-	// cue line and its dialogue body shouldn't re-enable a cue on the next
-	// line. Block-comment body lines (emitted while inBlock) are likewise
-	// invisible.
+	// blank line and a cue preserves cueAllowed, and a comment between a
+	// dialogue body line and a shouted ALL-CAPS line does not reopen a cue.
+	// Block-comment body lines (emitted while inBlock) are likewise invisible.
 	switch typ {
 	case token.LineComment, token.BlockCommentStart, token.BlockCommentEnd:
 		return
@@ -268,23 +270,7 @@ func (l *lexer) emit(typ token.Type, literal, sourceLine string, line, colStart,
 	if l.inBlock {
 		return
 	}
-	l.prev = typ
-}
-
-// canStartCue reports whether a cue (CharacterName or non-forced
-// DualDialogueChar) is allowed on the current line, given the last meaningful
-// token type. A cue must follow a block boundary so that ALL-CAPS dialogue
-// content doesn't get misread as a new cue.
-func canStartCue(prev token.Type) bool {
-	switch prev {
-	case token.Text,
-		token.Verse,
-		token.CharacterName,
-		token.ForcedCharacter,
-		token.DualDialogueChar:
-		return false
-	}
-	return true
+	l.cueAllowed = typ == token.Blank
 }
 
 // isCharacterName returns true if s looks like an ALL CAPS character name.

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -248,25 +248,30 @@ func TestDramatisPersonae(t *testing.T) {
 	input := "# Dramatis Personae\n## The Court\nKING LEAR\nCORDELIA\n# Act One"
 	tokens := Lex([]byte(input))
 
-	// All headings are generic now — no special DP tokens. KING LEAR is a cue
-	// token (preceded by a heading); CORDELIA is Text because it's on the
-	// line immediately after another cue-shaped line. The DP parser accepts
-	// either token type as a character entry, so semantic behaviour is
+	// All headings are generic now — no special DP tokens. KING LEAR and
+	// CORDELIA both tokenize as Text because neither has a blank line before
+	// it (the strict cue rule). The DP parser accepts Text as a character
+	// entry, so semantic behaviour in Dramatis Personae sections is
 	// unchanged.
 	assert.Equal(t, token.HeadingH1, tokens[0].Type)
 	assert.Equal(t, "Dramatis Personae", tokens[0].Literal)
 	assert.Equal(t, token.HeadingH2, tokens[1].Type)
 	assert.Equal(t, "The Court", tokens[1].Literal)
-	assert.Equal(t, token.CharacterName, tokens[2].Type)
+	assert.Equal(t, token.Text, tokens[2].Type)
 	assert.Equal(t, token.Text, tokens[3].Type)
 	assert.Equal(t, token.HeadingH1, tokens[4].Type)
 }
 
-func TestCueRequiresBlockBoundary(t *testing.T) {
-	// Adjacent ALL-CAPS lines: the second should be dialogue text, not a cue.
-	tokens := Lex([]byte("JIM\nWHAT\n"))
+func TestCueRequiresBlankLineBefore(t *testing.T) {
+	// Start of document is an implicit blank line.
+	tokens := Lex([]byte("JIM\nHello\n"))
 	assert.Equal(t, token.CharacterName, tokens[0].Type)
 	assert.Equal(t, "JIM", tokens[0].Literal)
+	assert.Equal(t, token.Text, tokens[1].Type)
+
+	// Adjacent ALL-CAPS lines: the second is dialogue text, not a cue.
+	tokens = Lex([]byte("JIM\nWHAT\n"))
+	assert.Equal(t, token.CharacterName, tokens[0].Type)
 	assert.Equal(t, token.Text, tokens[1].Type)
 	assert.Equal(t, "WHAT", tokens[1].Literal)
 
@@ -276,36 +281,68 @@ func TestCueRequiresBlockBoundary(t *testing.T) {
 	assert.Equal(t, token.Text, tokens[1].Type)
 	assert.Equal(t, token.Text, tokens[2].Type)
 
-	// Comment between cue and shouted dialogue is transparent: still text.
-	tokens = Lex([]byte("JIM\n// beat\nWHAT\n"))
-	assert.Equal(t, token.CharacterName, tokens[0].Type)
-	assert.Equal(t, token.LineComment, tokens[1].Type)
-	assert.Equal(t, token.Text, tokens[2].Type)
+	// A comment with a blank line before it is transparent — the cue after
+	// it is still valid.
+	tokens = Lex([]byte("# Play\n\n// note: make jim meaner\nJIM\nI am angry\n"))
+	assert.Equal(t, token.HeadingH1, tokens[0].Type)
+	assert.Equal(t, token.Blank, tokens[1].Type)
+	assert.Equal(t, token.LineComment, tokens[2].Type)
+	assert.Equal(t, token.CharacterName, tokens[3].Type)
+	assert.Equal(t, token.Text, tokens[4].Type)
 
-	// Blank line restores cue context.
-	tokens = Lex([]byte("JIM\nHello.\n\nJANE\nHi.\n"))
+	// Block comment with a blank line before it is transparent as well.
+	tokens = Lex([]byte("# Play\n\n/*\nnote:\naddress comments\n*/\nJIM\nHello\n"))
+	assert.Equal(t, token.HeadingH1, tokens[0].Type)
+	assert.Equal(t, token.Blank, tokens[1].Type)
+	assert.Equal(t, token.BlockCommentStart, tokens[2].Type)
+	// body lines of the block comment emit Text, but they're invisible to the
+	// cue-context tracker.
+	for i := 3; i < 5; i++ {
+		assert.Equal(t, token.Text, tokens[i].Type)
+	}
+	assert.Equal(t, token.BlockCommentEnd, tokens[5].Type)
+	assert.Equal(t, token.CharacterName, tokens[6].Type)
+
+	// A comment between dialogue body and an ALL-CAPS line does NOT reopen a
+	// cue — the comment has no blank line before it.
+	tokens = Lex([]byte("JIM\nHello.\n// inline note\nWHAT\n"))
 	assert.Equal(t, token.CharacterName, tokens[0].Type)
 	assert.Equal(t, token.Text, tokens[1].Type)
-	assert.Equal(t, token.Blank, tokens[2].Type)
-	assert.Equal(t, token.CharacterName, tokens[3].Type)
+	assert.Equal(t, token.LineComment, tokens[2].Type)
+	assert.Equal(t, token.Text, tokens[3].Type)
 
-	// Forced character always wins, even with no blank line.
+	// Heading without a blank line is NOT a cue boundary under the strict
+	// rule. ALICE becomes text (and the parser will render it as an implicit
+	// stage direction).
+	tokens = Lex([]byte("### SCENE 1\nALICE\nHello\n"))
+	assert.Equal(t, token.HeadingH3, tokens[0].Type)
+	assert.Equal(t, token.Text, tokens[1].Type)
+	assert.Equal(t, token.Text, tokens[2].Type)
+
+	// Page break without a blank line is also NOT a cue boundary.
+	tokens = Lex([]byte("===\n// note\nJIM\nHello\n"))
+	assert.Equal(t, token.PageBreak, tokens[0].Type)
+	assert.Equal(t, token.LineComment, tokens[1].Type)
+	assert.Equal(t, token.Text, tokens[2].Type)
+	assert.Equal(t, token.Text, tokens[3].Type)
+
+	// Forced character always wins, even without a blank line.
 	tokens = Lex([]byte("JIM\nHello.\n@JANE\nHi.\n"))
 	assert.Equal(t, token.CharacterName, tokens[0].Type)
 	assert.Equal(t, token.Text, tokens[1].Type)
 	assert.Equal(t, token.ForcedCharacter, tokens[2].Type)
 
-	// Stage direction is a block boundary — cue allowed immediately after.
-	tokens = Lex([]byte("> Lights up.\nALICE\nHi.\n"))
-	assert.Equal(t, token.StageDirection, tokens[0].Type)
-	assert.Equal(t, token.CharacterName, tokens[1].Type)
-	assert.Equal(t, token.Text, tokens[2].Type)
-
-	// Dual dialogue also needs a block boundary.
+	// Dual dialogue also needs a blank line before it.
 	tokens = Lex([]byte("JIM\nHello.\nJANE ^\nHi.\n"))
 	assert.Equal(t, token.CharacterName, tokens[0].Type)
 	assert.Equal(t, token.Text, tokens[1].Type)
 	assert.Equal(t, token.Text, tokens[2].Type)
+
+	tokens = Lex([]byte("JIM\nHello.\n\nJANE ^\nHi.\n"))
+	assert.Equal(t, token.CharacterName, tokens[0].Type)
+	assert.Equal(t, token.Text, tokens[1].Type)
+	assert.Equal(t, token.Blank, tokens[2].Type)
+	assert.Equal(t, token.DualDialogueChar, tokens[3].Type)
 }
 
 func TestPositionTracking(t *testing.T) {

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -248,14 +248,64 @@ func TestDramatisPersonae(t *testing.T) {
 	input := "# Dramatis Personae\n## The Court\nKING LEAR\nCORDELIA\n# Act One"
 	tokens := Lex([]byte(input))
 
-	// All headings are generic now — no special DP tokens
+	// All headings are generic now — no special DP tokens. KING LEAR is a cue
+	// token (preceded by a heading); CORDELIA is Text because it's on the
+	// line immediately after another cue-shaped line. The DP parser accepts
+	// either token type as a character entry, so semantic behaviour is
+	// unchanged.
 	assert.Equal(t, token.HeadingH1, tokens[0].Type)
 	assert.Equal(t, "Dramatis Personae", tokens[0].Literal)
 	assert.Equal(t, token.HeadingH2, tokens[1].Type)
 	assert.Equal(t, "The Court", tokens[1].Literal)
 	assert.Equal(t, token.CharacterName, tokens[2].Type)
-	assert.Equal(t, token.CharacterName, tokens[3].Type)
+	assert.Equal(t, token.Text, tokens[3].Type)
 	assert.Equal(t, token.HeadingH1, tokens[4].Type)
+}
+
+func TestCueRequiresBlockBoundary(t *testing.T) {
+	// Adjacent ALL-CAPS lines: the second should be dialogue text, not a cue.
+	tokens := Lex([]byte("JIM\nWHAT\n"))
+	assert.Equal(t, token.CharacterName, tokens[0].Type)
+	assert.Equal(t, "JIM", tokens[0].Literal)
+	assert.Equal(t, token.Text, tokens[1].Type)
+	assert.Equal(t, "WHAT", tokens[1].Literal)
+
+	// Parenthetical between cue and shouted dialogue: shouted line stays text.
+	tokens = Lex([]byte("JIM\n(angrily)\nWHAT\n"))
+	assert.Equal(t, token.CharacterName, tokens[0].Type)
+	assert.Equal(t, token.Text, tokens[1].Type)
+	assert.Equal(t, token.Text, tokens[2].Type)
+
+	// Comment between cue and shouted dialogue is transparent: still text.
+	tokens = Lex([]byte("JIM\n// beat\nWHAT\n"))
+	assert.Equal(t, token.CharacterName, tokens[0].Type)
+	assert.Equal(t, token.LineComment, tokens[1].Type)
+	assert.Equal(t, token.Text, tokens[2].Type)
+
+	// Blank line restores cue context.
+	tokens = Lex([]byte("JIM\nHello.\n\nJANE\nHi.\n"))
+	assert.Equal(t, token.CharacterName, tokens[0].Type)
+	assert.Equal(t, token.Text, tokens[1].Type)
+	assert.Equal(t, token.Blank, tokens[2].Type)
+	assert.Equal(t, token.CharacterName, tokens[3].Type)
+
+	// Forced character always wins, even with no blank line.
+	tokens = Lex([]byte("JIM\nHello.\n@JANE\nHi.\n"))
+	assert.Equal(t, token.CharacterName, tokens[0].Type)
+	assert.Equal(t, token.Text, tokens[1].Type)
+	assert.Equal(t, token.ForcedCharacter, tokens[2].Type)
+
+	// Stage direction is a block boundary — cue allowed immediately after.
+	tokens = Lex([]byte("> Lights up.\nALICE\nHi.\n"))
+	assert.Equal(t, token.StageDirection, tokens[0].Type)
+	assert.Equal(t, token.CharacterName, tokens[1].Type)
+	assert.Equal(t, token.Text, tokens[2].Type)
+
+	// Dual dialogue also needs a block boundary.
+	tokens = Lex([]byte("JIM\nHello.\nJANE ^\nHi.\n"))
+	assert.Equal(t, token.CharacterName, tokens[0].Type)
+	assert.Equal(t, token.Text, tokens[1].Type)
+	assert.Equal(t, token.Text, tokens[2].Type)
 }
 
 func TestPositionTracking(t *testing.T) {

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -248,11 +248,7 @@ func TestDramatisPersonae(t *testing.T) {
 	input := "# Dramatis Personae\n## The Court\nKING LEAR\nCORDELIA\n# Act One"
 	tokens := Lex([]byte(input))
 
-	// All headings are generic now — no special DP tokens. KING LEAR and
-	// CORDELIA both tokenize as Text because neither has a blank line before
-	// it (the strict cue rule). The DP parser accepts Text as a character
-	// entry, so semantic behaviour in Dramatis Personae sections is
-	// unchanged.
+	// The DP parser still accepts Text entries.
 	assert.Equal(t, token.HeadingH1, tokens[0].Type)
 	assert.Equal(t, "Dramatis Personae", tokens[0].Literal)
 	assert.Equal(t, token.HeadingH2, tokens[1].Type)
@@ -263,7 +259,7 @@ func TestDramatisPersonae(t *testing.T) {
 }
 
 func TestCueRequiresBlankLineBefore(t *testing.T) {
-	// Start of document is an implicit blank line.
+	// Start of document counts as cue context.
 	tokens := Lex([]byte("JIM\nHello\n"))
 	assert.Equal(t, token.CharacterName, tokens[0].Type)
 	assert.Equal(t, "JIM", tokens[0].Literal)
@@ -281,8 +277,7 @@ func TestCueRequiresBlankLineBefore(t *testing.T) {
 	assert.Equal(t, token.Text, tokens[1].Type)
 	assert.Equal(t, token.Text, tokens[2].Type)
 
-	// A comment with a blank line before it is transparent — the cue after
-	// it is still valid.
+	// Comments do not reset cue context.
 	tokens = Lex([]byte("# Play\n\n// note: make jim meaner\nJIM\nI am angry\n"))
 	assert.Equal(t, token.HeadingH1, tokens[0].Type)
 	assert.Equal(t, token.Blank, tokens[1].Type)
@@ -290,36 +285,32 @@ func TestCueRequiresBlankLineBefore(t *testing.T) {
 	assert.Equal(t, token.CharacterName, tokens[3].Type)
 	assert.Equal(t, token.Text, tokens[4].Type)
 
-	// Block comment with a blank line before it is transparent as well.
+	// Block comments are transparent too.
 	tokens = Lex([]byte("# Play\n\n/*\nnote:\naddress comments\n*/\nJIM\nHello\n"))
 	assert.Equal(t, token.HeadingH1, tokens[0].Type)
 	assert.Equal(t, token.Blank, tokens[1].Type)
 	assert.Equal(t, token.BlockCommentStart, tokens[2].Type)
-	// body lines of the block comment emit Text, but they're invisible to the
-	// cue-context tracker.
+	// Body lines stay invisible to cue tracking.
 	for i := 3; i < 5; i++ {
 		assert.Equal(t, token.Text, tokens[i].Type)
 	}
 	assert.Equal(t, token.BlockCommentEnd, tokens[5].Type)
 	assert.Equal(t, token.CharacterName, tokens[6].Type)
 
-	// A comment between dialogue body and an ALL-CAPS line does NOT reopen a
-	// cue — the comment has no blank line before it.
+	// A comment does not reopen cue context.
 	tokens = Lex([]byte("JIM\nHello.\n// inline note\nWHAT\n"))
 	assert.Equal(t, token.CharacterName, tokens[0].Type)
 	assert.Equal(t, token.Text, tokens[1].Type)
 	assert.Equal(t, token.LineComment, tokens[2].Type)
 	assert.Equal(t, token.Text, tokens[3].Type)
 
-	// Heading without a blank line is NOT a cue boundary under the strict
-	// rule. ALICE becomes text (and the parser will render it as an implicit
-	// stage direction).
+	// Without a blank line, ALICE is text.
 	tokens = Lex([]byte("### SCENE 1\nALICE\nHello\n"))
 	assert.Equal(t, token.HeadingH3, tokens[0].Type)
 	assert.Equal(t, token.Text, tokens[1].Type)
 	assert.Equal(t, token.Text, tokens[2].Type)
 
-	// Page break without a blank line is also NOT a cue boundary.
+	// Page breaks do not count.
 	tokens = Lex([]byte("===\n// note\nJIM\nHello\n"))
 	assert.Equal(t, token.PageBreak, tokens[0].Type)
 	assert.Equal(t, token.LineComment, tokens[1].Type)
@@ -332,7 +323,7 @@ func TestCueRequiresBlankLineBefore(t *testing.T) {
 	assert.Equal(t, token.Text, tokens[1].Type)
 	assert.Equal(t, token.ForcedCharacter, tokens[2].Type)
 
-	// Dual dialogue also needs a blank line before it.
+	// Dual dialogue needs the same rule.
 	tokens = Lex([]byte("JIM\nHello.\nJANE ^\nHi.\n"))
 	assert.Equal(t, token.CharacterName, tokens[0].Type)
 	assert.Equal(t, token.Text, tokens[1].Type)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -831,14 +831,8 @@ func (p *parser) parseGenericContent(section *ast.Section, level int) {
 			continue
 		}
 
-		// Structural content and text go into Children by default.
-		// Only Text tokens become Lines (prose reflow) in leaf generic
-		// sections — StageDirections keep their semantics and stay as Children
-		// so the `>` prefix survives rendering. ALL-CAPS lines that the lexer
-		// demoted to Text because they failed the strict cue rule (no blank
-		// line above) are promoted here to implicit stage directions, so the
-		// writer's failed-cue attempt renders as italic text instead of
-		// silently being reflowed as prose.
+		// Text becomes prose in leaf generic sections. Demoted ALL-CAPS lines
+		// are promoted to stage directions so they still render as italic text.
 		if p.at(token.Text) && !hasStructuralContent {
 			if lexer.IsCharacterName(strings.TrimSpace(p.peek().Literal)) {
 				tok := p.advance()
@@ -960,7 +954,7 @@ func (p *parser) parseDialogue() *ast.Dialogue {
 loop:
 	for !p.at(token.EOF) {
 		if p.at(token.Blank) {
-			// Peek ahead: if next non-blank is another character or structural, stop
+			// Stop if the blank leads into another cue or structural break.
 			saved := p.pos
 			p.skipBlanks()
 			if p.atAny(token.CharacterName, token.ForcedCharacter, token.DualDialogueChar,
@@ -975,7 +969,7 @@ loop:
 				p.pos = saved
 				break
 			}
-			// Single blank line continues dialogue — insert paragraph break marker
+			// Single blank line continues dialogue.
 			blankRange := p.tokens[saved].Range
 			p.pos = saved
 			p.skipBlanks()
@@ -1036,12 +1030,11 @@ loop:
 			dlg.Lines = append(dlg.Lines, line)
 
 		case token.LineComment:
-			// Skip comments within dialogue
+			// Skip comments within dialogue.
 			p.advance()
 
 		case token.BlockCommentStart:
-			// Block comments are transparent within dialogue — they must not
-			// end the block, matching the lexer's cue-context rule.
+			// Block comments are transparent within dialogue.
 			p.parseBlockComment()
 
 		default:

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -834,8 +834,21 @@ func (p *parser) parseGenericContent(section *ast.Section, level int) {
 		// Structural content and text go into Children by default.
 		// Only Text tokens become Lines (prose reflow) in leaf generic
 		// sections — StageDirections keep their semantics and stay as Children
-		// so the `>` prefix survives rendering.
+		// so the `>` prefix survives rendering. ALL-CAPS lines that the lexer
+		// demoted to Text because they failed the strict cue rule (no blank
+		// line above) are promoted here to implicit stage directions, so the
+		// writer's failed-cue attempt renders as italic text instead of
+		// silently being reflowed as prose.
 		if p.at(token.Text) && !hasStructuralContent {
+			if lexer.IsCharacterName(strings.TrimSpace(p.peek().Literal)) {
+				tok := p.advance()
+				section.AppendChild(&ast.StageDirection{
+					Content: parseInlineContent(tok.Literal, tok.Range),
+					Range:   tok.Range,
+				})
+				prevContinuation = token.EOF
+				continue
+			}
 			tok := p.advance()
 			line := ast.SectionLine{
 				Content: parseInlineContent(tok.Literal, tok.Range),

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -952,7 +952,8 @@ loop:
 			p.skipBlanks()
 			if p.atAny(token.CharacterName, token.ForcedCharacter, token.DualDialogueChar,
 				token.HeadingH1, token.HeadingH2, token.HeadingH3, token.SongStart,
-				token.SongEnd, token.PageBreak, token.EOF, token.StageDirection) {
+				token.SongEnd, token.PageBreak, token.EOF, token.StageDirection,
+				token.BlockCommentStart) {
 				p.pos = saved // restore; let caller handle the blank
 				break
 			}
@@ -1024,6 +1025,11 @@ loop:
 		case token.LineComment:
 			// Skip comments within dialogue
 			p.advance()
+
+		case token.BlockCommentStart:
+			// Block comments are transparent within dialogue — they must not
+			// end the block, matching the lexer's cue-context rule.
+			p.parseBlockComment()
 
 		default:
 			break loop

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -702,6 +702,32 @@ a block comment */`
 	assert.True(t, comment.Block)
 }
 
+func TestDemotedCueInLeafGenericSection(t *testing.T) {
+	// An ALL-CAPS line immediately under a generic section heading fails the
+	// strict cue rule (no blank line) and is demoted to Text by the lexer.
+	// In a leaf generic section the parser promotes it to an implicit stage
+	// direction so the writer's failed-cue attempt renders as italic text
+	// rather than being silently reflowed as prose.
+	input := "# Play\n\n## Notes\nALICE\n"
+	doc, errs := Parse([]byte(input))
+	require.Empty(t, errs)
+
+	play, ok := doc.Body[0].(*ast.Section)
+	require.True(t, ok)
+	require.NotEmpty(t, play.Children)
+	notes, ok := play.Children[0].(*ast.Section)
+	require.True(t, ok, "expected Notes section, got %T", play.Children[0])
+
+	require.NotEmpty(t, notes.Children, "ALL-CAPS line should appear as a stage direction child")
+	sd, ok := notes.Children[0].(*ast.StageDirection)
+	require.True(t, ok, "expected *ast.StageDirection, got %T", notes.Children[0])
+	require.Len(t, sd.Content, 1)
+	text, ok := sd.Content[0].(*ast.TextNode)
+	require.True(t, ok)
+	assert.Equal(t, "ALICE", text.Value)
+	assert.Empty(t, notes.Lines, "ALL-CAPS line must not become prose")
+}
+
 func TestCueCommentsAreTransparentInDialogue(t *testing.T) {
 	// Both line and block comments between a cue and its dialogue body must
 	// be transparent: they should not end the dialogue block, and they should

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -702,6 +702,34 @@ a block comment */`
 	assert.True(t, comment.Block)
 }
 
+func TestCueCommentsAreTransparentInDialogue(t *testing.T) {
+	// Both line and block comments between a cue and its dialogue body must
+	// be transparent: they should not end the dialogue block, and they should
+	// not cause a following shouted ALL-CAPS line to be reinterpreted as a
+	// new cue.
+	cases := map[string]string{
+		"line comment":  "# Play\n\nJIM\n// he pauses\nWHAT\n",
+		"block comment": "# Play\n\nJIM\n/* he pauses */\nWHAT\n",
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			doc, errs := Parse([]byte(input))
+			require.Empty(t, errs)
+
+			var dlg *ast.Dialogue
+			findDialogue(doc.Body, &dlg)
+			require.NotNil(t, dlg, "expected a single Dialogue block")
+			assert.Equal(t, "JIM", dlg.Character)
+
+			require.Len(t, dlg.Lines, 1, "WHAT should be dialogue text, not a new cue")
+			require.Len(t, dlg.Lines[0].Content, 1)
+			textNode, ok := dlg.Lines[0].Content[0].(*ast.TextNode)
+			require.True(t, ok, "expected TextNode, got %T", dlg.Lines[0].Content[0])
+			assert.Equal(t, "WHAT", textNode.Value)
+		})
+	}
+}
+
 func TestPageBreak(t *testing.T) {
 	input := `# Play
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -703,11 +703,7 @@ a block comment */`
 }
 
 func TestDemotedCueInLeafGenericSection(t *testing.T) {
-	// An ALL-CAPS line immediately under a generic section heading fails the
-	// strict cue rule (no blank line) and is demoted to Text by the lexer.
-	// In a leaf generic section the parser promotes it to an implicit stage
-	// direction so the writer's failed-cue attempt renders as italic text
-	// rather than being silently reflowed as prose.
+	// Demoted ALL-CAPS lines still render as stage directions in leaf generic sections.
 	input := "# Play\n\n## Notes\nALICE\n"
 	doc, errs := Parse([]byte(input))
 	require.Empty(t, errs)
@@ -729,10 +725,7 @@ func TestDemotedCueInLeafGenericSection(t *testing.T) {
 }
 
 func TestCueCommentsAreTransparentInDialogue(t *testing.T) {
-	// Both line and block comments between a cue and its dialogue body must
-	// be transparent: they should not end the dialogue block, and they should
-	// not cause a following shouted ALL-CAPS line to be reinterpreted as a
-	// new cue.
+	// Comments stay transparent inside dialogue.
 	cases := map[string]string{
 		"line comment":  "# Play\n\nJIM\n// he pauses\nWHAT\n",
 		"block comment": "# Play\n\nJIM\n/* he pauses */\nWHAT\n",

--- a/internal/parser/testdata/full.ds
+++ b/internal/parser/testdata/full.ds
@@ -30,9 +30,11 @@ CORDELIA
 Father, please come inside.
 
 SONG 1 The Storm
+
 KING LEAR
   The storm rages on,
   The wind howls and moans.
+
 SONG END
 
 ===

--- a/internal/parser/testdata/full.golden.json
+++ b/internal/parser/testdata/full.golden.json
@@ -433,14 +433,14 @@
                               "Value": "The storm rages on,",
                               "Range": {
                                 "Start": {
-                                  "Line": 33,
+                                  "Line": 34,
                                   "Column": 2,
-                                  "Offset": 480
+                                  "Offset": 481
                                 },
                                 "End": {
-                                  "Line": 33,
+                                  "Line": 34,
                                   "Column": 21,
-                                  "Offset": 499
+                                  "Offset": 500
                                 }
                               }
                             }
@@ -448,14 +448,14 @@
                           "IsVerse": true,
                           "Range": {
                             "Start": {
-                              "Line": 33,
+                              "Line": 34,
                               "Column": 0,
-                              "Offset": 478
+                              "Offset": 479
                             },
                             "End": {
-                              "Line": 33,
+                              "Line": 34,
                               "Column": 21,
-                              "Offset": 499
+                              "Offset": 500
                             }
                           }
                         },
@@ -465,14 +465,14 @@
                               "Value": "The wind howls and moans.",
                               "Range": {
                                 "Start": {
-                                  "Line": 34,
+                                  "Line": 35,
                                   "Column": 2,
-                                  "Offset": 502
+                                  "Offset": 503
                                 },
                                 "End": {
-                                  "Line": 34,
+                                  "Line": 35,
                                   "Column": 27,
-                                  "Offset": 527
+                                  "Offset": 528
                                 }
                               }
                             }
@@ -480,28 +480,28 @@
                           "IsVerse": true,
                           "Range": {
                             "Start": {
-                              "Line": 34,
+                              "Line": 35,
                               "Column": 0,
-                              "Offset": 500
+                              "Offset": 501
                             },
                             "End": {
-                              "Line": 34,
+                              "Line": 35,
                               "Column": 27,
-                              "Offset": 527
+                              "Offset": 528
                             }
                           }
                         }
                       ],
                       "Range": {
                         "Start": {
-                          "Line": 32,
+                          "Line": 33,
                           "Column": 0,
-                          "Offset": 468
+                          "Offset": 469
                         },
                         "End": {
-                          "Line": 34,
+                          "Line": 35,
                           "Column": 27,
-                          "Offset": 527
+                          "Offset": 528
                         }
                       }
                     }
@@ -513,23 +513,23 @@
                       "Offset": 451
                     },
                     "End": {
-                      "Line": 35,
+                      "Line": 37,
                       "Column": 8,
-                      "Offset": 536
+                      "Offset": 538
                     }
                   }
                 },
                 {
                   "Range": {
                     "Start": {
-                      "Line": 37,
+                      "Line": 39,
                       "Column": 0,
-                      "Offset": 538
+                      "Offset": 540
                     },
                     "End": {
-                      "Line": 37,
+                      "Line": 39,
                       "Column": 3,
-                      "Offset": 541
+                      "Offset": 543
                     }
                   }
                 }
@@ -544,9 +544,9 @@
                   "Offset": 200
                 },
                 "End": {
-                  "Line": 38,
+                  "Line": 40,
                   "Column": 0,
-                  "Offset": 542
+                  "Offset": 544
                 }
               }
             },
@@ -566,14 +566,14 @@
                           "Value": "My lord, I bring news.",
                           "Range": {
                             "Start": {
-                              "Line": 42,
+                              "Line": 44,
                               "Column": 0,
-                              "Offset": 561
+                              "Offset": 563
                             },
                             "End": {
-                              "Line": 42,
+                              "Line": 44,
                               "Column": 22,
-                              "Offset": 583
+                              "Offset": 585
                             }
                           }
                         }
@@ -581,28 +581,28 @@
                       "IsVerse": false,
                       "Range": {
                         "Start": {
-                          "Line": 42,
+                          "Line": 44,
                           "Column": 0,
-                          "Offset": 561
+                          "Offset": 563
                         },
                         "End": {
-                          "Line": 42,
+                          "Line": 44,
                           "Column": 22,
-                          "Offset": 583
+                          "Offset": 585
                         }
                       }
                     }
                   ],
                   "Range": {
                     "Start": {
-                      "Line": 41,
+                      "Line": 43,
                       "Column": 0,
-                      "Offset": 556
+                      "Offset": 558
                     },
                     "End": {
-                      "Line": 42,
+                      "Line": 44,
                       "Column": 22,
-                      "Offset": 583
+                      "Offset": 585
                     }
                   }
                 }
@@ -612,14 +612,14 @@
               "Lines": null,
               "Range": {
                 "Start": {
-                  "Line": 39,
+                  "Line": 41,
                   "Column": 0,
-                  "Offset": 543
+                  "Offset": 545
                 },
                 "End": {
-                  "Line": 43,
+                  "Line": 45,
                   "Column": 0,
-                  "Offset": 584
+                  "Offset": 586
                 }
               }
             }
@@ -634,9 +634,9 @@
               "Offset": 190
             },
             "End": {
-              "Line": 43,
+              "Line": 45,
               "Column": 0,
-              "Offset": 584
+              "Offset": 586
             }
           }
         }
@@ -651,9 +651,9 @@
           "Offset": 0
         },
         "End": {
-          "Line": 43,
+          "Line": 45,
           "Column": 0,
-          "Offset": 584
+          "Offset": 586
         }
       }
     }
@@ -665,9 +665,9 @@
       "Offset": 0
     },
     "End": {
-      "Line": 44,
+      "Line": 46,
       "Column": 0,
-      "Offset": 584
+      "Offset": 586
     }
   }
 }

--- a/site/content/syntax/06-dialogue.md
+++ b/site/content/syntax/06-dialogue.md
@@ -20,3 +20,9 @@ parenthetical and one or more speech lines.
 
 Character names are uppercase and may contain spaces, punctuation like periods
 and apostrophes, digits, and slashes for alias-aware names.
+
+A cue must be preceded by a blank line (or another structural break such as a
+heading). That way an ALL-CAPS line inside a speech — a shouted "WHAT" directly
+below the cue — stays part of the dialogue instead of turning into a new
+character. If you need a cue without a blank line before it, prefix the name
+with `@` to force it.

--- a/site/content/syntax/06-dialogue.md
+++ b/site/content/syntax/06-dialogue.md
@@ -21,12 +21,6 @@ parenthetical and one or more speech lines.
 Character names are uppercase and may contain spaces, punctuation like periods
 and apostrophes, digits, and slashes for alias-aware names.
 
-A cue must be preceded by a blank line, or be the first line of the document.
-Comments are transparent: a line or block comment directly above a cue counts,
-as long as the comment itself has a blank line (or the start of the document)
-before it. That way a shouted "WHAT" directly below a cue — even with a
-parenthetical or inline comment between them — stays part of the dialogue
-instead of turning into a new character. Headings, page breaks, and stage
-directions are not cue boundaries on their own: always put a blank line before
-a cue. When you need a cue without a blank line before it, prefix the name
-with `@` to force it (see Forced Elements).
+Cues need a blank line before them, or they can start the document. Comments do
+not reset cue context, so a shouted "WHAT" under `JIM` stays dialogue. Use
+`@NAME` when you need to force a cue without a blank line.

--- a/site/content/syntax/06-dialogue.md
+++ b/site/content/syntax/06-dialogue.md
@@ -21,8 +21,12 @@ parenthetical and one or more speech lines.
 Character names are uppercase and may contain spaces, punctuation like periods
 and apostrophes, digits, and slashes for alias-aware names.
 
-A cue must be preceded by a blank line (or another structural break such as a
-heading). That way an ALL-CAPS line inside a speech — a shouted "WHAT" directly
-below the cue — stays part of the dialogue instead of turning into a new
-character. If you need a cue without a blank line before it, prefix the name
-with `@` to force it.
+A cue is only recognised at a block boundary — the start of the document, the
+line after a blank line, or the line immediately after a heading, page break,
+stage direction, callout, or `SONG` / `SONG END` marker. Line comments and
+block comments between a cue and its dialogue are transparent and don't break
+this rule. That way an ALL-CAPS line inside a speech — a shouted "WHAT"
+directly below the cue, even with a parenthetical or comment between them —
+stays part of the dialogue instead of turning into a new character. When you
+need a cue without a blank line before it, prefix the name with `@` to force
+it (see Forced Elements).

--- a/site/content/syntax/06-dialogue.md
+++ b/site/content/syntax/06-dialogue.md
@@ -21,12 +21,12 @@ parenthetical and one or more speech lines.
 Character names are uppercase and may contain spaces, punctuation like periods
 and apostrophes, digits, and slashes for alias-aware names.
 
-A cue is only recognised at a block boundary — the start of the document, the
-line after a blank line, or the line immediately after a heading, page break,
-stage direction, callout, or `SONG` / `SONG END` marker. Line comments and
-block comments between a cue and its dialogue are transparent and don't break
-this rule. That way an ALL-CAPS line inside a speech — a shouted "WHAT"
-directly below the cue, even with a parenthetical or comment between them —
-stays part of the dialogue instead of turning into a new character. When you
-need a cue without a blank line before it, prefix the name with `@` to force
-it (see Forced Elements).
+A cue must be preceded by a blank line, or be the first line of the document.
+Comments are transparent: a line or block comment directly above a cue counts,
+as long as the comment itself has a blank line (or the start of the document)
+before it. That way a shouted "WHAT" directly below a cue — even with a
+parenthetical or inline comment between them — stays part of the dialogue
+instead of turning into a new character. Headings, page breaks, and stage
+directions are not cue boundaries on their own: always put a blank line before
+a cue. When you need a cue without a blank line before it, prefix the name
+with `@` to force it (see Forced Elements).

--- a/testdata/edge_cases.ds
+++ b/testdata/edge_cases.ds
@@ -43,7 +43,10 @@ Is everyone here?
 ALICE
 Yes.
 
-// Dialogue immediately after heading (no blank line separator)
+// ALL-CAPS line immediately after a heading (no blank line separator).
+// Under the strict cue rule, ALICE is NOT a cue — it becomes an implicit
+// stage direction, as does the following line. Use a blank line (or `@ALICE`)
+// to make this a real cue.
 ### SCENE 2
 ALICE
 No blank line before me.

--- a/testdata/edge_cases.ds
+++ b/testdata/edge_cases.ds
@@ -43,10 +43,8 @@ Is everyone here?
 ALICE
 Yes.
 
-// ALL-CAPS line immediately after a heading (no blank line separator).
-// Under the strict cue rule, ALICE is NOT a cue — it becomes an implicit
-// stage direction, as does the following line. Use a blank line (or `@ALICE`)
-// to make this a real cue.
+// ALL-CAPS line immediately after a heading.
+// Use a blank line (or `@ALICE`) to make this a cue.
 ### SCENE 2
 ALICE
 No blank line before me.


### PR DESCRIPTION
## Summary

- Tighten the cue-recognition rule: an ALL-CAPS line is only a cue when preceded by a blank line or at the start of the document. Comments are transparent — a comment directly above a cue counts provided it has a blank line of its own before it.
- Fixes the original bug where shouted ALL-CAPS dialogue (`JIM\nWHAT`, or `JIM\n(angrily)\nWHAT`) was misread as a new cue.
- `@NAME` remains the escape hatch for cues that can't have a blank line before them.
- ALL-CAPS lines that fail the rule fall through to plain `Text`. In leaf generic sections they'd have rendered as prose — the parser now promotes them to implicit `StageDirection` nodes so the writer's failed-cue attempt renders as italic and is easy to spot.
- Spec §3 flags the rule change as breaking; §7 is rewritten around the simpler rule. Site dialogue page and `edge_cases.ds` fixture updated to match.

## Test plan

- [x] `go test ./...` — lexer, parser, LSP, render suites all green
- [x] New tests: `TestCueRequiresBlankLineBefore` (lexer), `TestDemotedCueInLeafGenericSection` and `TestCueCommentsAreTransparentInDialogue` (parser)
- [x] `full.ds` golden regenerated to reflect blank lines required around embedded `SONG 1` cue
- [x] Manual spot-check of a real script in the web editor once merged