### PR TITLE
fix(lsp): target missing DP edit by play

### DIFF
--- a/internal/lsp/code_actions.go
+++ b/internal/lsp/code_actions.go
@@ -550,9 +550,10 @@ func insertMissingDramatisPersonaeEdit(doc *ast.Document, content string, index 
 		body += "\n"
 	}
 
-	// Insert after the play heading and any attached metadata block.
-	if len(index.topLevelSections) > 0 {
-		play := index.topLevelSections[0]
+	// Insert after the play that actually contains the first dialogue. This
+	// avoids dropping the section into a compilation header or notes block
+	// when the document has multiple top-level sections.
+	if play := firstDialoguePlay(index); play != nil {
 		line := insertAfterPlayHeader(play, content)
 		return &protocol.TextEdit{
 			Range: protocol.Range{
@@ -575,6 +576,18 @@ func insertMissingDramatisPersonaeEdit(doc *ast.Document, content string, index 
 		},
 		NewText: body,
 	}
+}
+
+func firstDialoguePlay(index *documentIndex) *ast.Section {
+	if index == nil {
+		return nil
+	}
+	for _, ref := range index.dialogues {
+		if ref.play != nil {
+			return ref.play
+		}
+	}
+	return nil
 }
 
 // insertAfterPlayHeader returns the insertion line under a play heading.

--- a/internal/lsp/dp_cue_code_actions_test.go
+++ b/internal/lsp/dp_cue_code_actions_test.go
@@ -160,3 +160,34 @@ Hello.`
 	assert.Equal(t, uint32(0), edits[0].Range.Start.Line)
 	assert.True(t, strings.HasPrefix(edits[0].NewText, "## Dramatis Personae\n"))
 }
+
+func TestComputeCodeActions_InsertMissingDramatisPersonae_TargetsFirstDialoguePlay(t *testing.T) {
+	content := `# Compilation
+Author: Editor
+
+## Notes
+This is frontmatter prose.
+
+# Play One
+
+ALICE
+Hi.`
+
+	actions := codeActionsFor(t, content)
+
+	var add *protocol.CodeAction
+	for i := range actions {
+		if actions[i].Title == "Add Dramatis Personae section" {
+			add = &actions[i]
+			break
+		}
+	}
+	require.NotNil(t, add, "expected an add-DP-section action")
+
+	edits := add.Edit.Changes[protocol.DocumentURI("file:///test.ds")]
+	require.Len(t, edits, 1)
+	// The edit should land in the play that actually contains the dialogue,
+	// not in the compilation header or notes section.
+	assert.GreaterOrEqual(t, edits[0].Range.Start.Line, uint32(7))
+	assert.True(t, strings.HasPrefix(edits[0].NewText, "## Dramatis Personae\n"))
+}


### PR DESCRIPTION
Release-prep audit for 0.7.0.

This fixes a real regression in the missing-Dramatis-Personae quick fix: in compilation-shaped documents, the insert action could target the first top-level section instead of the play that actually contains dialogue. The new test covers that case.