### PR TITLE
fix(render): stylable character descriptions and frontmatter values

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -466,7 +466,9 @@ Songs can appear within scenes or directly in the body.
 
 ## 11. Inline Formatting
 
-Formatting markers work within dialogue, stage directions, and verse.
+Formatting markers work within dialogue, stage directions, verse, character
+descriptions in the dramatis personae, and frontmatter/section-metadata values
+such as `Subtitle`.
 
 | Syntax | Result |
 |--------|--------|

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -45,9 +45,10 @@ func (t *TitlePage) nodeType() string       { return "TitlePage" }
 
 // KeyValue is a single title page entry.
 type KeyValue struct {
-	Key   string
-	Value string
-	Range token.Range
+	Key          string
+	Value        string
+	ValueInlines []Inline
+	Range        token.Range
 }
 
 // --- Section ---
@@ -198,10 +199,11 @@ type sectionItemRef struct {
 
 // Character describes a character entry in the dramatis personae.
 type Character struct {
-	Name        string
-	Aliases     []string
-	Description string
-	Range       token.Range
+	Name               string
+	Aliases            []string
+	Description        string
+	DescriptionInlines []Inline
+	Range              token.Range
 }
 
 // CharacterGroup is a named group of characters.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -142,6 +142,7 @@ func (p *parser) parseTitlePage() *ast.TitlePage {
 			if p.at(token.TitleValue) {
 				valTok := p.advance()
 				kv.Value = valTok.Literal
+				kv.ValueInlines = parseInlineContent(valTok.Literal, valTok.Range)
 				kv.Range.End = valTok.Range.End
 			}
 			tp.Entries = append(tp.Entries, kv)
@@ -152,8 +153,13 @@ func (p *parser) parseTitlePage() *ast.TitlePage {
 				last := &tp.Entries[len(tp.Entries)-1]
 				if last.Value != "" {
 					last.Value += "\n"
+					last.ValueInlines = append(last.ValueInlines, &ast.TextNode{
+						Value: "\n",
+						Range: token.Range{Start: valTok.Range.Start, End: valTok.Range.Start},
+					})
 				}
 				last.Value += valTok.Literal
+				last.ValueInlines = append(last.ValueInlines, parseInlineContent(valTok.Literal, valTok.Range)...)
 				last.Range.End = valTok.Range.End
 			}
 		}
@@ -671,20 +677,25 @@ func (p *parser) parseSectionMetadata() *ast.TitlePage {
 		}
 
 		raw := p.peek().Literal
