### PR TITLE
feat(lsp): add structural Rename Symbol for characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ Thumbs.db
 # Project-specific ignored files
 .design_docs/
 .tmp/
+.codex

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ SONG END
   - Document outline (acts/scenes/characters)
   - Hover info on character names (shows description from dramatis personae)
   - Go-to-definition (jump to character's dramatis personae entry)
+  - Rename Symbol for characters (updates dramatis personae entry,
+    aliases, and matching cues — refuses on prose mentions)
   - Context-aware completion for character cues
   - Diagnostics (parse errors, unknown character warnings, Dramatis
     Personae hygiene, cue hygiene)

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -45,6 +45,8 @@ Downstage includes:
 - Character cue suggestions in scene context
 - Structure-aware headings and folding
 - Diagnostics in the Problems panel
+- Rename Symbol on a character name (F2) updates the dramatis personae
+  entry and every matching cue at once
 - Snippets for acts, scenes, cues, stage directions, and songs
 
 ### Snippets for common structures

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -204,17 +204,13 @@ type Character struct {
 	Description        string
 	DescriptionInlines []Inline
 	Range              token.Range
-	// nameRange covers the primary name token within Range. Excluded from
-	// JSON to keep `downstage parse` output stable.
+	// nameRange covers the primary name token within Range.
 	nameRange token.Range
-	// aliasRanges covers each alias name token, in the same order as Aliases.
-	// Excluded from JSON for the same reason.
+	// aliasRanges covers each alias token, in alias order.
 	aliasRanges []token.Range
 }
 
-// NameRange returns the source range of the primary name token. When unset
-// (e.g. character constructed in tests) it falls back to a synthesized range
-// derived from Range and Name.
+// NameRange returns the source range of the primary name token.
 func (c Character) NameRange() token.Range {
 	if !isZeroRange(c.nameRange) {
 		return c.nameRange
@@ -226,12 +222,10 @@ func (c Character) NameRange() token.Range {
 	return r
 }
 
-// SetNameRange records the source range of the primary name token.
+// SetNameRange records the primary name range.
 func (c *Character) SetNameRange(r token.Range) { c.nameRange = r }
 
-// AliasRange returns the source range of the alias at index i. Returns a
-// zero range when the index is out of bounds or the alias range was not
-// captured by the parser.
+// AliasRange returns the source range of the alias at index i.
 func (c Character) AliasRange(i int) token.Range {
 	if i < 0 || i >= len(c.aliasRanges) {
 		return token.Range{}
@@ -239,8 +233,7 @@ func (c Character) AliasRange(i int) token.Range {
 	return c.aliasRanges[i]
 }
 
-// SetAliasRanges records the source ranges of alias tokens, indexed in
-// parallel with Aliases.
+// SetAliasRanges records alias ranges in alias order.
 func (c *Character) SetAliasRanges(rs []token.Range) { c.aliasRanges = rs }
 
 // CharacterGroup is a named group of characters.

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -204,7 +204,44 @@ type Character struct {
 	Description        string
 	DescriptionInlines []Inline
 	Range              token.Range
+	// nameRange covers the primary name token within Range. Excluded from
+	// JSON to keep `downstage parse` output stable.
+	nameRange token.Range
+	// aliasRanges covers each alias name token, in the same order as Aliases.
+	// Excluded from JSON for the same reason.
+	aliasRanges []token.Range
 }
+
+// NameRange returns the source range of the primary name token. When unset
+// (e.g. character constructed in tests) it falls back to a synthesized range
+// derived from Range and Name.
+func (c Character) NameRange() token.Range {
+	if !isZeroRange(c.nameRange) {
+		return c.nameRange
+	}
+	r := c.Range
+	r.End = r.Start
+	r.End.Column += token.UTF16Len(c.Name)
+	r.End.Offset += len(c.Name)
+	return r
+}
+
+// SetNameRange records the source range of the primary name token.
+func (c *Character) SetNameRange(r token.Range) { c.nameRange = r }
+
+// AliasRange returns the source range of the alias at index i. Returns a
+// zero range when the index is out of bounds or the alias range was not
+// captured by the parser.
+func (c Character) AliasRange(i int) token.Range {
+	if i < 0 || i >= len(c.aliasRanges) {
+		return token.Range{}
+	}
+	return c.aliasRanges[i]
+}
+
+// SetAliasRanges records the source ranges of alias tokens, indexed in
+// parallel with Aliases.
+func (c *Character) SetAliasRanges(rs []token.Range) { c.aliasRanges = rs }
 
 // CharacterGroup is a named group of characters.
 type CharacterGroup struct {

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -42,9 +42,37 @@ var conjunctionSeps = []string{" AND ", " & "}
 // splitConjunctionCue splits a cue like "BOB AND JANE" or "BOB & JANE"
 // into individual names. Returns nil if no conjunction is found.
 func splitConjunctionCue(name string) []string {
+	parts := splitConjunctionCueWithOffsets(name)
+	if len(parts) == 0 {
+		return nil
+	}
+	out := make([]string, len(parts))
+	for i, p := range parts {
+		out[i] = p.Name
+	}
+	return out
+}
+
+// conjunctionPart describes one participant of a conjunction cue,
+// alongside its byte offsets within the original cue string. Callers
+// that need to edit a sub-name in place (rename) use the offsets to
+// build a precise source range.
+type conjunctionPart struct {
+	Name  string
+	Start int // inclusive byte offset of the trimmed name within the cue
+	End   int // exclusive byte offset
+}
+
+// splitConjunctionCueWithOffsets returns participants of a conjunction
+// cue together with their byte spans inside the original name string.
+// Returns nil when the cue is a single name.
+func splitConjunctionCueWithOffsets(name string) []conjunctionPart {
 	upper := strings.ToUpper(name)
 
-	var parts []string
+	type rawPart struct {
+		start, end int // raw segment bounds, including any surrounding whitespace
+	}
+	var raws []rawPart
 	offset := 0
 	for offset < len(upper) {
 		bestIdx := -1
@@ -56,15 +84,25 @@ func splitConjunctionCue(name string) []string {
 			}
 		}
 		if bestIdx < 0 {
-			parts = append(parts, strings.TrimSpace(name[offset:]))
+			raws = append(raws, rawPart{start: offset, end: len(name)})
 			break
 		}
-		parts = append(parts, strings.TrimSpace(name[offset:offset+bestIdx]))
+		raws = append(raws, rawPart{start: offset, end: offset + bestIdx})
 		offset += bestIdx + bestLen
 	}
 
-	if len(parts) <= 1 {
+	if len(raws) <= 1 {
 		return nil
+	}
+
+	parts := make([]conjunctionPart, 0, len(raws))
+	for _, raw := range raws {
+		segment := name[raw.start:raw.end]
+		trimmedLeading := len(segment) - len(strings.TrimLeft(segment, " \t"))
+		trimmed := strings.TrimSpace(segment)
+		start := raw.start + trimmedLeading
+		end := start + len(trimmed)
+		parts = append(parts, conjunctionPart{Name: trimmed, Start: start, End: end})
 	}
 	return parts
 }

--- a/internal/lsp/handler.go
+++ b/internal/lsp/handler.go
@@ -57,6 +57,10 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, req jsonrp
 		return h.handleCodeAction(ctx, reply, req)
 	case protocol.MethodTextDocumentFoldingRange:
 		return h.handleFoldingRange(ctx, reply, req)
+	case protocol.MethodTextDocumentPrepareRename:
+		return h.handlePrepareRename(ctx, reply, req)
+	case protocol.MethodTextDocumentRename:
+		return h.handleRename(ctx, reply, req)
 	default:
 		return reply(ctx, nil, jsonrpc2.NewError(jsonrpc2.MethodNotFound, "method not found: "+method))
 	}
@@ -88,6 +92,9 @@ func (h *handler) handleInitialize(ctx context.Context, reply jsonrpc2.Replier, 
 			DefinitionProvider:     true,
 			CodeActionProvider:     true,
 			FoldingRangeProvider:   true,
+			RenameProvider: protocol.RenameOptions{
+				PrepareProvider: true,
+			},
 			CompletionProvider: &protocol.CompletionOptions{
 				TriggerCharacters: []string{"@", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"},
 			},
@@ -264,6 +271,46 @@ func (h *handler) handleFoldingRange(ctx context.Context, reply jsonrpc2.Replier
 		result = []protocol.FoldingRange{}
 	}
 	return reply(ctx, result, nil)
+}
+
+func (h *handler) handlePrepareRename(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+	var params protocol.PrepareRenameParams
+	if err := json.Unmarshal(req.Params(), &params); err != nil {
+		h.logger.Error("failed to unmarshal prepareRename params", slog.String("error", err.Error()))
+		return reply(ctx, nil, nil)
+	}
+
+	doc := h.dm.Get(params.TextDocument.URI)
+	if doc == nil {
+		return reply(ctx, nil, nil)
+	}
+
+	r := computePrepareRename(doc.doc, params.Position)
+	if r == nil {
+		// Returning a JSON-RPC error tells the client to refuse the
+		// rename UI gracefully (no popup with a misleading default).
+		return reply(ctx, nil, jsonrpc2.NewError(jsonrpc2.InvalidRequest, "cannot rename here"))
+	}
+	return reply(ctx, r, nil)
+}
+
+func (h *handler) handleRename(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+	var params protocol.RenameParams
+	if err := json.Unmarshal(req.Params(), &params); err != nil {
+		h.logger.Error("failed to unmarshal rename params", slog.String("error", err.Error()))
+		return reply(ctx, nil, nil)
+	}
+
+	doc := h.dm.Get(params.TextDocument.URI)
+	if doc == nil {
+		return reply(ctx, nil, nil)
+	}
+
+	edit, err := computeRename(doc.doc, params.TextDocument.URI, params.Position, params.NewName)
+	if err != nil {
+		return reply(ctx, nil, jsonrpc2.NewError(jsonrpc2.InvalidRequest, err.Error()))
+	}
+	return reply(ctx, edit, nil)
 }
 
 func (h *handler) publishDiagnostics(ctx context.Context, docURI protocol.DocumentURI, diags []protocol.Diagnostic) error {

--- a/internal/lsp/handler_test.go
+++ b/internal/lsp/handler_test.go
@@ -99,6 +99,14 @@ func TestHandleInitialize_AdvertisesFoldingRangeProvider(t *testing.T) {
 	if got.Capabilities.FoldingRangeProvider != true {
 		t.Fatalf("expected folding range provider to be advertised, got %#v", got.Capabilities.FoldingRangeProvider)
 	}
+
+	rename, ok := got.Capabilities.RenameProvider.(protocol.RenameOptions)
+	if !ok {
+		t.Fatalf("expected rename provider to be RenameOptions, got %T", got.Capabilities.RenameProvider)
+	}
+	if !rename.PrepareProvider {
+		t.Fatal("expected rename provider to advertise prepareProvider")
+	}
 }
 
 func TestHandle_UnknownMethodReturnsMethodNotFound(t *testing.T) {

--- a/internal/lsp/rename.go
+++ b/internal/lsp/rename.go
@@ -10,38 +10,16 @@ import (
 	"go.lsp.dev/protocol"
 )
 
-// errRenameInvalid signals that the cursor is not on a renameable symbol,
-// or that the requested new name is not acceptable. The handler converts
-// this into an LSP error response.
 var errRenameInvalid = errors.New("rename: invalid request")
 
-// renameTarget describes the specific spelling the cursor is on. A
-// character may be referenced by its primary name or any of its aliases;
-// each spelling is treated as its own renameable symbol so writers can
-// rename a single alias without rewriting the rest.
 type renameTarget struct {
-	character *ast.Character
-	// oldName is the spelling being renamed (case-preserved as declared
-	// in the dramatis personae).
-	oldName string
-	// upperKey is the case-folded form used to match cues.
-	upperKey string
-	// cursorRange is the range under the cursor — used by prepareRename
-	// to highlight the symbol. It is the dramatis personae entry when
-	// the cursor is on a declaration, or the cue range when the cursor
-	// is on a dialogue cue.
+	character   *ast.Character
+	upperKey    string
 	cursorRange token.Range
-	// kind tracks whether the declaration is the primary name or an alias.
-	kind renameKind
-	// aliasIndex is the alias position when kind == renameKindAlias.
-	aliasIndex int
+	kind        renameKind
+	aliasIndex  int
 }
 
-// declRange returns the canonical declaration range for the target —
-// always the dramatis personae entry (primary name or alias), never a
-// cue. The cue walk in computeRename relies on this so the declaration
-// edit does not overlap with the cue edit when rename is triggered
-// from a cue.
 func (t *renameTarget) declRange() token.Range {
 	if t.character == nil {
 		return token.Range{}
@@ -61,8 +39,6 @@ const (
 	renameKindAlias
 )
 
-// computePrepareRename returns the source range of the symbol under the
-// cursor when rename is supported there, or nil otherwise.
 func computePrepareRename(doc *ast.Document, pos protocol.Position) *protocol.Range {
 	if doc == nil {
 		return nil
@@ -75,9 +51,6 @@ func computePrepareRename(doc *ast.Document, pos protocol.Position) *protocol.Ra
 	return &r
 }
 
-// computeRename builds a workspace edit that renames every structural
-// reference to the symbol at the cursor. Returns errRenameInvalid when
-// the symbol is not renameable or the new name is not acceptable.
 func computeRename(doc *ast.Document, uri protocol.DocumentURI, pos protocol.Position, newName string) (*protocol.WorkspaceEdit, error) {
 	if doc == nil {
 		return nil, errRenameInvalid
@@ -105,13 +78,6 @@ func computeRename(doc *ast.Document, uri protocol.DocumentURI, pos protocol.Pos
 		{Range: toLSPRange(declRange), NewText: cleaned},
 	}
 
-	// Restrict cue updates to the play that owns the target's DP scope.
-	// In a compilation document each top-level play has its own dramatis
-	// personae, so a "BOB" in Play A is a different character than
-	// "BOB" in Play B. Walking the whole document would rewrite cues
-	// belonging to other plays. When the document uses the legacy
-	// document-wide DP (no top-level section owns one), play is nil and
-	// we fall back to a doc-wide walk.
 	scope, ok := renameScope(doc, declRange.Start.Line)
 	if !ok {
 		return nil, errRenameInvalid
@@ -123,7 +89,6 @@ func computeRename(doc *ast.Document, uri protocol.DocumentURI, pos protocol.Pos
 		}
 		nameRange := dlg.NameRange()
 
-		// Single-name cue: replace the whole cue when it matches.
 		if strings.ToUpper(cueName) == target.upperKey {
 			replacement := matchCueCasing(cueName, cleaned)
 			if replacement != cueName {
@@ -135,10 +100,6 @@ func computeRename(doc *ast.Document, uri protocol.DocumentURI, pos protocol.Pos
 			return
 		}
 
-		// Conjunction cue ("JAKE AND BOB"): rewrite each participant
-		// that matches the renamed spelling. Each participant has a
-		// known byte span inside the cue text, so we can build a
-		// precise range without disturbing the rest of the cue.
 		parts := splitConjunctionCueWithOffsets(dlg.Character)
 		for _, part := range parts {
 			if strings.ToUpper(part.Name) != target.upperKey {
@@ -162,12 +123,6 @@ func computeRename(doc *ast.Document, uri protocol.DocumentURI, pos protocol.Pos
 	}, nil
 }
 
-// findRenameTarget identifies the character spelling under the cursor.
-// Supported positions:
-//   - primary name in a dramatis personae entry
-//   - alias spelling in a dramatis personae entry
-//   - dialogue cue whose spelling matches a known character primary name
-//     or alias (excluding conjunction cues like "BOB AND JANE")
 func findRenameTarget(doc *ast.Document, pos protocol.Position) *renameTarget {
 	if target := findRenameTargetInDP(doc, pos); target != nil {
 		return target
@@ -215,7 +170,6 @@ func scanCharactersForPosition(characters []ast.Character, pos protocol.Position
 		if positionInRange(pos, ch.NameRange()) && strings.TrimSpace(ch.Name) != "" {
 			return &renameTarget{
 				character:   ch,
-				oldName:     ch.Name,
 				upperKey:    strings.ToUpper(strings.TrimSpace(ch.Name)),
 				cursorRange: ch.NameRange(),
 				kind:        renameKindPrimary,
@@ -230,7 +184,6 @@ func scanCharactersForPosition(characters []ast.Character, pos protocol.Position
 			if positionInRange(pos, r) && strings.TrimSpace(alias) != "" {
 				return &renameTarget{
 					character:   ch,
-					oldName:     alias,
 					upperKey:    strings.ToUpper(strings.TrimSpace(alias)),
 					cursorRange: r,
 					kind:        renameKindAlias,
@@ -247,9 +200,6 @@ func findRenameTargetInCue(doc *ast.Document, pos protocol.Position) *renameTarg
 	if cueName == "" {
 		return nil
 	}
-	// Skip conjunction cues — sub-name boundaries aren't ranged so we
-	// cannot rename a single participant safely. The user can rename
-	// from the dramatis personae entry instead.
 	if splitConjunctionCue(cueName) != nil {
 		return nil
 	}
@@ -263,7 +213,6 @@ func findRenameTargetInCue(doc *ast.Document, pos protocol.Position) *renameTarg
 		if strings.ToUpper(strings.TrimSpace(ch.Name)) == upperCue {
 			return &renameTarget{
 				character:   ch,
-				oldName:     ch.Name,
 				upperKey:    upperCue,
 				cursorRange: cueRange,
 				kind:        renameKindPrimary,
@@ -274,7 +223,6 @@ func findRenameTargetInCue(doc *ast.Document, pos protocol.Position) *renameTarg
 			if strings.ToUpper(strings.TrimSpace(alias)) == upperCue {
 				return &renameTarget{
 					character:   ch,
-					oldName:     alias,
 					upperKey:    upperCue,
 					cursorRange: cueRange,
 					kind:        renameKindAlias,
@@ -286,9 +234,6 @@ func findRenameTargetInCue(doc *ast.Document, pos protocol.Position) *renameTarg
 	return nil
 }
 
-// collectAllCharacters returns pointers to every character in the section,
-// including those nested in groups, so callers can mutate via the same
-// slice the parser populated.
 func collectAllCharacters(dp *ast.Section) []*ast.Character {
 	var out []*ast.Character
 	for i := range dp.Characters {
@@ -302,8 +247,6 @@ func collectAllCharacters(dp *ast.Section) []*ast.Character {
 	return out
 }
 
-// findCueAtPosition is a sibling of findCharacterAtPosition that also
-// returns the cue's source range, which prepareRename needs.
 func findCueAtPosition(doc *ast.Document, pos protocol.Position) (string, token.Range) {
 	for _, n := range doc.Body {
 		if name, r := findCueInNode(n, pos); name != "" {
@@ -342,10 +285,6 @@ func findCueInNode(n ast.Node, pos protocol.Position) (string, token.Range) {
 	return "", token.Range{}
 }
 
-// hasNameConflict returns true when renaming target to newName would
-// collide with another known spelling in the same dramatis personae —
-// e.g. renaming BOB to JANE when JANE already exists, or renaming an
-// alias to a spelling already used by the same entry.
 func hasNameConflict(doc *ast.Document, target *renameTarget, newName string) bool {
 	dp := scopedDramatisPersonae(doc, target.cursorRange.Start.Line)
 	if dp == nil {
@@ -358,7 +297,6 @@ func hasNameConflict(doc *ast.Document, target *renameTarget, newName string) bo
 	for _, ch := range collectAllCharacters(dp) {
 		nameKey := strings.ToUpper(strings.TrimSpace(ch.Name))
 		if ch == target.character && target.kind == renameKindPrimary {
-			// skip the spelling being renamed
 		} else if nameKey != "" && nameKey == upperNew {
 			return true
 		}
@@ -375,29 +313,16 @@ func hasNameConflict(doc *ast.Document, target *renameTarget, newName string) bo
 	return false
 }
 
-// renameScope returns the top-level play section whose dramatis
-// personae owns the rename target. The boolean is false when the
-// rename has no defined scope and must be refused — that happens when
-// the document mixes a legacy doc-level DP with one or more scoped
-// plays, and the cursor lands on the now-ignored legacy DP. A nil
-// section paired with a true result means the document is a pure
-// legacy layout (no scoped DPs anywhere), so a doc-wide walk is
-// correct.
 func renameScope(doc *ast.Document, line int) (*ast.Section, bool) {
 	if play := topLevelSectionForLine(doc, line); play != nil {
 		return play, true
 	}
 	if hasScopedDramatisPersonae(doc) {
-		// Mixed layout: legacy DP entries are intentionally disregarded
-		// by the rest of the LSP. Refuse rather than silently widening
-		// the rewrite across every scoped play.
 		return nil, false
 	}
 	return nil, true
 }
 
-// visitDialoguesInScope walks every dialogue node within the given play
-// section. When play is nil, it walks the entire document.
 func visitDialoguesInScope(doc *ast.Document, play *ast.Section, fn func(*ast.Dialogue)) {
 	var walk func(node ast.Node)
 	walk = func(node ast.Node) {
@@ -433,23 +358,12 @@ func visitDialoguesInScope(doc *ast.Document, play *ast.Section, fn func(*ast.Di
 
 func positionInRange(pos protocol.Position, r token.Range) bool {
 	if int(pos.Line) != r.Start.Line || r.Start.Line != r.End.Line {
-		// Character names always sit on a single source line; reject
-		// multi-line or off-line positions outright.
 		return false
 	}
 	col := int(pos.Character)
-	// End-exclusive to match the cue-position check. A cursor on the
-	// slash that follows an alias (or whitespace after a name) is no
-	// longer "inside" the symbol.
 	return col >= r.Start.Column && col < r.End.Column
 }
 
-// isValidCharacterName accepts identifiers a writer could realistically
-// type at a cue position. Names must contain at least one letter and may
-// include letters, digits, spaces, and a small punctuation set commonly
-// used in stage names (apostrophe, hyphen, period). The check stays
-// conservative — false rejections are easier to recover from than a
-// rename that produces an unparseable script.
 func isValidCharacterName(name string) bool {
 	hasLetter := false
 	for _, r := range name {
@@ -457,7 +371,6 @@ func isValidCharacterName(name string) bool {
 		case unicode.IsLetter(r):
 			hasLetter = true
 		case unicode.IsDigit(r), r == ' ', r == '\'', r == '-', r == '.':
-			// permitted
 		default:
 			return false
 		}
@@ -469,15 +382,11 @@ func isValidCharacterName(name string) bool {
 		return false
 	}
 	if strings.Contains(name, " - ") {
-		// Would be parsed as the start of a description.
 		return false
 	}
 	return true
 }
 
-// matchCueCasing keeps the casing convention of the existing cue when
-// generating the replacement. ALL CAPS cues stay ALL CAPS, lowercase
-// stays lowercase, otherwise the user-typed spelling is used as-is.
 func matchCueCasing(existing, replacement string) string {
 	trimmedReplacement := strings.TrimSpace(replacement)
 	if trimmedReplacement == "" {
@@ -523,11 +432,6 @@ func isZeroRange(r token.Range) bool {
 	return r.Start == (token.Position{}) && r.End == (token.Position{})
 }
 
-// subRangeWithinCue maps byte offsets inside the cue's source text to a
-// token.Range anchored relative to the cue's name range. Character cues
-// always sit on a single source line, so only the column needs adjusting.
-// UTF-16 columns are computed for the prefix bytes so the result stays
-// correct for non-ASCII names.
 func subRangeWithinCue(cueRange token.Range, cueText string, startByte, endByte int) token.Range {
 	if startByte < 0 {
 		startByte = 0

--- a/internal/lsp/rename.go
+++ b/internal/lsp/rename.go
@@ -1,0 +1,441 @@
+package lsp
+
+import (
+	"errors"
+	"strings"
+	"unicode"
+
+	"github.com/jscaltreto/downstage/internal/ast"
+	"github.com/jscaltreto/downstage/internal/token"
+	"go.lsp.dev/protocol"
+)
+
+// errRenameInvalid signals that the cursor is not on a renameable symbol,
+// or that the requested new name is not acceptable. The handler converts
+// this into an LSP error response.
+var errRenameInvalid = errors.New("rename: invalid request")
+
+// renameTarget describes the specific spelling the cursor is on. A
+// character may be referenced by its primary name or any of its aliases;
+// each spelling is treated as its own renameable symbol so writers can
+// rename a single alias without rewriting the rest.
+type renameTarget struct {
+	character *ast.Character
+	// oldName is the spelling being renamed (case-preserved as declared
+	// in the dramatis personae).
+	oldName string
+	// upperKey is the case-folded form used to match cues.
+	upperKey string
+	// declRange is the source range of the declaration token (the primary
+	// name entry or the specific alias entry).
+	declRange token.Range
+	// kind tracks whether the declaration is the primary name or an alias.
+	kind renameKind
+	// aliasIndex is the alias position when kind == renameKindAlias.
+	aliasIndex int
+}
+
+type renameKind int
+
+const (
+	renameKindPrimary renameKind = iota
+	renameKindAlias
+)
+
+// computePrepareRename returns the source range of the symbol under the
+// cursor when rename is supported there, or nil otherwise.
+func computePrepareRename(doc *ast.Document, pos protocol.Position) *protocol.Range {
+	if doc == nil {
+		return nil
+	}
+	target := findRenameTarget(doc, pos)
+	if target == nil {
+		return nil
+	}
+	r := toLSPRange(target.declRange)
+	return &r
+}
+
+// computeRename builds a workspace edit that renames every structural
+// reference to the symbol at the cursor. Returns errRenameInvalid when
+// the symbol is not renameable or the new name is not acceptable.
+func computeRename(doc *ast.Document, uri protocol.DocumentURI, pos protocol.Position, newName string) (*protocol.WorkspaceEdit, error) {
+	if doc == nil {
+		return nil, errRenameInvalid
+	}
+	target := findRenameTarget(doc, pos)
+	if target == nil {
+		return nil, errRenameInvalid
+	}
+	cleaned := strings.TrimSpace(newName)
+	if cleaned == "" {
+		return nil, errRenameInvalid
+	}
+	if !isValidCharacterName(cleaned) {
+		return nil, errRenameInvalid
+	}
+	if hasNameConflict(doc, target, cleaned) {
+		return nil, errRenameInvalid
+	}
+
+	edits := []protocol.TextEdit{
+		{Range: toLSPRange(target.declRange), NewText: cleaned},
+	}
+
+	visitDialogues(doc, func(dlg *ast.Dialogue) {
+		cueName := strings.TrimSpace(dlg.Character)
+		if cueName == "" {
+			return
+		}
+		if strings.ToUpper(cueName) != target.upperKey {
+			return
+		}
+		replacement := matchCueCasing(cueName, cleaned)
+		if replacement == cueName {
+			return
+		}
+		edits = append(edits, protocol.TextEdit{
+			Range:   toLSPRange(dlg.NameRange()),
+			NewText: replacement,
+		})
+	})
+
+	return &protocol.WorkspaceEdit{
+		Changes: map[protocol.DocumentURI][]protocol.TextEdit{
+			uri: edits,
+		},
+	}, nil
+}
+
+// findRenameTarget identifies the character spelling under the cursor.
+// Supported positions:
+//   - primary name in a dramatis personae entry
+//   - alias spelling in a dramatis personae entry
+//   - dialogue cue whose spelling matches a known character primary name
+//     or alias (excluding conjunction cues like "BOB AND JANE")
+func findRenameTarget(doc *ast.Document, pos protocol.Position) *renameTarget {
+	if target := findRenameTargetInDP(doc, pos); target != nil {
+		return target
+	}
+	return findRenameTargetInCue(doc, pos)
+}
+
+func findRenameTargetInDP(doc *ast.Document, pos protocol.Position) *renameTarget {
+	for _, node := range doc.Body {
+		section, ok := node.(*ast.Section)
+		if !ok {
+			continue
+		}
+		if target := findRenameTargetInSection(section, pos); target != nil {
+			return target
+		}
+	}
+	return nil
+}
+
+func findRenameTargetInSection(section *ast.Section, pos protocol.Position) *renameTarget {
+	if section.Kind == ast.SectionDramatisPersonae {
+		if target := scanCharactersForPosition(section.Characters, pos); target != nil {
+			return target
+		}
+		for gi := range section.Groups {
+			if target := scanCharactersForPosition(section.Groups[gi].Characters, pos); target != nil {
+				return target
+			}
+		}
+	}
+	for _, child := range section.Children {
+		if cs, ok := child.(*ast.Section); ok {
+			if target := findRenameTargetInSection(cs, pos); target != nil {
+				return target
+			}
+		}
+	}
+	return nil
+}
+
+func scanCharactersForPosition(characters []ast.Character, pos protocol.Position) *renameTarget {
+	for i := range characters {
+		ch := &characters[i]
+		if positionInRange(pos, ch.NameRange()) && strings.TrimSpace(ch.Name) != "" {
+			return &renameTarget{
+				character:  ch,
+				oldName:    ch.Name,
+				upperKey:   strings.ToUpper(strings.TrimSpace(ch.Name)),
+				declRange:  ch.NameRange(),
+				kind:       renameKindPrimary,
+				aliasIndex: -1,
+			}
+		}
+		for ai, alias := range ch.Aliases {
+			r := ch.AliasRange(ai)
+			if isZeroRange(r) {
+				continue
+			}
+			if positionInRange(pos, r) && strings.TrimSpace(alias) != "" {
+				return &renameTarget{
+					character:  ch,
+					oldName:    alias,
+					upperKey:   strings.ToUpper(strings.TrimSpace(alias)),
+					declRange:  r,
+					kind:       renameKindAlias,
+					aliasIndex: ai,
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func findRenameTargetInCue(doc *ast.Document, pos protocol.Position) *renameTarget {
+	cueName, nameRange := findCueAtPosition(doc, pos)
+	if cueName == "" {
+		return nil
+	}
+	// Skip conjunction cues — sub-name boundaries aren't ranged so we
+	// cannot rename a single participant safely. The user can rename
+	// from the dramatis personae entry instead.
+	if splitConjunctionCue(cueName) != nil {
+		return nil
+	}
+
+	dp := scopedDramatisPersonae(doc, int(pos.Line))
+	if dp == nil {
+		return nil
+	}
+	upperCue := strings.ToUpper(strings.TrimSpace(cueName))
+	for _, set := range collectAllCharacters(dp) {
+		ch := set
+		if strings.ToUpper(strings.TrimSpace(ch.Name)) == upperCue {
+			return &renameTarget{
+				character:  ch,
+				oldName:    ch.Name,
+				upperKey:   upperCue,
+				declRange:  nameRange,
+				kind:       renameKindPrimary,
+				aliasIndex: -1,
+			}
+		}
+		for ai, alias := range ch.Aliases {
+			if strings.ToUpper(strings.TrimSpace(alias)) == upperCue {
+				return &renameTarget{
+					character:  ch,
+					oldName:    alias,
+					upperKey:   upperCue,
+					declRange:  nameRange,
+					kind:       renameKindAlias,
+					aliasIndex: ai,
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// collectAllCharacters returns pointers to every character in the section,
+// including those nested in groups, so callers can mutate via the same
+// slice the parser populated.
+func collectAllCharacters(dp *ast.Section) []*ast.Character {
+	var out []*ast.Character
+	for i := range dp.Characters {
+		out = append(out, &dp.Characters[i])
+	}
+	for gi := range dp.Groups {
+		for ci := range dp.Groups[gi].Characters {
+			out = append(out, &dp.Groups[gi].Characters[ci])
+		}
+	}
+	return out
+}
+
+// findCueAtPosition is a sibling of findCharacterAtPosition that also
+// returns the cue's source range, which prepareRename needs.
+func findCueAtPosition(doc *ast.Document, pos protocol.Position) (string, token.Range) {
+	for _, n := range doc.Body {
+		if name, r := findCueInNode(n, pos); name != "" {
+			return name, r
+		}
+	}
+	return "", token.Range{}
+}
+
+func findCueInNode(n ast.Node, pos protocol.Position) (string, token.Range) {
+	line := int(pos.Line)
+	switch v := n.(type) {
+	case *ast.DualDialogue:
+		if name, r := findCueInNode(v.Left, pos); name != "" {
+			return name, r
+		}
+		return findCueInNode(v.Right, pos)
+	case *ast.Dialogue:
+		r := v.NameRange()
+		if r.Start.Line == line && int(pos.Character) >= r.Start.Column && int(pos.Character) < r.End.Column {
+			return v.Character, r
+		}
+	case *ast.Song:
+		for _, child := range v.Content {
+			if name, r := findCueInNode(child, pos); name != "" {
+				return name, r
+			}
+		}
+	case *ast.Section:
+		for _, child := range v.Children {
+			if name, r := findCueInNode(child, pos); name != "" {
+				return name, r
+			}
+		}
+	}
+	return "", token.Range{}
+}
+
+// hasNameConflict returns true when renaming target to newName would
+// collide with another known spelling in the same dramatis personae —
+// e.g. renaming BOB to JANE when JANE already exists, or renaming an
+// alias to a spelling already used by the same entry.
+func hasNameConflict(doc *ast.Document, target *renameTarget, newName string) bool {
+	dp := scopedDramatisPersonae(doc, target.declRange.Start.Line)
+	if dp == nil {
+		return false
+	}
+	upperNew := strings.ToUpper(strings.TrimSpace(newName))
+	if upperNew == target.upperKey {
+		return false
+	}
+	for _, ch := range collectAllCharacters(dp) {
+		nameKey := strings.ToUpper(strings.TrimSpace(ch.Name))
+		if ch == target.character && target.kind == renameKindPrimary {
+			// skip the spelling being renamed
+		} else if nameKey != "" && nameKey == upperNew {
+			return true
+		}
+		for ai, alias := range ch.Aliases {
+			aliasKey := strings.ToUpper(strings.TrimSpace(alias))
+			if ch == target.character && target.kind == renameKindAlias && ai == target.aliasIndex {
+				continue
+			}
+			if aliasKey != "" && aliasKey == upperNew {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// visitDialogues walks every dialogue node in the document, including
+// those nested inside dual dialogues and songs.
+func visitDialogues(doc *ast.Document, fn func(*ast.Dialogue)) {
+	var walk func(node ast.Node)
+	walk = func(node ast.Node) {
+		switch v := node.(type) {
+		case *ast.Dialogue:
+			fn(v)
+		case *ast.DualDialogue:
+			if v.Left != nil {
+				walk(v.Left)
+			}
+			if v.Right != nil {
+				walk(v.Right)
+			}
+		case *ast.Song:
+			for _, child := range v.Content {
+				walk(child)
+			}
+		case *ast.Section:
+			for _, child := range v.Children {
+				walk(child)
+			}
+		}
+	}
+	for _, node := range doc.Body {
+		walk(node)
+	}
+}
+
+func positionInRange(pos protocol.Position, r token.Range) bool {
+	if int(pos.Line) != r.Start.Line || r.Start.Line != r.End.Line {
+		// Character names always sit on a single source line; reject
+		// multi-line or off-line positions outright.
+		return false
+	}
+	col := int(pos.Character)
+	return col >= r.Start.Column && col <= r.End.Column
+}
+
+// isValidCharacterName accepts identifiers a writer could realistically
+// type at a cue position. Names must contain at least one letter and may
+// include letters, digits, spaces, and a small punctuation set commonly
+// used in stage names (apostrophe, hyphen, period). The check stays
+// conservative — false rejections are easier to recover from than a
+// rename that produces an unparseable script.
+func isValidCharacterName(name string) bool {
+	hasLetter := false
+	for _, r := range name {
+		switch {
+		case unicode.IsLetter(r):
+			hasLetter = true
+		case unicode.IsDigit(r), r == ' ', r == '\'', r == '-', r == '.':
+			// permitted
+		default:
+			return false
+		}
+	}
+	if !hasLetter {
+		return false
+	}
+	if strings.Contains(name, "/") {
+		return false
+	}
+	if strings.Contains(name, " - ") {
+		// Would be parsed as the start of a description.
+		return false
+	}
+	return true
+}
+
+// matchCueCasing keeps the casing convention of the existing cue when
+// generating the replacement. ALL CAPS cues stay ALL CAPS, lowercase
+// stays lowercase, otherwise the user-typed spelling is used as-is.
+func matchCueCasing(existing, replacement string) string {
+	trimmedReplacement := strings.TrimSpace(replacement)
+	if trimmedReplacement == "" {
+		return replacement
+	}
+	switch {
+	case isAllUpper(existing):
+		return strings.ToUpper(trimmedReplacement)
+	case isAllLower(existing):
+		return strings.ToLower(trimmedReplacement)
+	default:
+		return trimmedReplacement
+	}
+}
+
+func isAllUpper(s string) bool {
+	hasLetter := false
+	for _, r := range s {
+		if unicode.IsLetter(r) {
+			hasLetter = true
+			if !unicode.IsUpper(r) {
+				return false
+			}
+		}
+	}
+	return hasLetter
+}
+
+func isAllLower(s string) bool {
+	hasLetter := false
+	for _, r := range s {
+		if unicode.IsLetter(r) {
+			hasLetter = true
+			if !unicode.IsLower(r) {
+				return false
+			}
+		}
+	}
+	return hasLetter
+}
+
+func isZeroRange(r token.Range) bool {
+	return r.Start == (token.Position{}) && r.End == (token.Position{})
+}

--- a/internal/lsp/rename.go
+++ b/internal/lsp/rename.go
@@ -82,7 +82,15 @@ func computeRename(doc *ast.Document, uri protocol.DocumentURI, pos protocol.Pos
 		{Range: toLSPRange(target.declRange), NewText: cleaned},
 	}
 
-	visitDialogues(doc, func(dlg *ast.Dialogue) {
+	// Restrict cue updates to the play that owns the target's DP scope.
+	// In a compilation document each top-level play has its own dramatis
+	// personae, so a "BOB" in Play A is a different character than
+	// "BOB" in Play B. Walking the whole document would rewrite cues
+	// belonging to other plays. When the document uses the legacy
+	// document-wide DP (no top-level section owns one), play is nil and
+	// we fall back to a doc-wide walk.
+	scope := renameScope(doc, target.declRange.Start.Line)
+	visitDialoguesInScope(doc, scope, func(dlg *ast.Dialogue) {
 		cueName := strings.TrimSpace(dlg.Character)
 		if cueName == "" {
 			return
@@ -321,9 +329,20 @@ func hasNameConflict(doc *ast.Document, target *renameTarget, newName string) bo
 	return false
 }
 
-// visitDialogues walks every dialogue node in the document, including
-// those nested inside dual dialogues and songs.
-func visitDialogues(doc *ast.Document, fn func(*ast.Dialogue)) {
+// renameScope returns the top-level play section that owns the DP
+// resolving the rename target. Returns nil when the document uses a
+// document-wide DP (legacy / single-play layout), signalling a doc-wide
+// walk is correct.
+func renameScope(doc *ast.Document, line int) *ast.Section {
+	if !hasScopedDramatisPersonae(doc) {
+		return nil
+	}
+	return topLevelSectionForLine(doc, line)
+}
+
+// visitDialoguesInScope walks every dialogue node within the given play
+// section. When play is nil, it walks the entire document.
+func visitDialoguesInScope(doc *ast.Document, play *ast.Section, fn func(*ast.Dialogue)) {
 	var walk func(node ast.Node)
 	walk = func(node ast.Node) {
 		switch v := node.(type) {
@@ -345,6 +364,11 @@ func visitDialogues(doc *ast.Document, fn func(*ast.Dialogue)) {
 				walk(child)
 			}
 		}
+	}
+
+	if play != nil {
+		walk(play)
+		return
 	}
 	for _, node := range doc.Body {
 		walk(node)

--- a/internal/lsp/rename.go
+++ b/internal/lsp/rename.go
@@ -26,13 +26,32 @@ type renameTarget struct {
 	oldName string
 	// upperKey is the case-folded form used to match cues.
 	upperKey string
-	// declRange is the source range of the declaration token (the primary
-	// name entry or the specific alias entry).
-	declRange token.Range
+	// cursorRange is the range under the cursor — used by prepareRename
+	// to highlight the symbol. It is the dramatis personae entry when
+	// the cursor is on a declaration, or the cue range when the cursor
+	// is on a dialogue cue.
+	cursorRange token.Range
 	// kind tracks whether the declaration is the primary name or an alias.
 	kind renameKind
 	// aliasIndex is the alias position when kind == renameKindAlias.
 	aliasIndex int
+}
+
+// declRange returns the canonical declaration range for the target —
+// always the dramatis personae entry (primary name or alias), never a
+// cue. The cue walk in computeRename relies on this so the declaration
+// edit does not overlap with the cue edit when rename is triggered
+// from a cue.
+func (t *renameTarget) declRange() token.Range {
+	if t.character == nil {
+		return token.Range{}
+	}
+	switch t.kind {
+	case renameKindAlias:
+		return t.character.AliasRange(t.aliasIndex)
+	default:
+		return t.character.NameRange()
+	}
 }
 
 type renameKind int
@@ -52,7 +71,7 @@ func computePrepareRename(doc *ast.Document, pos protocol.Position) *protocol.Ra
 	if target == nil {
 		return nil
 	}
-	r := toLSPRange(target.declRange)
+	r := toLSPRange(target.cursorRange)
 	return &r
 }
 
@@ -78,8 +97,12 @@ func computeRename(doc *ast.Document, uri protocol.DocumentURI, pos protocol.Pos
 		return nil, errRenameInvalid
 	}
 
+	declRange := target.declRange()
+	if isZeroRange(declRange) {
+		return nil, errRenameInvalid
+	}
 	edits := []protocol.TextEdit{
-		{Range: toLSPRange(target.declRange), NewText: cleaned},
+		{Range: toLSPRange(declRange), NewText: cleaned},
 	}
 
 	// Restrict cue updates to the play that owns the target's DP scope.
@@ -89,7 +112,7 @@ func computeRename(doc *ast.Document, uri protocol.DocumentURI, pos protocol.Pos
 	// belonging to other plays. When the document uses the legacy
 	// document-wide DP (no top-level section owns one), play is nil and
 	// we fall back to a doc-wide walk.
-	scope := renameScope(doc, target.declRange.Start.Line)
+	scope := renameScope(doc, declRange.Start.Line)
 	visitDialoguesInScope(doc, scope, func(dlg *ast.Dialogue) {
 		cueName := strings.TrimSpace(dlg.Character)
 		if cueName == "" {
@@ -167,12 +190,12 @@ func scanCharactersForPosition(characters []ast.Character, pos protocol.Position
 		ch := &characters[i]
 		if positionInRange(pos, ch.NameRange()) && strings.TrimSpace(ch.Name) != "" {
 			return &renameTarget{
-				character:  ch,
-				oldName:    ch.Name,
-				upperKey:   strings.ToUpper(strings.TrimSpace(ch.Name)),
-				declRange:  ch.NameRange(),
-				kind:       renameKindPrimary,
-				aliasIndex: -1,
+				character:   ch,
+				oldName:     ch.Name,
+				upperKey:    strings.ToUpper(strings.TrimSpace(ch.Name)),
+				cursorRange: ch.NameRange(),
+				kind:        renameKindPrimary,
+				aliasIndex:  -1,
 			}
 		}
 		for ai, alias := range ch.Aliases {
@@ -182,12 +205,12 @@ func scanCharactersForPosition(characters []ast.Character, pos protocol.Position
 			}
 			if positionInRange(pos, r) && strings.TrimSpace(alias) != "" {
 				return &renameTarget{
-					character:  ch,
-					oldName:    alias,
-					upperKey:   strings.ToUpper(strings.TrimSpace(alias)),
-					declRange:  r,
-					kind:       renameKindAlias,
-					aliasIndex: ai,
+					character:   ch,
+					oldName:     alias,
+					upperKey:    strings.ToUpper(strings.TrimSpace(alias)),
+					cursorRange: r,
+					kind:        renameKindAlias,
+					aliasIndex:  ai,
 				}
 			}
 		}
@@ -196,7 +219,7 @@ func scanCharactersForPosition(characters []ast.Character, pos protocol.Position
 }
 
 func findRenameTargetInCue(doc *ast.Document, pos protocol.Position) *renameTarget {
-	cueName, nameRange := findCueAtPosition(doc, pos)
+	cueName, cueRange := findCueAtPosition(doc, pos)
 	if cueName == "" {
 		return nil
 	}
@@ -212,27 +235,26 @@ func findRenameTargetInCue(doc *ast.Document, pos protocol.Position) *renameTarg
 		return nil
 	}
 	upperCue := strings.ToUpper(strings.TrimSpace(cueName))
-	for _, set := range collectAllCharacters(dp) {
-		ch := set
+	for _, ch := range collectAllCharacters(dp) {
 		if strings.ToUpper(strings.TrimSpace(ch.Name)) == upperCue {
 			return &renameTarget{
-				character:  ch,
-				oldName:    ch.Name,
-				upperKey:   upperCue,
-				declRange:  nameRange,
-				kind:       renameKindPrimary,
-				aliasIndex: -1,
+				character:   ch,
+				oldName:     ch.Name,
+				upperKey:    upperCue,
+				cursorRange: cueRange,
+				kind:        renameKindPrimary,
+				aliasIndex:  -1,
 			}
 		}
 		for ai, alias := range ch.Aliases {
 			if strings.ToUpper(strings.TrimSpace(alias)) == upperCue {
 				return &renameTarget{
-					character:  ch,
-					oldName:    alias,
-					upperKey:   upperCue,
-					declRange:  nameRange,
-					kind:       renameKindAlias,
-					aliasIndex: ai,
+					character:   ch,
+					oldName:     alias,
+					upperKey:    upperCue,
+					cursorRange: cueRange,
+					kind:        renameKindAlias,
+					aliasIndex:  ai,
 				}
 			}
 		}
@@ -301,7 +323,7 @@ func findCueInNode(n ast.Node, pos protocol.Position) (string, token.Range) {
 // e.g. renaming BOB to JANE when JANE already exists, or renaming an
 // alias to a spelling already used by the same entry.
 func hasNameConflict(doc *ast.Document, target *renameTarget, newName string) bool {
-	dp := scopedDramatisPersonae(doc, target.declRange.Start.Line)
+	dp := scopedDramatisPersonae(doc, target.cursorRange.Start.Line)
 	if dp == nil {
 		return false
 	}

--- a/internal/lsp/rename.go
+++ b/internal/lsp/rename.go
@@ -112,7 +112,10 @@ func computeRename(doc *ast.Document, uri protocol.DocumentURI, pos protocol.Pos
 	// belonging to other plays. When the document uses the legacy
 	// document-wide DP (no top-level section owns one), play is nil and
 	// we fall back to a doc-wide walk.
-	scope := renameScope(doc, declRange.Start.Line)
+	scope, ok := renameScope(doc, declRange.Start.Line)
+	if !ok {
+		return nil, errRenameInvalid
+	}
 	visitDialoguesInScope(doc, scope, func(dlg *ast.Dialogue) {
 		cueName := strings.TrimSpace(dlg.Character)
 		if cueName == "" {
@@ -372,15 +375,25 @@ func hasNameConflict(doc *ast.Document, target *renameTarget, newName string) bo
 	return false
 }
 
-// renameScope returns the top-level play section that owns the DP
-// resolving the rename target. Returns nil when the document uses a
-// document-wide DP (legacy / single-play layout), signalling a doc-wide
-// walk is correct.
-func renameScope(doc *ast.Document, line int) *ast.Section {
-	if !hasScopedDramatisPersonae(doc) {
-		return nil
+// renameScope returns the top-level play section whose dramatis
+// personae owns the rename target. The boolean is false when the
+// rename has no defined scope and must be refused — that happens when
+// the document mixes a legacy doc-level DP with one or more scoped
+// plays, and the cursor lands on the now-ignored legacy DP. A nil
+// section paired with a true result means the document is a pure
+// legacy layout (no scoped DPs anywhere), so a doc-wide walk is
+// correct.
+func renameScope(doc *ast.Document, line int) (*ast.Section, bool) {
+	if play := topLevelSectionForLine(doc, line); play != nil {
+		return play, true
 	}
-	return topLevelSectionForLine(doc, line)
+	if hasScopedDramatisPersonae(doc) {
+		// Mixed layout: legacy DP entries are intentionally disregarded
+		// by the rest of the LSP. Refuse rather than silently widening
+		// the rewrite across every scoped play.
+		return nil, false
+	}
+	return nil, true
 }
 
 // visitDialoguesInScope walks every dialogue node within the given play
@@ -425,7 +438,10 @@ func positionInRange(pos protocol.Position, r token.Range) bool {
 		return false
 	}
 	col := int(pos.Character)
-	return col >= r.Start.Column && col <= r.End.Column
+	// End-exclusive to match the cue-position check. A cursor on the
+	// slash that follows an alias (or whitespace after a name) is no
+	// longer "inside" the symbol.
+	return col >= r.Start.Column && col < r.End.Column
 }
 
 // isValidCharacterName accepts identifiers a writer could realistically

--- a/internal/lsp/rename.go
+++ b/internal/lsp/rename.go
@@ -118,17 +118,38 @@ func computeRename(doc *ast.Document, uri protocol.DocumentURI, pos protocol.Pos
 		if cueName == "" {
 			return
 		}
-		if strings.ToUpper(cueName) != target.upperKey {
+		nameRange := dlg.NameRange()
+
+		// Single-name cue: replace the whole cue when it matches.
+		if strings.ToUpper(cueName) == target.upperKey {
+			replacement := matchCueCasing(cueName, cleaned)
+			if replacement != cueName {
+				edits = append(edits, protocol.TextEdit{
+					Range:   toLSPRange(nameRange),
+					NewText: replacement,
+				})
+			}
 			return
 		}
-		replacement := matchCueCasing(cueName, cleaned)
-		if replacement == cueName {
-			return
+
+		// Conjunction cue ("JAKE AND BOB"): rewrite each participant
+		// that matches the renamed spelling. Each participant has a
+		// known byte span inside the cue text, so we can build a
+		// precise range without disturbing the rest of the cue.
+		parts := splitConjunctionCueWithOffsets(dlg.Character)
+		for _, part := range parts {
+			if strings.ToUpper(part.Name) != target.upperKey {
+				continue
+			}
+			replacement := matchCueCasing(part.Name, cleaned)
+			if replacement == part.Name {
+				continue
+			}
+			edits = append(edits, protocol.TextEdit{
+				Range:   toLSPRange(subRangeWithinCue(nameRange, dlg.Character, part.Start, part.End)),
+				NewText: replacement,
+			})
 		}
-		edits = append(edits, protocol.TextEdit{
-			Range:   toLSPRange(dlg.NameRange()),
-			NewText: replacement,
-		})
 	})
 
 	return &protocol.WorkspaceEdit{
@@ -484,4 +505,32 @@ func isAllLower(s string) bool {
 
 func isZeroRange(r token.Range) bool {
 	return r.Start == (token.Position{}) && r.End == (token.Position{})
+}
+
+// subRangeWithinCue maps byte offsets inside the cue's source text to a
+// token.Range anchored relative to the cue's name range. Character cues
+// always sit on a single source line, so only the column needs adjusting.
+// UTF-16 columns are computed for the prefix bytes so the result stays
+// correct for non-ASCII names.
+func subRangeWithinCue(cueRange token.Range, cueText string, startByte, endByte int) token.Range {
+	if startByte < 0 {
+		startByte = 0
+	}
+	if endByte > len(cueText) {
+		endByte = len(cueText)
+	}
+	startUTF16 := token.UTF16Len(cueText[:startByte])
+	endUTF16 := token.UTF16Len(cueText[:endByte])
+	return token.Range{
+		Start: token.Position{
+			Line:   cueRange.Start.Line,
+			Column: cueRange.Start.Column + startUTF16,
+			Offset: cueRange.Start.Offset + startByte,
+		},
+		End: token.Position{
+			Line:   cueRange.Start.Line,
+			Column: cueRange.Start.Column + endUTF16,
+			Offset: cueRange.Start.Offset + endByte,
+		},
+	}
 }

--- a/internal/lsp/rename_test.go
+++ b/internal/lsp/rename_test.go
@@ -267,9 +267,50 @@ Hi.
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got, want := len(edit.Changes[renameURI]), 2; got != want {
-		t.Fatalf("expected %d edits from cue trigger, got %d", want, got)
+	edits := edit.Changes[renameURI]
+	if got, want := len(edits), 2; got != want {
+		t.Fatalf("expected %d edits from cue trigger, got %d: %+v", want, got, edits)
 	}
+
+	// The edit set must include the DP entry and the cue, with no
+	// overlapping ranges. VS Code rejects overlapping workspace edits
+	// with "Rename failed to apply edits".
+	assertNoOverlappingEdits(t, edits)
+	lines := map[uint32]bool{}
+	for _, e := range edits {
+		lines[e.Range.Start.Line] = true
+	}
+	if !lines[4] {
+		t.Errorf("expected DP entry at line 4 to be edited, got edits on lines %v", lines)
+	}
+	if !lines[10] {
+		t.Errorf("expected cue at line 10 to be edited, got edits on lines %v", lines)
+	}
+}
+
+// assertNoOverlappingEdits fails the test when any two edits target
+// ranges that overlap. VS Code requires non-overlapping edits in a
+// workspace edit; overlapping edits surface as "Rename failed to apply
+// edits" to the user with no LSP-side log.
+func assertNoOverlappingEdits(t *testing.T, edits []protocol.TextEdit) {
+	t.Helper()
+	for i := 0; i < len(edits); i++ {
+		for j := i + 1; j < len(edits); j++ {
+			if rangesOverlap(edits[i].Range, edits[j].Range) {
+				t.Fatalf("overlapping edits: %+v and %+v", edits[i], edits[j])
+			}
+		}
+	}
+}
+
+func rangesOverlap(a, b protocol.Range) bool {
+	if a.End.Line < b.Start.Line || (a.End.Line == b.Start.Line && a.End.Character <= b.Start.Character) {
+		return false
+	}
+	if b.End.Line < a.Start.Line || (b.End.Line == a.Start.Line && b.End.Character <= a.Start.Character) {
+		return false
+	}
+	return true
 }
 
 func TestComputeRename_RejectsConflictWithExistingName(t *testing.T) {

--- a/internal/lsp/rename_test.go
+++ b/internal/lsp/rename_test.go
@@ -1,0 +1,469 @@
+package lsp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/parser"
+	"go.lsp.dev/protocol"
+)
+
+const renameURI protocol.DocumentURI = "file:///rename.ds"
+
+func TestPrepareRename_OnDramatisPersonaePrimaryName(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+BOB - The good guy
+JANE
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hello.
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	r := computePrepareRename(doc, protocol.Position{Line: 4, Character: 1})
+	if r == nil {
+		t.Fatal("expected rename range on DP primary name")
+	}
+	if r.Start.Line != 4 || r.Start.Character != 0 || r.End.Character != 3 {
+		t.Errorf("unexpected range %+v", r)
+	}
+}
+
+func TestPrepareRename_OnAliasDeclaration(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+BOB/B - The good guy
+
+## ACT I
+
+### SCENE 1
+
+B
+Hello.
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	r := computePrepareRename(doc, protocol.Position{Line: 4, Character: 4})
+	if r == nil {
+		t.Fatal("expected rename range on alias")
+	}
+	if r.Start.Character != 4 || r.End.Character != 5 {
+		t.Errorf("unexpected alias range %+v", r)
+	}
+}
+
+func TestPrepareRename_OnDialogueCue(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+BOB
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hello.
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	r := computePrepareRename(doc, protocol.Position{Line: 10, Character: 1})
+	if r == nil {
+		t.Fatal("expected rename range on cue")
+	}
+	if r.Start.Line != 10 || r.Start.Character != 0 || r.End.Character != 3 {
+		t.Errorf("unexpected cue range %+v", r)
+	}
+}
+
+func TestPrepareRename_RefusesOnDialogueBody(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+BOB
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hello.
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	r := computePrepareRename(doc, protocol.Position{Line: 11, Character: 1})
+	if r != nil {
+		t.Errorf("expected no rename on dialogue body, got %+v", r)
+	}
+}
+
+func TestPrepareRename_RefusesOnConjunctionCue(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+BOB
+JANE
+
+## ACT I
+
+### SCENE 1
+
+BOB AND JANE
+Hello.
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	r := computePrepareRename(doc, protocol.Position{Line: 11, Character: 1})
+	if r != nil {
+		t.Errorf("expected no rename on conjunction cue, got %+v", r)
+	}
+}
+
+func TestPrepareRename_RefusesOnPlainProse(t *testing.T) {
+	src := `# Notes
+
+Just some prose mentioning BOB.
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	r := computePrepareRename(doc, protocol.Position{Line: 2, Character: 28})
+	if r != nil {
+		t.Errorf("expected no rename on prose, got %+v", r)
+	}
+}
+
+func TestComputeRename_UpdatesDeclarationAndCues(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+BOB - The good guy
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hello.
+
+BOB
+Again.
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	edit, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, "ROBERT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if edit == nil {
+		t.Fatal("expected workspace edit")
+	}
+	edits := edit.Changes[renameURI]
+	if got, want := len(edits), 3; got != want {
+		t.Fatalf("expected %d edits (1 decl + 2 cues), got %d: %+v", want, got, edits)
+	}
+	for _, e := range edits {
+		if e.NewText != "ROBERT" {
+			t.Errorf("expected NewText ROBERT, got %q", e.NewText)
+		}
+	}
+}
+
+func TestComputeRename_PreservesAliasWhenRenamingPrimary(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+BOB/B - The good guy
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hi.
+
+B
+Yo.
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	edit, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, "ROBERT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	edits := edit.Changes[renameURI]
+	// Expect: BOB declaration + the BOB cue. The B alias and B cue stay put.
+	if got, want := len(edits), 2; got != want {
+		t.Fatalf("expected %d edits, got %d: %+v", want, got, edits)
+	}
+	for _, e := range edits {
+		if !strings.EqualFold(e.NewText, "ROBERT") {
+			t.Errorf("expected NewText ROBERT, got %q", e.NewText)
+		}
+	}
+}
+
+func TestComputeRename_AliasOnly(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+BOB/B - The good guy
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hi.
+
+B
+Yo.
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	// Cursor on the alias B in the DP entry (column 4).
+	edit, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 4}, "BOBBY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	edits := edit.Changes[renameURI]
+	// Expect: alias declaration + the B cue; BOB cue and BOB primary untouched.
+	if got, want := len(edits), 2; got != want {
+		t.Fatalf("expected %d edits, got %d: %+v", want, got, edits)
+	}
+}
+
+func TestComputeRename_CuePosition(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+BOB
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hi.
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	edit, err := computeRename(doc, renameURI, protocol.Position{Line: 10, Character: 1}, "ROBERT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := len(edit.Changes[renameURI]), 2; got != want {
+		t.Fatalf("expected %d edits from cue trigger, got %d", want, got)
+	}
+}
+
+func TestComputeRename_RejectsConflictWithExistingName(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+BOB
+JANE
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hi.
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	_, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, "JANE")
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+}
+
+func TestComputeRename_RejectsConflictWithAlias(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+BOB/B
+JANE
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hi.
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	_, err := computeRename(doc, renameURI, protocol.Position{Line: 5, Character: 1}, "B")
+	if err == nil {
+		t.Fatal("expected conflict error against existing alias")
+	}
+}
+
+func TestComputeRename_RejectsInvalidName(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+BOB
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hi.
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	cases := map[string]string{
+		"empty":           "",
+		"slash":           "BOB/X",
+		"description sep": "BOB - X",
+		"punctuation":     "BOB!",
+		"digits only":     "1234",
+	}
+	for name, newName := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, newName)
+			if err == nil {
+				t.Fatalf("expected error for %q", newName)
+			}
+		})
+	}
+}
+
+func TestComputeRename_PreservesCueCasing(t *testing.T) {
+	// The forced cue prefix lets writers cue characters in non-canonical
+	// case. Rename should preserve each cue's existing case style.
+	src := `# Play
+
+## Dramatis Personae
+
+BOB
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hi.
+
+@Bob
+Hi too.
+`
+	doc, errs := parser.Parse([]byte(src))
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+
+	edit, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, "Robert")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	edits := edit.Changes[renameURI]
+	gotTexts := make(map[string]int)
+	for _, e := range edits {
+		gotTexts[e.NewText]++
+	}
+	if gotTexts["ROBERT"] < 1 {
+		t.Errorf("expected ALL-CAPS cue to stay ALL CAPS, got %+v", gotTexts)
+	}
+	if gotTexts["Robert"] < 1 {
+		t.Errorf("expected mixed-case cue to keep typed case, got %+v", gotTexts)
+	}
+}
+
+func TestComputeRename_DualDialogue(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+BOB
+JANE
+
+## ACT I
+
+### SCENE 1
+
+BOB ^
+Hi.
+
+JANE
+Hello.
+`
+	doc, errs := parser.Parse([]byte(src))
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+
+	edit, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, "ROBERT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := len(edit.Changes[renameURI]), 2; got != want {
+		t.Fatalf("expected %d edits across DP + dual cue, got %d: %+v", want, got, edit.Changes[renameURI])
+	}
+}
+
+func TestComputeRename_SongDialogue(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+BOB
+
+## ACT I
+
+### SCENE 1
+
+SONG: Opening
+
+BOB
+Sing it.
+
+SONG END
+`
+	doc, errs := parser.Parse([]byte(src))
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+
+	edit, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, "ROBERT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := len(edit.Changes[renameURI]), 2; got != want {
+		t.Fatalf("expected %d edits across DP + song cue, got %d: %+v", want, got, edit.Changes[renameURI])
+	}
+}
+
+func TestPrepareRename_NilDoc(t *testing.T) {
+	if r := computePrepareRename(nil, protocol.Position{}); r != nil {
+		t.Errorf("expected nil for nil doc, got %+v", r)
+	}
+}
+
+func TestComputeRename_NilDoc(t *testing.T) {
+	if _, err := computeRename(nil, renameURI, protocol.Position{}, "X"); err == nil {
+		t.Error("expected error for nil doc")
+	}
+}

--- a/internal/lsp/rename_test.go
+++ b/internal/lsp/rename_test.go
@@ -205,7 +205,6 @@ Yo.
 		t.Fatalf("unexpected error: %v", err)
 	}
 	edits := edit.Changes[renameURI]
-	// Expect: BOB declaration + the BOB cue. The B alias and B cue stay put.
 	if got, want := len(edits), 2; got != want {
 		t.Fatalf("expected %d edits, got %d: %+v", want, got, edits)
 	}
@@ -235,13 +234,11 @@ Yo.
 `
 	doc, _ := parser.Parse([]byte(src))
 
-	// Cursor on the alias B in the DP entry (column 4).
 	edit, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 4}, "BOBBY")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	edits := edit.Changes[renameURI]
-	// Expect: alias declaration + the B cue; BOB cue and BOB primary untouched.
 	if got, want := len(edits), 2; got != want {
 		t.Fatalf("expected %d edits, got %d: %+v", want, got, edits)
 	}
@@ -272,9 +269,6 @@ Hi.
 		t.Fatalf("expected %d edits from cue trigger, got %d: %+v", want, got, edits)
 	}
 
-	// The edit set must include the DP entry and the cue, with no
-	// overlapping ranges. VS Code rejects overlapping workspace edits
-	// with "Rename failed to apply edits".
 	assertNoOverlappingEdits(t, edits)
 	lines := map[uint32]bool{}
 	for _, e := range edits {
@@ -288,10 +282,6 @@ Hi.
 	}
 }
 
-// assertNoOverlappingEdits fails the test when any two edits target
-// ranges that overlap. VS Code requires non-overlapping edits in a
-// workspace edit; overlapping edits surface as "Rename failed to apply
-// edits" to the user with no LSP-side log.
 func assertNoOverlappingEdits(t *testing.T, edits []protocol.TextEdit) {
 	t.Helper()
 	for i := 0; i < len(edits); i++ {
@@ -375,26 +365,27 @@ Hi.
 `
 	doc, _ := parser.Parse([]byte(src))
 
-	cases := map[string]string{
-		"empty":           "",
-		"slash":           "BOB/X",
-		"description sep": "BOB - X",
-		"punctuation":     "BOB!",
-		"digits only":     "1234",
+	cases := []struct {
+		name    string
+		newName string
+	}{
+		{name: "empty", newName: ""},
+		{name: "slash", newName: "BOB/X"},
+		{name: "description sep", newName: "BOB - X"},
+		{name: "punctuation", newName: "BOB!"},
+		{name: "digits only", newName: "1234"},
 	}
-	for name, newName := range cases {
-		t.Run(name, func(t *testing.T) {
-			_, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, newName)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, tc.newName)
 			if err == nil {
-				t.Fatalf("expected error for %q", newName)
+				t.Fatalf("expected error for %q", tc.newName)
 			}
 		})
 	}
 }
 
 func TestComputeRename_PreservesCueCasing(t *testing.T) {
-	// The forced cue prefix lets writers cue characters in non-canonical
-	// case. Rename should preserve each cue's existing case style.
 	src := `# Play
 
 ## Dramatis Personae
@@ -466,9 +457,6 @@ Solo.
 	edits := edit.Changes[renameURI]
 	assertNoOverlappingEdits(t, edits)
 
-	// Expect: DP entry, the "JAKE" sub-name in "JAKE AND BOB", the
-	// "JAKE" sub-name in "BOB AND JAKE", and the solo "JAKE" cue. The
-	// BOB sub-names stay put.
 	if got, want := len(edits), 4; got != want {
 		t.Fatalf("expected %d edits, got %d: %+v", want, got, edits)
 	}
@@ -478,8 +466,6 @@ Solo.
 		}
 	}
 
-	// The two sub-name edits must hit the JAKE positions inside their
-	// respective cues, not the whole cue.
 	for _, e := range edits {
 		if e.Range.Start.Line != 11 && e.Range.Start.Line != 14 {
 			continue
@@ -491,8 +477,6 @@ Solo.
 }
 
 func TestComputeRename_ConjunctionCueLeavesUnaffectedParticipantsAlone(t *testing.T) {
-	// Renaming JAKE in a "JAKE AND BOB" cue must not alter "BOB" or
-	// the surrounding " AND " separator.
 	src := `# Play
 
 ## Dramatis Personae
@@ -521,7 +505,6 @@ Hi.
 		if e.Range.Start.Line != 11 {
 			continue
 		}
-		// The cue starts at column 0; "JAKE" is columns 0..4.
 		if e.Range.Start.Character != 0 || e.Range.End.Character != 4 {
 			t.Errorf("expected JAKE-only edit on conjunction cue, got %+v", e.Range)
 		}
@@ -593,8 +576,6 @@ SONG END
 }
 
 func TestComputeRename_CompilationScopesToOwningPlay(t *testing.T) {
-	// Each play in a compilation has its own dramatis personae. Renaming
-	// BOB in Play A must not rewrite the (different) BOB in Play B.
 	src := `# Play A
 
 ## Dramatis Personae
@@ -626,13 +607,11 @@ Hello from B.
 		t.Fatalf("parse errors: %v", errs)
 	}
 
-	// Cursor on Play A's DP entry.
 	edit, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, "ROBERT")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	edits := edit.Changes[renameURI]
-	// Expect: Play A DP entry + Play A cue. Play B's DP entry and cue stay put.
 	if got, want := len(edits), 2; got != want {
 		t.Fatalf("expected %d edits scoped to Play A, got %d: %+v", want, got, edits)
 	}
@@ -644,8 +623,6 @@ Hello from B.
 }
 
 func TestComputeRename_CompilationCueScopesToOwningPlay(t *testing.T) {
-	// Triggering rename from a cue should also stay within that cue's
-	// owning play.
 	src := `# Play A
 
 ## Dramatis Personae
@@ -677,7 +654,6 @@ Hello from B.
 		t.Fatalf("parse errors: %v", errs)
 	}
 
-	// Cursor on Play B's cue (line 23).
 	edit, err := computeRename(doc, renameURI, protocol.Position{Line: 23, Character: 1}, "ROBERT")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -694,8 +670,6 @@ Hello from B.
 }
 
 func TestComputeRename_CompilationConflictScopedToPlay(t *testing.T) {
-	// A name that exists in another play should NOT be flagged as a
-	// conflict; each play's DP scope is independent.
 	src := `# Play A
 
 ## Dramatis Personae
@@ -727,16 +701,12 @@ Hi.
 		t.Fatalf("parse errors: %v", errs)
 	}
 
-	// Renaming Play A's BOB → JANE is fine because Play A has no JANE.
 	if _, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, "JANE"); err != nil {
 		t.Fatalf("expected rename to succeed across plays, got %v", err)
 	}
 }
 
 func TestPrepareRename_RefusesOnSlashAfterPrimaryName(t *testing.T) {
-	// "BOB/B" — column 3 sits on the slash, which is the byte
-	// immediately after the primary name. End-inclusive bounds would
-	// incorrectly fire here.
 	src := `# Play
 
 ## Dramatis Personae
@@ -748,14 +718,12 @@ BOB/B - The good guy
 	if r := computePrepareRename(doc, protocol.Position{Line: 4, Character: 3}); r != nil {
 		t.Errorf("expected refusal on the slash after BOB, got %+v", r)
 	}
-	// Sanity: the column right before the slash is still on the name.
 	if r := computePrepareRename(doc, protocol.Position{Line: 4, Character: 2}); r == nil {
 		t.Error("expected rename on the last char of BOB")
 	}
 }
 
 func TestPrepareRename_RefusesOnWhitespaceAfterAlias(t *testing.T) {
-	// "BOB/B - desc" — column 5 is the space right after the alias B.
 	src := `# Play
 
 ## Dramatis Personae
@@ -770,10 +738,6 @@ BOB/B - desc
 }
 
 func TestComputeRename_MixedLayoutRefusesLegacyDPTrigger(t *testing.T) {
-	// A document with both a doc-level legacy DP and one or more
-	// scoped plays. The rest of the LSP intentionally ignores the
-	// legacy DP in this layout, so we must refuse rename triggered on
-	// it rather than silently rewriting cues across the scoped plays.
 	src := `## Dramatis Personae
 
 BOB
@@ -796,7 +760,6 @@ Hello from A.
 		t.Fatalf("parse errors: %v", errs)
 	}
 
-	// Cursor on the legacy doc-level DP entry (line 2).
 	if _, err := computeRename(doc, renameURI, protocol.Position{Line: 2, Character: 1}, "ROBERT"); err == nil {
 		t.Fatal("expected rename to be refused on legacy DP entry in mixed layout")
 	}

--- a/internal/lsp/rename_test.go
+++ b/internal/lsp/rename_test.go
@@ -433,6 +433,101 @@ Hi too.
 	}
 }
 
+func TestComputeRename_RewritesConjunctionCueParticipants(t *testing.T) {
+	src := `# Play
+
+## Dramatis Personae
+
+JAKE
+BOB
+
+## ACT I
+
+### SCENE 1
+
+JAKE AND BOB
+Hi.
+
+BOB AND JAKE
+Hello.
+
+JAKE
+Solo.
+`
+	doc, errs := parser.Parse([]byte(src))
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+
+	edit, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, "JAKOB")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	edits := edit.Changes[renameURI]
+	assertNoOverlappingEdits(t, edits)
+
+	// Expect: DP entry, the "JAKE" sub-name in "JAKE AND BOB", the
+	// "JAKE" sub-name in "BOB AND JAKE", and the solo "JAKE" cue. The
+	// BOB sub-names stay put.
+	if got, want := len(edits), 4; got != want {
+		t.Fatalf("expected %d edits, got %d: %+v", want, got, edits)
+	}
+	for _, e := range edits {
+		if e.NewText != "JAKOB" {
+			t.Errorf("expected NewText JAKOB, got %q", e.NewText)
+		}
+	}
+
+	// The two sub-name edits must hit the JAKE positions inside their
+	// respective cues, not the whole cue.
+	for _, e := range edits {
+		if e.Range.Start.Line != 11 && e.Range.Start.Line != 14 {
+			continue
+		}
+		if w := e.Range.End.Character - e.Range.Start.Character; w != 4 {
+			t.Errorf("expected sub-name edit width 4 (len(\"JAKE\")), got %d on line %d", w, e.Range.Start.Line)
+		}
+	}
+}
+
+func TestComputeRename_ConjunctionCueLeavesUnaffectedParticipantsAlone(t *testing.T) {
+	// Renaming JAKE in a "JAKE AND BOB" cue must not alter "BOB" or
+	// the surrounding " AND " separator.
+	src := `# Play
+
+## Dramatis Personae
+
+JAKE
+BOB
+
+## ACT I
+
+### SCENE 1
+
+JAKE AND BOB
+Hi.
+`
+	doc, errs := parser.Parse([]byte(src))
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+
+	edit, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, "JAKOB")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	edits := edit.Changes[renameURI]
+	for _, e := range edits {
+		if e.Range.Start.Line != 11 {
+			continue
+		}
+		// The cue starts at column 0; "JAKE" is columns 0..4.
+		if e.Range.Start.Character != 0 || e.Range.End.Character != 4 {
+			t.Errorf("expected JAKE-only edit on conjunction cue, got %+v", e.Range)
+		}
+	}
+}
+
 func TestComputeRename_DualDialogue(t *testing.T) {
 	src := `# Play
 

--- a/internal/lsp/rename_test.go
+++ b/internal/lsp/rename_test.go
@@ -733,6 +733,75 @@ Hi.
 	}
 }
 
+func TestPrepareRename_RefusesOnSlashAfterPrimaryName(t *testing.T) {
+	// "BOB/B" — column 3 sits on the slash, which is the byte
+	// immediately after the primary name. End-inclusive bounds would
+	// incorrectly fire here.
+	src := `# Play
+
+## Dramatis Personae
+
+BOB/B - The good guy
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	if r := computePrepareRename(doc, protocol.Position{Line: 4, Character: 3}); r != nil {
+		t.Errorf("expected refusal on the slash after BOB, got %+v", r)
+	}
+	// Sanity: the column right before the slash is still on the name.
+	if r := computePrepareRename(doc, protocol.Position{Line: 4, Character: 2}); r == nil {
+		t.Error("expected rename on the last char of BOB")
+	}
+}
+
+func TestPrepareRename_RefusesOnWhitespaceAfterAlias(t *testing.T) {
+	// "BOB/B - desc" — column 5 is the space right after the alias B.
+	src := `# Play
+
+## Dramatis Personae
+
+BOB/B - desc
+`
+	doc, _ := parser.Parse([]byte(src))
+
+	if r := computePrepareRename(doc, protocol.Position{Line: 4, Character: 5}); r != nil {
+		t.Errorf("expected refusal on the space after alias B, got %+v", r)
+	}
+}
+
+func TestComputeRename_MixedLayoutRefusesLegacyDPTrigger(t *testing.T) {
+	// A document with both a doc-level legacy DP and one or more
+	// scoped plays. The rest of the LSP intentionally ignores the
+	// legacy DP in this layout, so we must refuse rename triggered on
+	// it rather than silently rewriting cues across the scoped plays.
+	src := `## Dramatis Personae
+
+BOB
+
+# Play A
+
+## Dramatis Personae
+
+BOB
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hello from A.
+`
+	doc, errs := parser.Parse([]byte(src))
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+
+	// Cursor on the legacy doc-level DP entry (line 2).
+	if _, err := computeRename(doc, renameURI, protocol.Position{Line: 2, Character: 1}, "ROBERT"); err == nil {
+		t.Fatal("expected rename to be refused on legacy DP entry in mixed layout")
+	}
+}
+
 func TestPrepareRename_NilDoc(t *testing.T) {
 	if r := computePrepareRename(nil, protocol.Position{}); r != nil {
 		t.Errorf("expected nil for nil doc, got %+v", r)

--- a/internal/lsp/rename_test.go
+++ b/internal/lsp/rename_test.go
@@ -456,6 +456,147 @@ SONG END
 	}
 }
 
+func TestComputeRename_CompilationScopesToOwningPlay(t *testing.T) {
+	// Each play in a compilation has its own dramatis personae. Renaming
+	// BOB in Play A must not rewrite the (different) BOB in Play B.
+	src := `# Play A
+
+## Dramatis Personae
+
+BOB
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hello from A.
+
+# Play B
+
+## Dramatis Personae
+
+BOB
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hello from B.
+`
+	doc, errs := parser.Parse([]byte(src))
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+
+	// Cursor on Play A's DP entry.
+	edit, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, "ROBERT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	edits := edit.Changes[renameURI]
+	// Expect: Play A DP entry + Play A cue. Play B's DP entry and cue stay put.
+	if got, want := len(edits), 2; got != want {
+		t.Fatalf("expected %d edits scoped to Play A, got %d: %+v", want, got, edits)
+	}
+	for _, e := range edits {
+		if e.Range.Start.Line >= 13 {
+			t.Errorf("edit leaked into Play B at line %d: %+v", e.Range.Start.Line, e)
+		}
+	}
+}
+
+func TestComputeRename_CompilationCueScopesToOwningPlay(t *testing.T) {
+	// Triggering rename from a cue should also stay within that cue's
+	// owning play.
+	src := `# Play A
+
+## Dramatis Personae
+
+BOB
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hello from A.
+
+# Play B
+
+## Dramatis Personae
+
+BOB
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hello from B.
+`
+	doc, errs := parser.Parse([]byte(src))
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+
+	// Cursor on Play B's cue (line 23).
+	edit, err := computeRename(doc, renameURI, protocol.Position{Line: 23, Character: 1}, "ROBERT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	edits := edit.Changes[renameURI]
+	if got, want := len(edits), 2; got != want {
+		t.Fatalf("expected %d edits scoped to Play B, got %d: %+v", want, got, edits)
+	}
+	for _, e := range edits {
+		if e.Range.Start.Line < 13 {
+			t.Errorf("edit leaked into Play A at line %d: %+v", e.Range.Start.Line, e)
+		}
+	}
+}
+
+func TestComputeRename_CompilationConflictScopedToPlay(t *testing.T) {
+	// A name that exists in another play should NOT be flagged as a
+	// conflict; each play's DP scope is independent.
+	src := `# Play A
+
+## Dramatis Personae
+
+BOB
+
+## ACT I
+
+### SCENE 1
+
+BOB
+Hi.
+
+# Play B
+
+## Dramatis Personae
+
+JANE
+
+## ACT I
+
+### SCENE 1
+
+JANE
+Hi.
+`
+	doc, errs := parser.Parse([]byte(src))
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+
+	// Renaming Play A's BOB → JANE is fine because Play A has no JANE.
+	if _, err := computeRename(doc, renameURI, protocol.Position{Line: 4, Character: 1}, "JANE"); err != nil {
+		t.Fatalf("expected rename to succeed across plays, got %v", err)
+	}
+}
+
 func TestPrepareRename_NilDoc(t *testing.T) {
 	if r := computePrepareRename(nil, protocol.Position{}); r != nil {
 		t.Errorf("expected nil for nil doc, got %+v", r)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -940,9 +940,9 @@ func (p *parser) parseGenericContent(section *ast.Section, level int) {
 
 func parseCharacterEntry(tok token.Token) ast.Character {
 	ch := ast.Character{Range: tok.Range}
-	namePart := tok.Literal
+	nameEnd := len(tok.Literal)
 	if idx := strings.Index(tok.Literal, " - "); idx >= 0 {
-		namePart = strings.TrimSpace(tok.Literal[:idx])
+		nameEnd = idx
 		descStart := idx + 3
 		descRaw := tok.Literal[descStart:]
 		trimmedLeading := len(descRaw) - len(strings.TrimLeft(descRaw, " \t"))
@@ -955,8 +955,70 @@ func parseCharacterEntry(tok token.Token) ast.Character {
 			ch.DescriptionInlines = parseInlineContent(descTrimmed, descRange)
 		}
 	}
-	ch.Name, ch.Aliases = parseAliasSpec(strings.TrimSpace(namePart))
+
+	namePart := tok.Literal[:nameEnd]
+	name, nameRange, aliases, aliasRanges := parseAliasSpecRanges(namePart, tok.Range, tok.Literal)
+	ch.Name = name
+	ch.Aliases = aliases
+	if !isZeroRange(nameRange) {
+		ch.SetNameRange(nameRange)
+	}
+	if len(aliasRanges) > 0 {
+		ch.SetAliasRanges(aliasRanges)
+	}
 	return ch
+}
+
+func isZeroRange(r token.Range) bool {
+	return r.Start == (token.Position{}) && r.End == (token.Position{})
+}
+
+// parseAliasSpecRanges splits a "NAME/ALIAS1/ALIAS2" segment and returns
+// each spelling alongside its source range within base. Empty segments are
+// dropped, matching parseAliasSpec semantics.
+func parseAliasSpecRanges(segment string, base token.Range, baseLiteral string) (string, token.Range, []string, []token.Range) {
+	var (
+		name        string
+		nameRange   token.Range
+		aliases     []string
+		aliasRanges []token.Range
+		cursor      int
+	)
+
+	for i, part := range strings.Split(segment, "/") {
+		offsetInSegment := cursor
+		cursor += len(part) + 1 // include the slash separator
+
+		trimmedLeading := len(part) - len(strings.TrimLeft(part, " \t"))
+		trimmed := strings.TrimSpace(part)
+		startByte := offsetInSegment + trimmedLeading
+		endByte := startByte + len(trimmed)
+
+		if i == 0 {
+			name = trimmed
+			if trimmed != "" {
+				nameRange = sliceInlineRange(baseLiteral, base, startByte, endByte)
+			}
+			continue
+		}
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToUpper(trimmed)
+		duplicate := false
+		for _, existing := range aliases {
+			if strings.ToUpper(existing) == key {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		aliases = append(aliases, trimmed)
+		aliasRanges = append(aliasRanges, sliceInlineRange(baseLiteral, base, startByte, endByte))
+	}
+	return name, nameRange, aliases, aliasRanges
 }
 
 func hasUnsupportedDPDash(raw string) bool {
@@ -1372,24 +1434,6 @@ func isSectionKeyword(title, keyword string) bool {
 	return false
 }
 
-func parseAliasSpec(raw string) (string, []string) {
-	parts := strings.Split(raw, "/")
-	if len(parts) == 0 {
-		return "", nil
-	}
-
-	name := strings.TrimSpace(parts[0])
-	var aliases []string
-	for _, part := range parts[1:] {
-		alias := strings.TrimSpace(part)
-		if alias == "" {
-			continue
-		}
-		aliases = appendUniqueAliases(aliases, alias)
-	}
-	return name, aliases
-}
-
 func (p *parser) skipTitlePageOverflow() {
 	for p.at(token.TitleKey) || p.at(token.TitleValue) {
 		p.advance()
@@ -1431,25 +1475,6 @@ func findInlineDelimiter(s string, start int, delimiter string) int {
 	}
 
 	return strings.Index(s[start:end], delimiter)
-}
-
-func appendUniqueAliases(existing []string, aliases ...string) []string {
-	seen := make(map[string]struct{}, len(existing))
-	for _, alias := range existing {
-		seen[strings.ToUpper(alias)] = struct{}{}
-	}
-	for _, alias := range aliases {
-		key := strings.ToUpper(strings.TrimSpace(alias))
-		if key == "" {
-			continue
-		}
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		existing = append(existing, strings.TrimSpace(alias))
-	}
-	return existing
 }
 
 func shiftRangeStart(r token.Range, columnDelta, offsetDelta int) token.Range {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -957,7 +957,7 @@ func parseCharacterEntry(tok token.Token) ast.Character {
 	}
 
 	namePart := tok.Literal[:nameEnd]
-	name, nameRange, aliases, aliasRanges := parseAliasSpecRanges(namePart, tok.Range, tok.Literal)
+	name, nameRange, aliases, aliasRanges := parseAliasSpecRanges(namePart, tok.Range)
 	ch.Name = name
 	ch.Aliases = aliases
 	if !isZeroRange(nameRange) {
@@ -975,8 +975,8 @@ func isZeroRange(r token.Range) bool {
 
 // parseAliasSpecRanges splits a "NAME/ALIAS1/ALIAS2" segment and returns
 // each spelling alongside its source range within base. Empty segments are
-// dropped, matching parseAliasSpec semantics.
-func parseAliasSpecRanges(segment string, base token.Range, baseLiteral string) (string, token.Range, []string, []token.Range) {
+// dropped.
+func parseAliasSpecRanges(segment string, base token.Range) (string, token.Range, []string, []token.Range) {
 	var (
 		name        string
 		nameRange   token.Range
@@ -997,7 +997,7 @@ func parseAliasSpecRanges(segment string, base token.Range, baseLiteral string) 
 		if i == 0 {
 			name = trimmed
 			if trimmed != "" {
-				nameRange = sliceInlineRange(baseLiteral, base, startByte, endByte)
+				nameRange = sliceInlineRange(segment, base, startByte, endByte)
 			}
 			continue
 		}
@@ -1016,7 +1016,7 @@ func parseAliasSpecRanges(segment string, base token.Range, baseLiteral string) 
 			continue
 		}
 		aliases = append(aliases, trimmed)
-		aliasRanges = append(aliasRanges, sliceInlineRange(baseLiteral, base, startByte, endByte))
+		aliasRanges = append(aliasRanges, sliceInlineRange(segment, base, startByte, endByte))
 	}
 	return name, nameRange, aliases, aliasRanges
 }


### PR DESCRIPTION
## Summary
- Adds `textDocument/prepareRename` + `textDocument/rename` for character names.
- Each spelling (primary name or a specific alias) is its own renameable symbol — renaming `BOB` does not rewrite the alias `B` or vice versa.
- Cue casing is preserved: ALL CAPS cues stay ALL CAPS, mixed-case cues keep their typed form.
- Refuses on prose mentions, conjunction cues (`BOB AND JANE`), and new names that would collide or that contain syntax the parser would reinterpret (`/`, ` - `, etc.).
- Parser now records source ranges for the primary name and each alias on `ast.Character`. Fields are unexported and excluded from `downstage parse` JSON, so existing golden output stays stable.

VS Code picks rename up automatically through the LSP client; no extension changes needed beyond the README mention.

Closes #106.

## Test plan
- [x] `go test ./...`
- [x] In VS Code: F2 on a DP entry, an alias, and a cue — confirm declaration + matching cues update; alias rename leaves primary untouched
- [x] In VS Code: F2 on a `BOB AND JANE` cue and on plain prose — confirm the rename UI is refused
- [x] Verify rename with a name that collides with another character / alias surfaces an error in the VS Code UI