-		if key, value, ok := parseMetadataEntry(raw); ok {
+		if key, value, valueStart, ok := parseMetadataEntryBytes(raw); ok {
 			tok := p.advance()
 			if len(tp.Entries) == 0 {
 				start = tok.Range
 			}
-			tp.Entries = append(tp.Entries, ast.KeyValue{
+			kv := ast.KeyValue{
 				Key:   key,
 				Value: value,
 				Range: tok.Range,
-			})
+			}
+			if value != "" {
+				valueRange := sliceInlineRange(tok.Literal, tok.Range, valueStart, valueStart+len(value))
+				kv.ValueInlines = parseInlineContent(value, valueRange)
+			}
+			tp.Entries = append(tp.Entries, kv)
 			continue
 		}
 
-		if value, ok := parseMetadataContinuation(raw); ok {
+		if value, valueStart, ok := parseMetadataContinuationBytes(raw); ok {
 			if len(tp.Entries) == 0 {
 				p.pos = saved
 				return nil
@@ -693,8 +704,16 @@ func (p *parser) parseSectionMetadata() *ast.TitlePage {
 			last := &tp.Entries[len(tp.Entries)-1]
 			if last.Value != "" {
 				last.Value += "\n"
+				last.ValueInlines = append(last.ValueInlines, &ast.TextNode{
+					Value: "\n",
+					Range: token.Range{Start: tok.Range.Start, End: tok.Range.Start},
+				})
 			}
 			last.Value += value
+			if value != "" {
+				valueRange := sliceInlineRange(tok.Literal, tok.Range, valueStart, valueStart+len(value))
+				last.ValueInlines = append(last.ValueInlines, parseInlineContent(value, valueRange)...)
+			}
 			last.Range.End = tok.Range.End
 			continue
 		}
@@ -713,25 +732,40 @@ func (p *parser) parseSectionMetadata() *ast.TitlePage {
 }
 
 func parseMetadataEntry(raw string) (key, value string, ok bool) {
+	key, value, _, ok = parseMetadataEntryBytes(raw)
+	return key, value, ok
+}
+
+// parseMetadataEntryBytes is like parseMetadataEntry but also returns the
+// byte offset within raw at which the trimmed value begins.
+func parseMetadataEntryBytes(raw string) (key, value string, valueStart int, ok bool) {
 	idx := strings.Index(raw, ":")
 	if idx <= 0 {
-		return "", "", false
+		return "", "", 0, false
 	}
 	key = strings.TrimSpace(raw[:idx])
 	if key == "" {
-		return "", "", false
+		return "", "", 0, false
 	}
-	return key, strings.TrimSpace(raw[idx+1:]), true
+	rest := raw[idx+1:]
+	leading := len(rest) - len(strings.TrimLeft(rest, " \t"))
+	return key, strings.TrimSpace(rest), idx + 1 + leading, true
 }
 
 func parseMetadataContinuation(raw string) (string, bool) {
+	v, _, ok := parseMetadataContinuationBytes(raw)
+	return v, ok
+}
+
+func parseMetadataContinuationBytes(raw string) (value string, valueStart int, ok bool) {
 	if raw == "" {
-		return "", false
+		return "", 0, false
 	}
 	if raw[0] != ' ' && raw[0] != '\t' {
-		return "", false
+		return "", 0, false
 	}
-	return strings.TrimSpace(raw), true
+	leading := len(raw) - len(strings.TrimLeft(raw, " \t"))
+	return strings.TrimSpace(raw), leading, true
 }
 
 // parseActContent fills Children for an act section with scenes and content.
@@ -909,7 +943,17 @@ func parseCharacterEntry(tok token.Token) ast.Character {
 	namePart := tok.Literal
 	if idx := strings.Index(tok.Literal, " - "); idx >= 0 {
 		namePart = strings.TrimSpace(tok.Literal[:idx])
-		ch.Description = strings.TrimSpace(tok.Literal[idx+3:])
+		descStart := idx + 3
+		descRaw := tok.Literal[descStart:]
+		trimmedLeading := len(descRaw) - len(strings.TrimLeft(descRaw, " \t"))
+		descTrimmed := strings.TrimSpace(descRaw)
+		ch.Description = descTrimmed
+		if descTrimmed != "" {
+			startByte := descStart + trimmedLeading
+			endByte := startByte + len(descTrimmed)
+			descRange := sliceInlineRange(tok.Literal, tok.Range, startByte, endByte)
+			ch.DescriptionInlines = parseInlineContent(descTrimmed, descRange)
+		}
 	}
 	ch.Name, ch.Aliases = parseAliasSpec(strings.TrimSpace(namePart))
 	return ch

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1207,3 +1207,71 @@ func findDialogue(nodes []ast.Node, result **ast.Dialogue) {
 		}
 	}
 }
+
+func TestCharacterDescriptionInlines(t *testing.T) {
+	input := `# The Play
+
+## Dramatis Personae
+
+HAMLET - Prince of **Denmark**, _melancholic_
+`
+	doc, errs := Parse([]byte(input))
+	require.Empty(t, errs)
+	require.Len(t, doc.Body, 1)
+
+	top, ok := doc.Body[0].(*ast.Section)
+	require.True(t, ok)
+	require.Len(t, top.Children, 1)
+	section, ok := top.Children[0].(*ast.Section)
+	require.True(t, ok)
+	require.Equal(t, ast.SectionDramatisPersonae, section.Kind)
+	require.Len(t, section.Characters, 1)
+
+	ch := section.Characters[0]
+	assert.Equal(t, "HAMLET", ch.Name)
+	assert.Equal(t, "Prince of **Denmark**, _melancholic_", ch.Description)
+	require.NotEmpty(t, ch.DescriptionInlines)
+
+	var hasBold, hasUnderline bool
+	for _, inline := range ch.DescriptionInlines {
+		switch inline.(type) {
+		case *ast.BoldNode:
+			hasBold = true
+		case *ast.UnderlineNode:
+			hasUnderline = true
+		}
+	}
+	assert.True(t, hasBold, "expected bold inline in description")
+	assert.True(t, hasUnderline, "expected underline inline in description")
+}
+
+func TestTitlePageValueInlines(t *testing.T) {
+	input := `# A Play
+Subtitle: A tragedy in *five* acts
+Author: Jane Doe
+`
+	doc, errs := Parse([]byte(input))
+	require.Empty(t, errs)
+	require.Len(t, doc.Body, 1)
+	top, ok := doc.Body[0].(*ast.Section)
+	require.True(t, ok)
+	require.NotNil(t, top.Metadata)
+	require.Len(t, top.Metadata.Entries, 2)
+
+	var subtitle *ast.KeyValue
+	for i := range top.Metadata.Entries {
+		if strings.EqualFold(top.Metadata.Entries[i].Key, "subtitle") {
+			subtitle = &top.Metadata.Entries[i]
+		}
+	}
+	require.NotNil(t, subtitle)
+
+	require.NotEmpty(t, subtitle.ValueInlines)
+	var hasItalic bool
+	for _, inline := range subtitle.ValueInlines {
+		if _, ok := inline.(*ast.ItalicNode); ok {
+			hasItalic = true
+		}
+	}
+	assert.True(t, hasItalic, "expected italic inline in subtitle value")
+}

--- a/internal/parser/testdata/acts_and_scenes.golden.json
+++ b/internal/parser/testdata/acts_and_scenes.golden.json
@@ -11,6 +11,23 @@
           {
             "Key": "Title",
             "Value": "Structured Play",
+            "ValueInlines": [
+              {
+                "Value": "Structured Play",
+                "Range": {
+                  "Start": {
+                    "Line": 1,
+                    "Column": 7,
+                    "Offset": 25
+                  },
+                  "End": {
+                    "Line": 1,
+                    "Column": 22,
+                    "Offset": 40
+                  }
+                }
+              }
+            ],
             "Range": {
               "Start": {
                 "Line": 1,
@@ -50,6 +67,23 @@
               "Name": "ALICE",
               "Aliases": null,
               "Description": "The protagonist",
+              "DescriptionInlines": [
+                {
+                  "Value": "The protagonist",
+                  "Range": {
+                    "Start": {
+                      "Line": 5,
+                      "Column": 8,
+                      "Offset": 72
+                    },
+                    "End": {
+                      "Line": 5,
+                      "Column": 23,
+                      "Offset": 87
+                    }
+                  }
+                }
+              ],
               "Range": {
                 "Start": {
                   "Line": 5,

--- a/internal/parser/testdata/dual_dialogue.golden.json
+++ b/internal/parser/testdata/dual_dialogue.golden.json
@@ -11,6 +11,23 @@
           {
             "Key": "Title",
             "Value": "Test",
+            "ValueInlines": [
+              {
+                "Value": "Test",
+                "Range": {
+                  "Start": {
+                    "Line": 1,
+                    "Column": 7,
+                    "Offset": 14
+                  },
+                  "End": {
+                    "Line": 1,
+                    "Column": 11,
+                    "Offset": 18
+                  }
+                }
+              }
+            ],
             "Range": {
               "Start": {
                 "Line": 1,
@@ -50,6 +67,23 @@
               "Name": "BRICK",
               "Aliases": null,
               "Description": "One half of the pair",
+              "DescriptionInlines": [
+                {
+                  "Value": "One half of the pair",
+                  "Range": {
+                    "Start": {
+                      "Line": 5,
+                      "Column": 8,
+                      "Offset": 50
+                    },
+                    "End": {
+                      "Line": 5,
+                      "Column": 28,
+                      "Offset": 70
+                    }
+                  }
+                }
+              ],
               "Range": {
                 "Start": {
                   "Line": 5,
@@ -67,6 +101,23 @@
               "Name": "STEEL",
               "Aliases": null,
               "Description": "The other half of the pair",
+              "DescriptionInlines": [
+                {
+                  "Value": "The other half of the pair",
+                  "Range": {
+                    "Start": {
+                      "Line": 6,
+                      "Column": 8,
+                      "Offset": 79
+                    },
+                    "End": {
+                      "Line": 6,
+                      "Column": 34,
+                      "Offset": 105
+                    }
+                  }
+                }
+              ],
               "Range": {
                 "Start": {
                   "Line": 6,

--- a/internal/parser/testdata/formatting.golden.json
+++ b/internal/parser/testdata/formatting.golden.json
@@ -11,6 +11,23 @@
           {
             "Key": "Title",
             "Value": "Formatting",
+            "ValueInlines": [
+              {
+                "Value": "Formatting",
+                "Range": {
+                  "Start": {
+                    "Line": 1,
+                    "Column": 7,
+                    "Offset": 20
+                  },
+                  "End": {
+                    "Line": 1,
+                    "Column": 17,
+                    "Offset": 30
+                  }
+                }
+              }
+            ],
             "Range": {
               "Start": {
                 "Line": 1,
@@ -50,6 +67,23 @@
               "Name": "ALICE",
               "Aliases": null,
               "Description": "A speaker",
+              "DescriptionInlines": [
+                {
+                  "Value": "A speaker",
+                  "Range": {
+                    "Start": {
+                      "Line": 5,
+                      "Column": 8,
+                      "Offset": 62
+                    },
+                    "End": {
+                      "Line": 5,
+                      "Column": 17,
+                      "Offset": 71
+                    }
+                  }
+                }
+              ],
               "Range": {
                 "Start": {
                   "Line": 5,

--- a/internal/parser/testdata/full.golden.json
+++ b/internal/parser/testdata/full.golden.json
@@ -11,6 +11,23 @@
           {
             "Key": "Author",
             "Value": "Test Writer",
+            "ValueInlines": [
+              {
+                "Value": "Test Writer",
+                "Range": {
+                  "Start": {
+                    "Line": 1,
+                    "Column": 8,
+                    "Offset": 31
+                  },
+                  "End": {
+                    "Line": 1,
+                    "Column": 19,
+                    "Offset": 42
+                  }
+                }
+              }
+            ],
             "Range": {
               "Start": {
                 "Line": 1,
@@ -27,6 +44,23 @@
           {
             "Key": "Draft",
             "Value": "Second",
+            "ValueInlines": [
+              {
+                "Value": "Second",
+                "Range": {
+                  "Start": {
+                    "Line": 2,
+                    "Column": 7,
+                    "Offset": 50
+                  },
+                  "End": {
+                    "Line": 2,
+                    "Column": 13,
+                    "Offset": 56
+                  }
+                }
+              }
+            ],
             "Range": {
               "Start": {
                 "Line": 2,
@@ -70,6 +104,23 @@
                   "Name": "KING LEAR",
                   "Aliases": null,
                   "Description": "King of Britain",
+                  "DescriptionInlines": [
+                    {
+                      "Value": "King of Britain",
+                      "Range": {
+                        "Start": {
+                          "Line": 6,
+                          "Column": 12,
+                          "Offset": 105
+                        },
+                        "End": {
+                          "Line": 6,
+                          "Column": 27,
+                          "Offset": 120
+                        }
+                      }
+                    }
+                  ],
                   "Range": {
                     "Start": {
                       "Line": 6,
@@ -87,6 +138,23 @@
                   "Name": "CORDELIA",
                   "Aliases": null,
                   "Description": "His youngest daughter",
+                  "DescriptionInlines": [
+                    {
+                      "Value": "His youngest daughter",
+                      "Range": {
+                        "Start": {
+                          "Line": 7,
+                          "Column": 11,
+                          "Offset": 132
+                        },
+                        "End": {
+                          "Line": 7,
+                          "Column": 32,
+                          "Offset": 153
+                        }
+                      }
+                    }
+                  ],
                   "Range": {
                     "Start": {
                       "Line": 7,
@@ -121,6 +189,23 @@
                   "Name": "KENT",
                   "Aliases": null,
                   "Description": "A loyal earl",
+                  "DescriptionInlines": [
+                    {
+                      "Value": "A loyal earl",
+                      "Range": {
+                        "Start": {
+                          "Line": 10,
+                          "Column": 7,
+                          "Offset": 176
+                        },
+                        "End": {
+                          "Line": 10,
+                          "Column": 19,
+                          "Offset": 188
+                        }
+                      }
+                    }
+                  ],
                   "Range": {
                     "Start": {
                       "Line": 10,

--- a/internal/parser/testdata/simple.golden.json
+++ b/internal/parser/testdata/simple.golden.json
@@ -11,6 +11,23 @@
           {
             "Key": "Author",
             "Value": "Jane Doe",
+            "ValueInlines": [
+              {
+                "Value": "Jane Doe",
+                "Range": {
+                  "Start": {
+                    "Line": 1,
+                    "Column": 8,
+                    "Offset": 24
+                  },
+                  "End": {
+                    "Line": 1,
+                    "Column": 16,
+                    "Offset": 32
+                  }
+                }
+              }
+            ],
             "Range": {
               "Start": {
                 "Line": 1,

--- a/internal/parser/testdata/simple_dialogue.golden.json
+++ b/internal/parser/testdata/simple_dialogue.golden.json
@@ -11,6 +11,23 @@
           {
             "Key": "Title",
             "Value": "Test",
+            "ValueInlines": [
+              {
+                "Value": "Test",
+                "Range": {
+                  "Start": {
+                    "Line": 1,
+                    "Column": 7,
+                    "Offset": 19
+                  },
+                  "End": {
+                    "Line": 1,
+                    "Column": 11,
+                    "Offset": 23
+                  }
+                }
+              }
+            ],
             "Range": {
               "Start": {
                 "Line": 1,
@@ -50,6 +67,23 @@
               "Name": "ALICE",
               "Aliases": null,
               "Description": "A test character",
+              "DescriptionInlines": [
+                {
+                  "Value": "A test character",
+                  "Range": {
+                    "Start": {
+                      "Line": 5,
+                      "Column": 8,
+                      "Offset": 55
+                    },
+                    "End": {
+                      "Line": 5,
+                      "Column": 24,
+                      "Offset": 71
+                    }
+                  }
+                }
+              ],
               "Range": {
                 "Start": {
                   "Line": 5,
@@ -67,6 +101,23 @@
               "Name": "BOB",
               "Aliases": null,
               "Description": "Another test character",
+              "DescriptionInlines": [
+                {
+                  "Value": "Another test character",
+                  "Range": {
+                    "Start": {
+                      "Line": 6,
+                      "Column": 6,
+                      "Offset": 78
+                    },
+                    "End": {
+                      "Line": 6,
+                      "Column": 28,
+                      "Offset": 100
+                    }
+                  }
+                }
+              ],
               "Range": {
                 "Start": {
                   "Line": 6,
@@ -84,6 +135,7 @@
               "Name": "ALICE",
               "Aliases": null,
               "Description": "",
+              "DescriptionInlines": null,
               "Range": {
                 "Start": {
                   "Line": 8,
@@ -101,6 +153,7 @@
               "Name": "Hello, Bob!",
               "Aliases": null,
               "Description": "",
+              "DescriptionInlines": null,
               "Range": {
                 "Start": {
                   "Line": 9,
@@ -118,6 +171,7 @@
               "Name": "BOB",
               "Aliases": null,
               "Description": "",
+              "DescriptionInlines": null,
               "Range": {
                 "Start": {
                   "Line": 11,
@@ -135,6 +189,7 @@
               "Name": "Hello, Alice!",
               "Aliases": null,
               "Description": "",
+              "DescriptionInlines": null,
               "Range": {
                 "Start": {
                   "Line": 12,

--- a/internal/render/html/html.go
+++ b/internal/render/html/html.go
@@ -122,7 +122,7 @@ func (r *htmlRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 	if titleKV != nil && titleKV.Value != "" {
 		fmt.Fprintf(&r.buf, "<h1%s>%s</h1>\n", r.sourceAttr(titleKV.Range), html.EscapeString(titleKV.Value))
 	}
-	if subtitleKV != nil && subtitleKV.Value != "" {
+	if subtitleKV != nil && hasKeyValueContent(*subtitleKV) {
 		fmt.Fprintf(&r.buf, "<p class=\"subtitle\"%s>", r.sourceAttr(subtitleKV.Range))
 		r.renderInlineContent(keyValueInlines(*subtitleKV))
 		r.buf.WriteString("</p>\n")
@@ -334,12 +334,10 @@ func (r *htmlRenderer) renderMetadata(className string, tp *ast.TitlePage) {
 
 func (r *htmlRenderer) renderSubplayMetadata(tp *ast.TitlePage) {
 	_, subtitleKV, authorKVs, other := partitionHTMLTitlePageEntries(tp)
-	if subtitleKV != nil {
-		if s := strings.TrimSpace(subtitleKV.Value); s != "" {
-			r.buf.WriteString("<p class=\"downstage-subplay-subtitle\">")
-			r.renderInlineContent(keyValueInlines(*subtitleKV))
-			r.buf.WriteString("</p>\n")
-		}
+	if subtitleKV != nil && hasKeyValueContent(*subtitleKV) {
+		r.buf.WriteString("<p class=\"downstage-subplay-subtitle\">")
+		r.renderInlineContent(keyValueInlines(*subtitleKV))
+		r.buf.WriteString("</p>\n")
 	}
 	if len(authorKVs) > 0 {
 		r.buf.WriteString("<p class=\"downstage-subplay-author-label\">by</p>\n")
@@ -383,7 +381,7 @@ func partitionHTMLTitlePageEntries(tp *ast.TitlePage) (title *ast.KeyValue, subt
 func (r *htmlRenderer) renderCharacterEntry(ch ast.Character) {
 	r.buf.WriteString("<div class=\"character-entry\">")
 	fmt.Fprintf(&r.buf, "<dt>%s</dt>", html.EscapeString(render.CharacterDisplayName(ch)))
-	if ch.Description != "" {
+	if hasCharacterDescription(ch) {
 		r.buf.WriteString("<dd>")
 		r.renderInlineContent(characterDescriptionInlines(ch))
 		r.buf.WriteString("</dd>")
@@ -665,6 +663,15 @@ func keyValueInlines(kv ast.KeyValue) []ast.Inline {
 	return []ast.Inline{&ast.TextNode{Value: kv.Value}}
 }
 
+// hasKeyValueContent reports whether a KeyValue has any renderable value,
+// checking both the legacy string and the inline form.
+func hasKeyValueContent(kv ast.KeyValue) bool {
+	if strings.TrimSpace(kv.Value) != "" {
+		return true
+	}
+	return strings.TrimSpace(render.PlainText(kv.ValueInlines)) != ""
+}
+
 // characterDescriptionInlines is the same fallback for Character descriptions.
 func characterDescriptionInlines(ch ast.Character) []ast.Inline {
 	if len(ch.DescriptionInlines) > 0 {
@@ -674,6 +681,14 @@ func characterDescriptionInlines(ch ast.Character) []ast.Inline {
 		return nil
 	}
 	return []ast.Inline{&ast.TextNode{Value: ch.Description}}
+}
+
+// hasCharacterDescription is the gate for rendering a description.
+func hasCharacterDescription(ch ast.Character) bool {
+	if strings.TrimSpace(ch.Description) != "" {
+		return true
+	}
+	return strings.TrimSpace(render.PlainText(ch.DescriptionInlines)) != ""
 }
 
 func dialogueParentheticalInlines(d *ast.Dialogue) []ast.Inline {

--- a/internal/render/html/html.go
+++ b/internal/render/html/html.go
@@ -123,7 +123,9 @@ func (r *htmlRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 		fmt.Fprintf(&r.buf, "<h1%s>%s</h1>\n", r.sourceAttr(titleKV.Range), html.EscapeString(titleKV.Value))
 	}
 	if subtitleKV != nil && subtitleKV.Value != "" {
-		fmt.Fprintf(&r.buf, "<p class=\"subtitle\"%s>%s</p>\n", r.sourceAttr(subtitleKV.Range), html.EscapeString(subtitleKV.Value))
+		fmt.Fprintf(&r.buf, "<p class=\"subtitle\"%s>", r.sourceAttr(subtitleKV.Range))
+		r.renderInlineContent(keyValueInlines(*subtitleKV))
+		r.buf.WriteString("</p>\n")
 	}
 	if len(authorKVs) > 0 {
 		fmt.Fprintf(&r.buf, "<p class=\"author\"%s>by</p>\n", r.sourceAttr(authorKVs[0].Range))
@@ -137,7 +139,9 @@ func (r *htmlRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 		for _, kv := range other {
 			fmt.Fprintf(&r.buf, "<div%s>", r.sourceAttr(kv.Range))
 			fmt.Fprintf(&r.buf, "<dt>%s</dt>", html.EscapeString(kv.Key))
-			fmt.Fprintf(&r.buf, "<dd>%s</dd>", html.EscapeString(kv.Value))
+			r.buf.WriteString("<dd>")
+			r.renderInlineContent(keyValueInlines(kv))
+			r.buf.WriteString("</dd>")
 			r.buf.WriteString("</div>\n")
 		}
 		r.buf.WriteString("</dl>\n")
@@ -320,7 +324,9 @@ func (r *htmlRenderer) renderMetadata(className string, tp *ast.TitlePage) {
 		}
 		r.buf.WriteString("<div>")
 		fmt.Fprintf(&r.buf, "<dt>%s</dt>", html.EscapeString(kv.Key))
-		fmt.Fprintf(&r.buf, "<dd>%s</dd>", html.EscapeString(kv.Value))
+		r.buf.WriteString("<dd>")
+		r.renderInlineContent(keyValueInlines(kv))
+		r.buf.WriteString("</dd>")
 		r.buf.WriteString("</div>\n")
 	}
 	r.buf.WriteString("</dl>\n")
@@ -330,7 +336,9 @@ func (r *htmlRenderer) renderSubplayMetadata(tp *ast.TitlePage) {
 	_, subtitleKV, authorKVs, other := partitionHTMLTitlePageEntries(tp)
 	if subtitleKV != nil {
 		if s := strings.TrimSpace(subtitleKV.Value); s != "" {
-			fmt.Fprintf(&r.buf, "<p class=\"downstage-subplay-subtitle\">%s</p>\n", html.EscapeString(s))
+			r.buf.WriteString("<p class=\"downstage-subplay-subtitle\">")
+			r.renderInlineContent(keyValueInlines(*subtitleKV))
+			r.buf.WriteString("</p>\n")
 		}
 	}
 	if len(authorKVs) > 0 {
@@ -376,7 +384,9 @@ func (r *htmlRenderer) renderCharacterEntry(ch ast.Character) {
 	r.buf.WriteString("<div class=\"character-entry\">")
 	fmt.Fprintf(&r.buf, "<dt>%s</dt>", html.EscapeString(render.CharacterDisplayName(ch)))
 	if ch.Description != "" {
-		fmt.Fprintf(&r.buf, "<dd>%s</dd>", html.EscapeString(ch.Description))
+		r.buf.WriteString("<dd>")
+		r.renderInlineContent(characterDescriptionInlines(ch))
+		r.buf.WriteString("</dd>")
 	}
 	r.buf.WriteString("</div>\n")
 }
@@ -640,6 +650,30 @@ func (r *htmlRenderer) renderInlineContent(inlines []ast.Inline) {
 			}
 		}
 	}
+}
+
+// keyValueInlines returns the inline representation of a KeyValue's value,
+// falling back to a single TextNode when the parser didn't populate
+// ValueInlines (e.g. tests that build KeyValues by hand).
+func keyValueInlines(kv ast.KeyValue) []ast.Inline {
+	if len(kv.ValueInlines) > 0 {
+		return kv.ValueInlines
+	}
+	if kv.Value == "" {
+		return nil
+	}
+	return []ast.Inline{&ast.TextNode{Value: kv.Value}}
+}
+
+// characterDescriptionInlines is the same fallback for Character descriptions.
+func characterDescriptionInlines(ch ast.Character) []ast.Inline {
+	if len(ch.DescriptionInlines) > 0 {
+		return ch.DescriptionInlines
+	}
+	if ch.Description == "" {
+		return nil
+	}
+	return []ast.Inline{&ast.TextNode{Value: ch.Description}}
 }
 
 func dialogueParentheticalInlines(d *ast.Dialogue) []ast.Inline {

--- a/internal/render/html/html_test.go
+++ b/internal/render/html/html_test.go
@@ -609,6 +609,29 @@ func TestRender_DramatisPersonaeInlineStyling(t *testing.T) {
 	assert.NotContains(t, out, "_ragged_")
 }
 
+func TestRender_DramatisPersonaeDescriptionInlinesWithoutValue(t *testing.T) {
+	doc := &ast.Document{
+		Body: []ast.Node{
+			&ast.Section{
+				Kind: ast.SectionDramatisPersonae,
+				Characters: []ast.Character{
+					{
+						Name: "GHOST",
+						DescriptionInlines: []ast.Inline{
+							&ast.TextNode{Value: "A "},
+							&ast.BoldNode{Content: []ast.Inline{&ast.TextNode{Value: "spectre"}}},
+						},
+					},
+				},
+			},
+		},
+	}
+	out := renderHTML(t, doc)
+
+	assert.Contains(t, out, "<dd>A <strong>spectre</strong></dd>",
+		"description should render from inlines even when the legacy Description string is empty")
+}
+
 func TestRender_TitlePageSubtitleInlineStyling(t *testing.T) {
 	doc := &ast.Document{
 		TitlePage: &ast.TitlePage{
@@ -630,6 +653,28 @@ func TestRender_TitlePageSubtitleInlineStyling(t *testing.T) {
 
 	assert.Contains(t, out, "<p class=\"subtitle\">A tragedy in <em>five</em> acts</p>")
 	assert.NotContains(t, out, "_five_")
+}
+
+func TestRender_TitlePageSubtitleInlinesWithoutValue(t *testing.T) {
+	doc := &ast.Document{
+		TitlePage: &ast.TitlePage{
+			Entries: []ast.KeyValue{
+				{Key: "Title", Value: "A Play"},
+				{
+					Key: "Subtitle",
+					ValueInlines: []ast.Inline{
+						&ast.TextNode{Value: "A tragedy in "},
+						&ast.ItalicNode{Content: []ast.Inline{&ast.TextNode{Value: "five"}}},
+						&ast.TextNode{Value: " acts"},
+					},
+				},
+			},
+		},
+	}
+	out := renderHTML(t, doc)
+
+	assert.Contains(t, out, "<p class=\"subtitle\">A tragedy in <em>five</em> acts</p>",
+		"subtitle should render from inlines even when the legacy Value string is empty")
 }
 
 func TestRender_PageBreak(t *testing.T) {

--- a/internal/render/html/html_test.go
+++ b/internal/render/html/html_test.go
@@ -581,6 +581,57 @@ func TestRender_DramatisPersonae(t *testing.T) {
 	assert.Contains(t, out, "<dt>ROSENCRANTZ</dt>")
 }
 
+func TestRender_DramatisPersonaeInlineStyling(t *testing.T) {
+	doc := &ast.Document{
+		Body: []ast.Node{
+			&ast.Section{
+				Kind: ast.SectionDramatisPersonae,
+				Characters: []ast.Character{
+					{
+						Name:        "GHOST",
+						Description: "A *spectre* in _ragged_ attire",
+						DescriptionInlines: []ast.Inline{
+							&ast.TextNode{Value: "A "},
+							&ast.BoldNode{Content: []ast.Inline{&ast.TextNode{Value: "spectre"}}},
+							&ast.TextNode{Value: " in "},
+							&ast.ItalicNode{Content: []ast.Inline{&ast.TextNode{Value: "ragged"}}},
+							&ast.TextNode{Value: " attire"},
+						},
+					},
+				},
+			},
+		},
+	}
+	out := renderHTML(t, doc)
+
+	assert.Contains(t, out, "<dd>A <strong>spectre</strong> in <em>ragged</em> attire</dd>")
+	assert.NotContains(t, out, "*spectre*")
+	assert.NotContains(t, out, "_ragged_")
+}
+
+func TestRender_TitlePageSubtitleInlineStyling(t *testing.T) {
+	doc := &ast.Document{
+		TitlePage: &ast.TitlePage{
+			Entries: []ast.KeyValue{
+				{Key: "Title", Value: "A Play"},
+				{
+					Key:   "Subtitle",
+					Value: "A tragedy in _five_ acts",
+					ValueInlines: []ast.Inline{
+						&ast.TextNode{Value: "A tragedy in "},
+						&ast.ItalicNode{Content: []ast.Inline{&ast.TextNode{Value: "five"}}},
+						&ast.TextNode{Value: " acts"},
+					},
+				},
+			},
+		},
+	}
+	out := renderHTML(t, doc)
+
+	assert.Contains(t, out, "<p class=\"subtitle\">A tragedy in <em>five</em> acts</p>")
+	assert.NotContains(t, out, "_five_")
+}
+
 func TestRender_PageBreak(t *testing.T) {
 	doc := &ast.Document{
 		Body: []ast.Node{

--- a/internal/render/pdf/base.go
+++ b/internal/render/pdf/base.go
@@ -450,7 +450,7 @@ func (b *pdfBase) centeredInlines(inlines []ast.Inline, prefix, suffix string) e
 // and wraps across multiple lines when the content is too wide. Explicit
 // '\n' characters produce hard line breaks. The base font style is restored
 // on exit.
-func (b *pdfBase) centeredWrappedInlines(inlines []ast.Inline, prefix, suffix string) error {
+func (b *pdfBase) centeredWrappedInlines(inlines []ast.Inline, prefix, suffix string) {
 	baseStyle := b.fontStyle
 
 	runs := flattenInlineRuns(inlines, baseStyle)
@@ -478,7 +478,6 @@ func (b *pdfBase) centeredWrappedInlines(inlines []ast.Inline, prefix, suffix st
 	}
 
 	b.setStyle(baseStyle)
-	return nil
 }
 
 // flattenInlineRuns walks inline nodes and emits styled text runs. Nested

--- a/internal/render/pdf/base.go
+++ b/internal/render/pdf/base.go
@@ -446,6 +446,198 @@ func (b *pdfBase) centeredInlines(inlines []ast.Inline, prefix, suffix string) e
 	return nil
 }
 
+// centeredWrappedInlines renders styled inline content centered within bodyW
+// and wraps across multiple lines when the content is too wide. Explicit
+// '\n' characters produce hard line breaks. The base font style is restored
+// on exit.
+func (b *pdfBase) centeredWrappedInlines(inlines []ast.Inline, prefix, suffix string) error {
+	baseStyle := b.fontStyle
+
+	runs := flattenInlineRuns(inlines, baseStyle)
+	if prefix != "" {
+		runs = append([]dialogueTextRun{{text: prefix, style: baseStyle}}, runs...)
+	}
+	if suffix != "" {
+		runs = append(runs, dialogueTextRun{text: suffix, style: baseStyle})
+	}
+
+	lines := wrapStyledRuns(b.pdf, b.cfg.FontFamily, b.cfg.FontSize, runs, b.bodyW)
+
+	for _, line := range lines {
+		totalWidth := 0.0
+		for _, run := range line {
+			b.setStyle(run.style)
+			totalWidth += b.pdf.GetStringWidth(run.text)
+		}
+		b.pdf.SetX(b.marginL + (b.bodyW-totalWidth)/2)
+		for _, run := range line {
+			b.setStyle(run.style)
+			b.pdf.Write(b.lineHeight, run.text)
+		}
+		b.pdf.Ln(b.lineHeight)
+	}
+
+	b.setStyle(baseStyle)
+	return nil
+}
+
+// flattenInlineRuns walks inline nodes and emits styled text runs. Nested
+// styles are merged onto a base style so the caller's font context is
+// respected (e.g. an italic <subtitle> stays italic when no inline marker
+// overrides it).
+func flattenInlineRuns(inlines []ast.Inline, baseStyle string) []dialogueTextRun {
+	var runs []dialogueTextRun
+	var walk func(nodes []ast.Inline, style string)
+	walk = func(nodes []ast.Inline, style string) {
+		for _, n := range nodes {
+			switch v := n.(type) {
+			case *ast.TextNode:
+				if v.Value != "" {
+					runs = append(runs, dialogueTextRun{text: v.Value, style: style})
+				}
+			case *ast.BoldNode:
+				walk(v.Content, mergeStyles(style, "B"))
+			case *ast.ItalicNode:
+				walk(v.Content, mergeStyles(style, "I"))
+			case *ast.BoldItalicNode:
+				walk(v.Content, mergeStyles(style, "BI"))
+			case *ast.UnderlineNode:
+				walk(v.Content, mergeStyles(style, "U"))
+			case *ast.StrikethroughNode:
+				walk(v.Content, mergeStyles(style, "S"))
+			case *ast.InlineDirectionNode:
+				runs = append(runs, dialogueTextRun{text: "(", style: mergeStyles(style, "I")})
+				walk(v.Content, mergeStyles(style, "I"))
+				runs = append(runs, dialogueTextRun{text: ")", style: mergeStyles(style, "I")})
+			}
+		}
+	}
+	walk(inlines, baseStyle)
+	return runs
+}
+
+// wrapStyledRuns greedy-wraps a sequence of styled runs into lines that fit
+// within maxWidth. Word boundaries are whitespace; explicit '\n' characters
+// force a hard break. A single token longer than maxWidth overflows onto
+// its own line rather than being broken.
+func wrapStyledRuns(pdf stringWidthMeasurer, family string, size float64, runs []dialogueTextRun, maxWidth float64) [][]dialogueTextRun {
+	tokens := tokenizeStyledRuns(runs)
+
+	var lines [][]dialogueTextRun
+	var current []dialogueTextRun
+	currentWidth := 0.0
+
+	flush := func() {
+		lines = append(lines, trimTrailingWhitespaceRuns(current))
+		current = nil
+		currentWidth = 0.0
+	}
+
+	appendToken := func(tok dialogueTextRun) {
+		if len(current) > 0 && current[len(current)-1].style == tok.style {
+			current[len(current)-1].text += tok.text
+			return
+		}
+		current = append(current, tok)
+	}
+
+	for _, tok := range tokens {
+		if tok.text == "\n" {
+			flush()
+			continue
+		}
+		pdf.SetFont(family, tok.style, size)
+		w := pdf.GetStringWidth(tok.text)
+
+		if len(current) == 0 {
+			if strings.TrimSpace(tok.text) == "" {
+				continue
+			}
+			appendToken(tok)
+			currentWidth = w
+			continue
+		}
+
+		if currentWidth+w > maxWidth && strings.TrimSpace(tok.text) != "" {
+			flush()
+			appendToken(tok)
+			currentWidth = w
+			continue
+		}
+
+		appendToken(tok)
+		currentWidth += w
+	}
+
+	if len(current) > 0 {
+		flush()
+	}
+	return lines
+}
+
+type stringWidthMeasurer interface {
+	SetFont(familyStr, styleStr string, size float64)
+	GetStringWidth(s string) float64
+}
+
+// tokenizeStyledRuns splits each run's text into tokens of words, whitespace,
+// and explicit '\n' newlines, preserving the style from the originating run.
+func tokenizeStyledRuns(runs []dialogueTextRun) []dialogueTextRun {
+	var tokens []dialogueTextRun
+	for _, run := range runs {
+		if run.text == "" {
+			continue
+		}
+		var buf strings.Builder
+		var inSpace bool
+		flush := func() {
+			if buf.Len() > 0 {
+				tokens = append(tokens, dialogueTextRun{text: buf.String(), style: run.style})
+				buf.Reset()
+			}
+		}
+		for _, r := range run.text {
+			switch {
+			case r == '\n':
+				flush()
+				tokens = append(tokens, dialogueTextRun{text: "\n", style: run.style})
+				inSpace = false
+			case r == ' ' || r == '\t':
+				if !inSpace {
+					flush()
+					inSpace = true
+				}
+				buf.WriteRune(r)
+			default:
+				if inSpace {
+					flush()
+					inSpace = false
+				}
+				buf.WriteRune(r)
+			}
+		}
+		flush()
+	}
+	return tokens
+}
+
+func trimTrailingWhitespaceRuns(line []dialogueTextRun) []dialogueTextRun {
+	for len(line) > 0 {
+		last := &line[len(line)-1]
+		trimmed := strings.TrimRight(last.text, " \t")
+		if trimmed == last.text {
+			break
+		}
+		if trimmed == "" {
+			line = line[:len(line)-1]
+			continue
+		}
+		last.text = trimmed
+		break
+	}
+	return line
+}
+
 func (b *pdfBase) remainingPageHeight() float64 {
 	return b.pageH - b.marginB - b.pdf.GetY()
 }

--- a/internal/render/pdf/condensed.go
+++ b/internal/render/pdf/condensed.go
@@ -131,10 +131,12 @@ func (r *condensedRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 		r.pdf.Ln(r.lineHeight)
 	}
 
-	if subtitle != "" {
+	if subtitle != nil && strings.TrimSpace(subtitle.Value) != "" {
 		r.pdf.SetFont(r.cfg.FontFamily, "I", r.cfg.FontSize+1)
-		r.centeredWrappedText(subtitle, r.lineHeight)
-		r.pdf.Ln(r.lineHeight)
+		r.fontStyle = "I"
+		if err := r.centeredInlines(keyValueInlines(*subtitle), "", ""); err != nil {
+			return err
+		}
 	}
 
 	if len(authors) > 0 {
@@ -149,9 +151,12 @@ func (r *condensedRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 
 	if len(other) > 0 {
 		r.pdf.SetFont(r.cfg.FontFamily, "", r.cfg.FontSize-1)
+		r.fontStyle = ""
 		placeBottomBlock(&r.pdfBase, other)
 		for _, kv := range other {
-			r.centeredWrappedText(kv.Key+": "+kv.Value, r.lineHeight)
+			if err := r.centeredInlines(keyValueInlines(kv), kv.Key+": ", ""); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/render/pdf/condensed.go
+++ b/internal/render/pdf/condensed.go
@@ -131,12 +131,13 @@ func (r *condensedRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 		r.pdf.Ln(r.lineHeight)
 	}
 
-	if subtitle != nil && strings.TrimSpace(subtitle.Value) != "" {
+	if subtitle != nil && hasKeyValueContent(*subtitle) {
 		r.pdf.SetFont(r.cfg.FontFamily, "I", r.cfg.FontSize+1)
 		r.fontStyle = "I"
-		if err := r.centeredInlines(keyValueInlines(*subtitle), "", ""); err != nil {
+		if err := r.centeredWrappedInlines(keyValueInlines(*subtitle), "", ""); err != nil {
 			return err
 		}
+		r.pdf.Ln(r.lineHeight)
 	}
 
 	if len(authors) > 0 {
@@ -154,7 +155,7 @@ func (r *condensedRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 		r.fontStyle = ""
 		placeBottomBlock(&r.pdfBase, other)
 		for _, kv := range other {
-			if err := r.centeredInlines(keyValueInlines(kv), kv.Key+": ", ""); err != nil {
+			if err := r.centeredWrappedInlines(keyValueInlines(kv), kv.Key+": ", ""); err != nil {
 				return err
 			}
 		}

--- a/internal/render/pdf/condensed.go
+++ b/internal/render/pdf/condensed.go
@@ -134,9 +134,7 @@ func (r *condensedRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 	if subtitle != nil && hasKeyValueContent(*subtitle) {
 		r.pdf.SetFont(r.cfg.FontFamily, "I", r.cfg.FontSize+1)
 		r.fontStyle = "I"
-		if err := r.centeredWrappedInlines(keyValueInlines(*subtitle), "", ""); err != nil {
-			return err
-		}
+		r.centeredWrappedInlines(keyValueInlines(*subtitle), "", "")
 		r.pdf.Ln(r.lineHeight)
 	}
 
@@ -155,9 +153,7 @@ func (r *condensedRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 		r.fontStyle = ""
 		placeBottomBlock(&r.pdfBase, other)
 		for _, kv := range other {
-			if err := r.centeredWrappedInlines(keyValueInlines(kv), kv.Key+": ", ""); err != nil {
-				return err
-			}
+			r.centeredWrappedInlines(keyValueInlines(kv), kv.Key+": ", "")
 		}
 	}
 

--- a/internal/render/pdf/dramatis.go
+++ b/internal/render/pdf/dramatis.go
@@ -45,13 +45,9 @@ func renderCharacterEntry(b *pdfBase, ch ast.Character, indent float64) {
 	b.pdf.Write(b.lineHeight, render.CharacterDisplayName(ch))
 	b.setStyle("")
 
-	if ch.Description != "" {
+	if hasCharacterDescription(ch) {
 		b.pdf.Write(b.lineHeight, " \u2014 ")
-		inlines := ch.DescriptionInlines
-		if len(inlines) == 0 {
-			inlines = []ast.Inline{&ast.TextNode{Value: ch.Description}}
-		}
-		_ = b.renderInlineContent(inlines)
+		_ = b.renderInlineContent(characterDescriptionInlines(ch))
 	}
 
 	b.pdf.Ln(b.lineHeight)

--- a/internal/render/pdf/dramatis.go
+++ b/internal/render/pdf/dramatis.go
@@ -46,7 +46,12 @@ func renderCharacterEntry(b *pdfBase, ch ast.Character, indent float64) {
 	b.setStyle("")
 
 	if ch.Description != "" {
-		b.pdf.Write(b.lineHeight, " \u2014 "+ch.Description)
+		b.pdf.Write(b.lineHeight, " \u2014 ")
+		inlines := ch.DescriptionInlines
+		if len(inlines) == 0 {
+			inlines = []ast.Inline{&ast.TextNode{Value: ch.Description}}
+		}
+		_ = b.renderInlineContent(inlines)
 	}
 
 	b.pdf.Ln(b.lineHeight)

--- a/internal/render/pdf/pdf_test.go
+++ b/internal/render/pdf/pdf_test.go
@@ -918,3 +918,64 @@ func TestCondensedPrepareDialogueLinesOnlyNarrowsFirstVisualLine(t *testing.T) {
 	narrowAllLines := r.pdf.SplitText(text, 45)
 	assert.Less(t, len(prepared[0].wrappedText), len(narrowAllLines))
 }
+
+func TestWrapStyledRuns_WrapsAtMaxWidth(t *testing.T) {
+	r := NewRenderer(render.DefaultConfig()).(*pdfRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	runs := []dialogueTextRun{
+		{text: "A tragedy in ", style: "I"},
+		{text: "five", style: "BI"},
+		{text: " acts, as recounted by a reliable narrator", style: "I"},
+	}
+	singleLineWidth := r.pdf.GetStringWidth("A tragedy in five acts, as recounted by a reliable narrator")
+
+	lines := wrapStyledRuns(r.pdf, r.cfg.FontFamily, r.cfg.FontSize, runs, singleLineWidth/2)
+	require.Greater(t, len(lines), 1, "expected content to wrap across multiple lines")
+
+	for _, line := range lines {
+		total := 0.0
+		for _, run := range line {
+			r.pdf.SetFont(r.cfg.FontFamily, run.style, r.cfg.FontSize)
+			total += r.pdf.GetStringWidth(run.text)
+		}
+		assert.LessOrEqual(t, total, singleLineWidth, "each wrapped line should stay within the measured width")
+	}
+}
+
+func TestWrapStyledRuns_HonorsHardNewlines(t *testing.T) {
+	r := NewRenderer(render.DefaultConfig()).(*pdfRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	runs := []dialogueTextRun{
+		{text: "line one\nline two", style: ""},
+	}
+	lines := wrapStyledRuns(r.pdf, r.cfg.FontFamily, r.cfg.FontSize, runs, 1000)
+	require.Len(t, lines, 2)
+	assert.Equal(t, "line one", lines[0][0].text)
+	assert.Equal(t, "line two", lines[1][0].text)
+}
+
+func TestRender_TitlePageSubtitleInlineOnlyField(t *testing.T) {
+	r := NewRenderer(render.DefaultConfig())
+	doc := &ast.Document{
+		TitlePage: &ast.TitlePage{
+			Entries: []ast.KeyValue{
+				{Key: "Title", Value: "A Play"},
+				{
+					Key: "Subtitle",
+					ValueInlines: []ast.Inline{
+						&ast.TextNode{Value: "A tragedy in "},
+						&ast.ItalicNode{Content: []ast.Inline{&ast.TextNode{Value: "five"}}},
+						&ast.TextNode{Value: " acts"},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := render.Walk(r, doc, &buf)
+	require.NoError(t, err)
+	assert.True(t, buf.Len() > 0, "PDF output should not be empty when subtitle uses inline-only content")
+}

--- a/internal/render/pdf/pdf_test.go
+++ b/internal/render/pdf/pdf_test.go
@@ -956,6 +956,33 @@ func TestWrapStyledRuns_HonorsHardNewlines(t *testing.T) {
 	assert.Equal(t, "line two", lines[1][0].text)
 }
 
+func TestPlaceBottomBlock_ReservesSpaceForInlineOnlyValues(t *testing.T) {
+	r := NewRenderer(render.DefaultConfig()).(*pdfRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	words := "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam quis nostrud exercitation ullamco"
+	inlines := []ast.Inline{&ast.TextNode{Value: words}}
+	entries := []ast.KeyValue{
+		// Inline-only entry: legacy Value is empty, ValueInlines carries
+		// the full text. If placeBottomBlock read kv.Value it would
+		// reserve only a single line and leave the rendered content
+		// hanging below the target.
+		{Key: "Notes", ValueInlines: inlines},
+	}
+
+	r.pdf.SetY(r.marginT)
+	placeBottomBlock(&r.pdfBase, entries)
+	yAfter := r.pdf.GetY()
+
+	text := "Notes: " + words
+	wrappedLines := len(r.pdf.SplitText(text, r.bodyW))
+	require.Greater(t, wrappedLines, 1, "test inputs should force multi-line wrapping")
+
+	expectedTarget := r.pageH - r.marginB - r.lineHeight - float64(wrappedLines)*r.lineHeight
+	assert.InDelta(t, expectedTarget, yAfter, 0.01,
+		"placeBottomBlock must reserve space for every wrapped line derived from the rendered inline content")
+}
+
 func TestRender_TitlePageSubtitleInlineOnlyField(t *testing.T) {
 	r := NewRenderer(render.DefaultConfig())
 	doc := &ast.Document{

--- a/internal/render/pdf/titlepage.go
+++ b/internal/render/pdf/titlepage.go
@@ -29,10 +29,12 @@ func (r *pdfRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 		r.pdf.Ln(r.lineHeight)
 	}
 
-	if subtitle != "" {
+	if subtitle != nil && strings.TrimSpace(subtitle.Value) != "" {
 		r.pdf.SetFont(r.cfg.FontFamily, "I", r.cfg.FontSize+2)
-		r.centeredWrappedText(subtitle, r.lineHeight)
-		r.pdf.Ln(r.lineHeight)
+		r.fontStyle = "I"
+		if err := r.centeredInlines(keyValueInlines(*subtitle), "", ""); err != nil {
+			return err
+		}
 	}
 
 	if len(authors) > 0 {
@@ -48,9 +50,12 @@ func (r *pdfRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 	// Remaining metadata near the bottom.
 	if len(other) > 0 {
 		r.pdf.SetFont(r.cfg.FontFamily, "", r.cfg.FontSize)
+		r.fontStyle = ""
 		placeBottomBlock(&r.pdfBase, other)
 		for _, kv := range other {
-			r.centeredWrappedText(kv.Key+": "+kv.Value, r.lineHeight)
+			if err := r.centeredInlines(keyValueInlines(kv), kv.Key+": ", ""); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -75,13 +80,14 @@ func renderInlinePlayHeader(b *pdfBase, section *ast.Section, titleSize float64,
 	b.centeredWrappedText(strings.ToUpper(displayTitle), b.lineHeight)
 	b.pdf.Ln(b.lineHeight)
 
-	if s := strings.TrimSpace(subtitle); s != "" {
+	if subtitle != nil && strings.TrimSpace(subtitle.Value) != "" {
 		b.pdf.SetFont(b.cfg.FontFamily, "I", metadataSize)
-		b.centeredWrappedText(s, b.lineHeight)
-		b.pdf.Ln(b.lineHeight)
+		b.fontStyle = "I"
+		_ = b.centeredInlines(keyValueInlines(*subtitle), "", "")
 	}
 
 	b.pdf.SetFont(b.cfg.FontFamily, "", metadataSize)
+	b.fontStyle = ""
 	if len(authors) > 0 {
 		b.centeredWrappedText("by", b.lineHeight)
 		b.pdf.Ln(b.lineHeight / 2)
@@ -90,7 +96,7 @@ func renderInlinePlayHeader(b *pdfBase, section *ast.Section, titleSize float64,
 		}
 	}
 	for _, kv := range other {
-		b.centeredWrappedText(kv.Key+": "+kv.Value, b.lineHeight)
+		_ = b.centeredInlines(keyValueInlines(kv), kv.Key+": ", "")
 		b.pdf.Ln(b.lineHeight)
 	}
 
@@ -200,14 +206,16 @@ func applyDocumentMetadata(b *pdfBase, tp *ast.TitlePage) {
 	if len(authors) > 0 {
 		b.pdf.SetAuthor(strings.Join(authors, ", "), true)
 	}
-	if s := strings.TrimSpace(subtitle); s != "" {
-		b.pdf.SetSubject(s, true)
+	if subtitle != nil {
+		if s := strings.TrimSpace(render.PlainText(keyValueInlines(*subtitle))); s != "" {
+			b.pdf.SetSubject(s, true)
+		}
 	}
 	var keywords []string
 	for _, kv := range other {
 		switch strings.ToLower(strings.TrimSpace(kv.Key)) {
 		case "keywords", "tags":
-			keywords = append(keywords, kv.Value)
+			keywords = append(keywords, render.PlainText(keyValueInlines(kv)))
 		}
 	}
 	if len(keywords) > 0 {
@@ -241,16 +249,31 @@ func placeBottomBlock(b *pdfBase, entries []ast.KeyValue) {
 	b.pdf.SetY(target)
 }
 
-func partitionTitlePageEntries(tp *ast.TitlePage) (title string, subtitle string, authors []string, other []ast.KeyValue) {
-	if tp == nil {
-		return "", "", nil, nil
+// keyValueInlines returns the inline representation of a KeyValue's value,
+// falling back to a single TextNode when the parser didn't populate
+// ValueInlines (e.g. tests that build KeyValues by hand).
+func keyValueInlines(kv ast.KeyValue) []ast.Inline {
+	if len(kv.ValueInlines) > 0 {
+		return kv.ValueInlines
 	}
-	for _, kv := range tp.Entries {
+	if kv.Value == "" {
+		return nil
+	}
+	return []ast.Inline{&ast.TextNode{Value: kv.Value}}
+}
+
+func partitionTitlePageEntries(tp *ast.TitlePage) (title string, subtitle *ast.KeyValue, authors []string, other []ast.KeyValue) {
+	if tp == nil {
+		return "", nil, nil, nil
+	}
+	for i := range tp.Entries {
+		kv := tp.Entries[i]
 		switch strings.ToLower(strings.TrimSpace(kv.Key)) {
 		case "title":
 			title = kv.Value
 		case "subtitle":
-			subtitle = kv.Value
+			c := kv
+			subtitle = &c
 		case "author":
 			if strings.TrimSpace(kv.Value) != "" {
 				authors = append(authors, kv.Value)

--- a/internal/render/pdf/titlepage.go
+++ b/internal/render/pdf/titlepage.go
@@ -236,7 +236,7 @@ func applyDocumentMetadata(b *pdfBase, tp *ast.TitlePage) {
 func placeBottomBlock(b *pdfBase, entries []ast.KeyValue) {
 	reserve := b.lineHeight
 	for _, kv := range entries {
-		text := kv.Key + ": " + kv.Value
+		text := kv.Key + ": " + render.PlainText(keyValueInlines(kv))
 		wrapped := b.pdf.SplitText(text, b.bodyW)
 		if len(wrapped) == 0 {
 			wrapped = []string{text}

--- a/internal/render/pdf/titlepage.go
+++ b/internal/render/pdf/titlepage.go
@@ -32,9 +32,7 @@ func (r *pdfRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 	if subtitle != nil && hasKeyValueContent(*subtitle) {
 		r.pdf.SetFont(r.cfg.FontFamily, "I", r.cfg.FontSize+2)
 		r.fontStyle = "I"
-		if err := r.centeredWrappedInlines(keyValueInlines(*subtitle), "", ""); err != nil {
-			return err
-		}
+		r.centeredWrappedInlines(keyValueInlines(*subtitle), "", "")
 		r.pdf.Ln(r.lineHeight)
 	}
 
@@ -54,9 +52,7 @@ func (r *pdfRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 		r.fontStyle = ""
 		placeBottomBlock(&r.pdfBase, other)
 		for _, kv := range other {
-			if err := r.centeredWrappedInlines(keyValueInlines(kv), kv.Key+": ", ""); err != nil {
-				return err
-			}
+			r.centeredWrappedInlines(keyValueInlines(kv), kv.Key+": ", "")
 		}
 	}
 
@@ -84,7 +80,7 @@ func renderInlinePlayHeader(b *pdfBase, section *ast.Section, titleSize float64,
 	if subtitle != nil && hasKeyValueContent(*subtitle) {
 		b.pdf.SetFont(b.cfg.FontFamily, "I", metadataSize)
 		b.fontStyle = "I"
-		_ = b.centeredWrappedInlines(keyValueInlines(*subtitle), "", "")
+		b.centeredWrappedInlines(keyValueInlines(*subtitle), "", "")
 		b.pdf.Ln(b.lineHeight)
 	}
 
@@ -98,7 +94,7 @@ func renderInlinePlayHeader(b *pdfBase, section *ast.Section, titleSize float64,
 		}
 	}
 	for _, kv := range other {
-		_ = b.centeredWrappedInlines(keyValueInlines(kv), kv.Key+": ", "")
+		b.centeredWrappedInlines(keyValueInlines(kv), kv.Key+": ", "")
 		b.pdf.Ln(b.lineHeight)
 	}
 

--- a/internal/render/pdf/titlepage.go
+++ b/internal/render/pdf/titlepage.go
@@ -29,12 +29,13 @@ func (r *pdfRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 		r.pdf.Ln(r.lineHeight)
 	}
 
-	if subtitle != nil && strings.TrimSpace(subtitle.Value) != "" {
+	if subtitle != nil && hasKeyValueContent(*subtitle) {
 		r.pdf.SetFont(r.cfg.FontFamily, "I", r.cfg.FontSize+2)
 		r.fontStyle = "I"
-		if err := r.centeredInlines(keyValueInlines(*subtitle), "", ""); err != nil {
+		if err := r.centeredWrappedInlines(keyValueInlines(*subtitle), "", ""); err != nil {
 			return err
 		}
+		r.pdf.Ln(r.lineHeight)
 	}
 
 	if len(authors) > 0 {
@@ -53,7 +54,7 @@ func (r *pdfRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 		r.fontStyle = ""
 		placeBottomBlock(&r.pdfBase, other)
 		for _, kv := range other {
-			if err := r.centeredInlines(keyValueInlines(kv), kv.Key+": ", ""); err != nil {
+			if err := r.centeredWrappedInlines(keyValueInlines(kv), kv.Key+": ", ""); err != nil {
 				return err
 			}
 		}
@@ -80,10 +81,11 @@ func renderInlinePlayHeader(b *pdfBase, section *ast.Section, titleSize float64,
 	b.centeredWrappedText(strings.ToUpper(displayTitle), b.lineHeight)
 	b.pdf.Ln(b.lineHeight)
 
-	if subtitle != nil && strings.TrimSpace(subtitle.Value) != "" {
+	if subtitle != nil && hasKeyValueContent(*subtitle) {
 		b.pdf.SetFont(b.cfg.FontFamily, "I", metadataSize)
 		b.fontStyle = "I"
-		_ = b.centeredInlines(keyValueInlines(*subtitle), "", "")
+		_ = b.centeredWrappedInlines(keyValueInlines(*subtitle), "", "")
+		b.pdf.Ln(b.lineHeight)
 	}
 
 	b.pdf.SetFont(b.cfg.FontFamily, "", metadataSize)
@@ -96,7 +98,7 @@ func renderInlinePlayHeader(b *pdfBase, section *ast.Section, titleSize float64,
 		}
 	}
 	for _, kv := range other {
-		_ = b.centeredInlines(keyValueInlines(kv), kv.Key+": ", "")
+		_ = b.centeredWrappedInlines(keyValueInlines(kv), kv.Key+": ", "")
 		b.pdf.Ln(b.lineHeight)
 	}
 
@@ -260,6 +262,36 @@ func keyValueInlines(kv ast.KeyValue) []ast.Inline {
 		return nil
 	}
 	return []ast.Inline{&ast.TextNode{Value: kv.Value}}
+}
+
+// hasKeyValueContent reports whether a KeyValue has any renderable value,
+// checking both the legacy string and the inline form so ASTs built only
+// with ValueInlines still render.
+func hasKeyValueContent(kv ast.KeyValue) bool {
+	if strings.TrimSpace(kv.Value) != "" {
+		return true
+	}
+	return strings.TrimSpace(render.PlainText(kv.ValueInlines)) != ""
+}
+
+// hasCharacterDescription is the same gate for Character entries.
+func hasCharacterDescription(ch ast.Character) bool {
+	if strings.TrimSpace(ch.Description) != "" {
+		return true
+	}
+	return strings.TrimSpace(render.PlainText(ch.DescriptionInlines)) != ""
+}
+
+// characterDescriptionInlines returns the inline representation of a
+// Character's description with a TextNode fallback for hand-built ASTs.
+func characterDescriptionInlines(ch ast.Character) []ast.Inline {
+	if len(ch.DescriptionInlines) > 0 {
+		return ch.DescriptionInlines
+	}
+	if ch.Description == "" {
+		return nil
+	}
+	return []ast.Inline{&ast.TextNode{Value: ch.Description}}
 }
 
 func partitionTitlePageEntries(tp *ast.TitlePage) (title string, subtitle *ast.KeyValue, authors []string, other []ast.KeyValue) {


### PR DESCRIPTION
## Summary

- Character descriptions in dramatis personae and title-page / section-metadata values (Subtitle, free-form metadata) now render inline styling (`*italic*`, `**bold**`, `_underline_`, `~strike~`) instead of leaking the raw markers.
- Title and Author stay plain: heading-styled content and identifiers, respectively. PDF doc-info (Subject, Keywords) uses plain text extracted from the inlines so markers never reach metadata.
- Parser carries parsed inlines on `ast.Character.DescriptionInlines` and `ast.KeyValue.ValueInlines`; renderers route through the shared inline walker.
- PDF gets a new `centeredWrappedInlines` that flattens inlines to styled runs, greedy-wraps against `bodyW` (respecting hard `\n` from continuation values), and centers each wrapped line — restoring the wrap behaviour the old `centeredWrappedText` provided for Subtitle and bottom metadata.
- `placeBottomBlock` sizes its reserve from the rendered inline plain text instead of the legacy `kv.Value`, so inline-only and styled entries don't collide with the footer.
- Render gates now check both the legacy string and the inline form, so ASTs built with `ValueInlines` / `DescriptionInlines` alone (and empty `Value` / `Description`) render correctly.

## Test plan

- [x] `go test ./...`
- [x] New parser tests: inline styling populated on Character descriptions and title-page subtitle values
- [x] New HTML tests: styled subtitle + description produce `<em>` / `<strong>`; inline-only subtitle and description still render
- [x] New PDF tests: `wrapStyledRuns` wraps at max width and honours hard newlines; `placeBottomBlock` reserves for multi-line inline-only entries; inline-only subtitle produces non-empty PDF output
- [x] Parser golden files regenerated with `UPDATE_GOLDEN=1`

Spec updated (SPEC.md §11) to note that inline formatting now applies in character descriptions and frontmatter values.