### PR TITLE
feat(stats): add manuscript statistics command

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ brew install downstage
 ```
 downstage parse play.ds       # Output AST as JSON
 downstage validate play.ds    # Check for errors
+downstage stats play.ds       # Report word/dialogue/runtime stats
 downstage render play.ds      # Render to PDF (default)
 downstage render -f html play.ds  # Render to HTML
 downstage lsp                 # Start LSP server (stdio)
@@ -177,6 +178,32 @@ Both formats support two styles via `--style`:
 PDF uses Courier 12pt on letter-size pages for manuscript, and Libre Baskerville
 10pt on half-letter for acting edition. HTML produces a self-contained document with
 embedded CSS using semantic `.downstage-*` class names for custom styling.
+
+### Statistics
+
+`downstage stats` reports manuscript metrics derived from the parsed AST:
+word counts, dialogue breakdown, per-character speeches and lines, scene/act
+counts, and a rough runtime estimate.
+
+```
+downstage stats play.ds                 # Human-readable summary
+downstage stats play.ds --format json   # Machine-readable output
+downstage stats play.ds --rate slow     # Use the 110 wpm preset
+downstage stats play.ds --wpm 140 --pause 0  # Custom rate, no pause overhead
+```
+
+Runtime is based on spoken dialogue word count divided by a speaking rate,
+plus a small pause factor for pacing:
+
+```
+spoken_minutes    = dialogue_words / words_per_minute
+estimated_minutes = spoken_minutes * (1 + pause_factor)
+```
+
+Presets: `slow` (110 wpm), `standard` (130 wpm, default), `conversational`
+(150 wpm). The default pause factor is 10%. Stage directions and prose do
+not contribute to the runtime estimate. Treat the output as a rough guide,
+not a prediction.
 
 ## Editor Setup
 

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -1,0 +1,153 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+
+	"github.com/jscaltreto/downstage/internal/parser"
+	"github.com/jscaltreto/downstage/internal/stats"
+	"github.com/spf13/cobra"
+)
+
+var (
+	statsFormat      string
+	statsRatePreset  string
+	statsWordsPerMin int
+	statsPauseFactor float64
+	statsPauseSet    bool
+)
+
+var statsCmd = &cobra.Command{
+	Use:   "stats <file.ds>",
+	Short: "Report manuscript statistics for a .ds file",
+	Long: `Parses a Downstage (.ds) file and reports word counts, per-character
+dialogue tallies, scene/act counts, and a rough runtime estimate.
+
+The runtime estimate is derived from dialogue word count alone. Choose a
+preset with --rate (slow, standard, conversational) or override the rate
+directly with --wpm.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runStats,
+}
+
+func init() {
+	statsCmd.Flags().StringVarP(&statsFormat, "format", "f", "text", "output format: text or json")
+	statsCmd.Flags().StringVar(&statsRatePreset, "rate", "standard", "speaking rate preset: slow, standard, conversational")
+	statsCmd.Flags().IntVar(&statsWordsPerMin, "wpm", 0, "override speaking rate in words per minute (disables --rate preset)")
+	statsCmd.Flags().Float64Var(&statsPauseFactor, "pause", stats.DefaultPauseFactor, "pause overhead applied to spoken runtime (e.g. 0.10 for 10%)")
+	statsCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		statsPauseSet = cmd.Flags().Changed("pause")
+	}
+	rootCmd.AddCommand(statsCmd)
+}
+
+func runStats(cmd *cobra.Command, args []string) error {
+	filename := args[0]
+	slog.Debug("computing stats", "filename", filename)
+
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", filename, err)
+	}
+
+	doc, errs := parser.Parse(content)
+	for _, e := range errs {
+		fmt.Fprintf(cmd.ErrOrStderr(), "%s:%d:%d: %s\n",
+			filepath.Base(filename),
+			e.Range.Start.Line+1,
+			e.Range.Start.Column+1,
+			e.Message,
+		)
+	}
+
+	opts := stats.RuntimeOptions{
+		Preset:         statsRatePreset,
+		WordsPerMinute: statsWordsPerMin,
+		PauseFactor:    statsPauseFactor,
+	}
+	if statsPauseSet {
+		opts = opts.WithPauseFactor(statsPauseFactor)
+	}
+	result := stats.Compute(doc, opts)
+
+	switch statsFormat {
+	case "json":
+		return writeStatsJSON(cmd.OutOrStdout(), result)
+	case "text", "":
+		return writeStatsText(cmd.OutOrStdout(), result)
+	default:
+		return errors.New("unknown --format: use text or json")
+	}
+}
+
+func writeStatsJSON(w io.Writer, s stats.Stats) error {
+	out, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling stats: %w", err)
+	}
+	fmt.Fprintln(w, string(out))
+	return nil
+}
+
+func writeStatsText(w io.Writer, s stats.Stats) error {
+	fmt.Fprintln(w, "Manuscript")
+	fmt.Fprintf(w, "  Acts:             %d\n", s.Acts)
+	fmt.Fprintf(w, "  Scenes:           %d\n", s.Scenes)
+	fmt.Fprintf(w, "  Songs:            %d\n", s.Songs)
+	fmt.Fprintf(w, "  Speeches:         %d\n", s.Speeches)
+	fmt.Fprintf(w, "  Stage directions: %d\n", s.StageDirections)
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "Words")
+	fmt.Fprintf(w, "  Total:            %d\n", s.TotalWords)
+	fmt.Fprintf(w, "  Dialogue:         %d (%s)\n", s.DialogueWords, percent(s.DialogueWords, s.TotalWords))
+	fmt.Fprintf(w, "  Stage directions: %d\n", s.StageDirectionWords)
+	fmt.Fprintf(w, "  Dialogue lines:   %d\n", s.DialogueLines)
+	fmt.Fprintln(w)
+
+	if len(s.Characters) > 0 {
+		fmt.Fprintln(w, "Characters (by speeches)")
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  NAME\tSPEECHES\tLINES\tWORDS")
+		for _, c := range s.Characters {
+			fmt.Fprintf(tw, "  %s\t%d\t%d\t%d\n", c.Name, c.Speeches, c.DialogueLines, c.DialogueWords)
+		}
+		tw.Flush()
+		fmt.Fprintln(w)
+	}
+
+	fmt.Fprintln(w, "Runtime (estimate)")
+	fmt.Fprintf(w, "  Preset:           %s\n", s.Runtime.Preset)
+	fmt.Fprintf(w, "  Rate:             %d wpm\n", s.Runtime.WordsPerMinute)
+	fmt.Fprintf(w, "  Pause factor:     %.0f%%\n", s.Runtime.PauseFactor*100)
+	fmt.Fprintf(w, "  Estimated length: %s (~%.1f min)\n", formatRuntime(s.Runtime.Minutes), s.Runtime.Minutes)
+	fmt.Fprintln(w, "  Based on spoken dialogue only; treat as a rough guide.")
+	return nil
+}
+
+func percent(part, total int) string {
+	if total == 0 {
+		return "0%"
+	}
+	return fmt.Sprintf("%.0f%%", float64(part)/float64(total)*100)
+}
+
+func formatRuntime(minutes float64) string {
+	if minutes <= 0 {
+		return "0m"
+	}
+	total := int(math.Round(minutes))
+	h := total / 60
+	m := total % 60
+	if h == 0 {
+		return fmt.Sprintf("%dm", m)
+	}
+	return fmt.Sprintf("%dh %02dm", h, m)
+}

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -101,7 +101,7 @@ func writeStatsText(w io.Writer, s stats.Stats) error {
 	fmt.Fprintf(w, "  Acts:             %d\n", s.Acts)
 	fmt.Fprintf(w, "  Scenes:           %d\n", s.Scenes)
 	fmt.Fprintf(w, "  Songs:            %d\n", s.Songs)
-	fmt.Fprintf(w, "  Speeches:         %d\n", s.Speeches)
+	fmt.Fprintf(w, "  Lines:            %d\n", s.Lines)
 	fmt.Fprintf(w, "  Stage directions: %d\n", s.StageDirections)
 	fmt.Fprintln(w)
 
@@ -109,15 +109,14 @@ func writeStatsText(w io.Writer, s stats.Stats) error {
 	fmt.Fprintf(w, "  Total:            %d\n", s.TotalWords)
 	fmt.Fprintf(w, "  Dialogue:         %d (%s)\n", s.DialogueWords, percent(s.DialogueWords, s.TotalWords))
 	fmt.Fprintf(w, "  Stage directions: %d\n", s.StageDirectionWords)
-	fmt.Fprintf(w, "  Dialogue lines:   %d\n", s.DialogueLines)
 	fmt.Fprintln(w)
 
 	if len(s.Characters) > 0 {
-		fmt.Fprintln(w, "Characters (by speeches)")
+		fmt.Fprintln(w, "Characters (by lines)")
 		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(tw, "  NAME\tSPEECHES\tLINES\tWORDS")
+		fmt.Fprintln(tw, "  NAME\tLINES\tWORDS")
 		for _, c := range s.Characters {
-			fmt.Fprintf(tw, "  %s\t%d\t%d\t%d\n", c.Name, c.Speeches, c.DialogueLines, c.DialogueWords)
+			fmt.Fprintf(tw, "  %s\t%d\t%d\n", c.Name, c.Lines, c.DialogueWords)
 		}
 		tw.Flush()
 		fmt.Fprintln(w)

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -72,7 +72,7 @@ Hello world.
 	if err := json.Unmarshal([]byte(out), &s); err != nil {
 		t.Fatalf("unmarshal: %v\n---\n%s", err, out)
 	}
-	if s.Acts != 1 || s.Speeches != 1 {
+	if s.Acts != 1 || s.Lines != 1 {
 		t.Errorf("unexpected stats: %+v", s)
 	}
 	if s.Runtime.Preset != "standard" || s.Runtime.WordsPerMinute != 130 {

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/stats"
+)
+
+func runStatsCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	// Reset flag-scoped state between runs.
+	statsFormat = "text"
+	statsRatePreset = "standard"
+	statsWordsPerMin = 0
+	statsPauseFactor = stats.DefaultPauseFactor
+	statsPauseSet = false
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(append([]string{"stats"}, args...))
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+func TestStatsCmdTextOutput(t *testing.T) {
+	path := writeScript(t, `## Dramatis Personae
+
+ALICE - A lead
+
+## ACT I
+
+### SCENE 1
+
+ALICE
+Hello world.
+`)
+	out, err := runStatsCmd(t, path)
+	if err != nil {
+		t.Fatalf("runStatsCmd: %v\n%s", err, out)
+	}
+	for _, want := range []string{"Acts:", "ALICE", "Runtime (estimate)", "standard"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text output missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestStatsCmdJSONOutput(t *testing.T) {
+	path := writeScript(t, `## Dramatis Personae
+
+ALICE - A lead
+
+## ACT I
+
+### SCENE 1
+
+ALICE
+Hello world.
+`)
+	out, err := runStatsCmd(t, "--format", "json", path)
+	if err != nil {
+		t.Fatalf("runStatsCmd: %v", err)
+	}
+
+	var s stats.Stats
+	if err := json.Unmarshal([]byte(out), &s); err != nil {
+		t.Fatalf("unmarshal: %v\n---\n%s", err, out)
+	}
+	if s.Acts != 1 || s.Speeches != 1 {
+		t.Errorf("unexpected stats: %+v", s)
+	}
+	if s.Runtime.Preset != "standard" || s.Runtime.WordsPerMinute != 130 {
+		t.Errorf("unexpected runtime: %+v", s.Runtime)
+	}
+}
+
+func writeScript(t *testing.T, src string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "script.ds")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}

--- a/internal/stats/runtime.go
+++ b/internal/stats/runtime.go
@@ -1,0 +1,100 @@
+package stats
+
+import "strings"
+
+// Speaking rate presets in words per minute. These are coarse bands meant
+// to bracket likely pacing; they are not performance predictions. See
+// docs/stats.md for the rationale.
+const (
+	WPMSlow           = 110
+	WPMStandard       = 130
+	WPMConversational = 150
+
+	// DefaultPauseFactor accounts for short transitions, breaths, and
+	// beats between speeches that spoken-word timing alone does not
+	// capture. Kept intentionally small so the estimate stays anchored to
+	// the dialogue word count.
+	DefaultPauseFactor = 0.10
+)
+
+// RuntimeOptions configures the runtime heuristic. Zero values fall back
+// to the "standard" preset and DefaultPauseFactor.
+type RuntimeOptions struct {
+	// Preset selects a built-in WPM band: "slow", "standard",
+	// "conversational", or "" (standard). Ignored when WordsPerMinute is
+	// set to a non-zero value.
+	Preset string
+	// WordsPerMinute overrides the preset when > 0.
+	WordsPerMinute int
+	// PauseFactor is a multiplicative overhead applied to the spoken-word
+	// runtime. A negative value is treated as zero.
+	PauseFactor float64
+	// pauseFactorSet disambiguates "omitted" (use default) from
+	// "explicitly zero" when PauseFactor == 0.
+	pauseFactorSet bool
+}
+
+// WithPauseFactor returns opts with PauseFactor explicitly set, including
+// zero. Use this when a caller wants to disable the pause adjustment.
+func (o RuntimeOptions) WithPauseFactor(f float64) RuntimeOptions {
+	o.PauseFactor = f
+	o.pauseFactorSet = true
+	return o
+}
+
+// RuntimeEstimate describes a rough performance length in minutes. It is
+// derived from dialogue word count and is explicitly an estimate, not a
+// prediction.
+type RuntimeEstimate struct {
+	Preset         string  `json:"preset"`
+	WordsPerMinute int     `json:"wordsPerMinute"`
+	PauseFactor    float64 `json:"pauseFactor"`
+	DialogueWords  int     `json:"dialogueWords"`
+	Minutes        float64 `json:"minutes"`
+}
+
+// EstimateRuntime applies the documented heuristic:
+//
+//	spoken = dialogueWords / wordsPerMinute
+//	minutes = spoken * (1 + pauseFactor)
+//
+// Only spoken dialogue contributes; stage directions and prose do not.
+func EstimateRuntime(dialogueWords int, opts RuntimeOptions) RuntimeEstimate {
+	preset, wpm := resolvePreset(opts)
+	pause := opts.PauseFactor
+	if !opts.pauseFactorSet && pause == 0 {
+		pause = DefaultPauseFactor
+	}
+	if pause < 0 {
+		pause = 0
+	}
+	minutes := 0.0
+	if dialogueWords > 0 && wpm > 0 {
+		minutes = float64(dialogueWords) / float64(wpm) * (1 + pause)
+	}
+	return RuntimeEstimate{
+		Preset:         preset,
+		WordsPerMinute: wpm,
+		PauseFactor:    pause,
+		DialogueWords:  dialogueWords,
+		Minutes:        minutes,
+	}
+}
+
+func resolvePreset(opts RuntimeOptions) (string, int) {
+	if opts.WordsPerMinute > 0 {
+		// A non-zero WordsPerMinute is always an explicit override; report
+		// it as "custom" so the surfaced preset matches the rate in use.
+		return "custom", opts.WordsPerMinute
+	}
+	switch strings.ToLower(strings.TrimSpace(opts.Preset)) {
+	case "slow":
+		return "slow", WPMSlow
+	case "conversational":
+		return "conversational", WPMConversational
+	case "", "standard":
+		return "standard", WPMStandard
+	default:
+		return "standard", WPMStandard
+	}
+}

--- a/internal/stats/runtime.go
+++ b/internal/stats/runtime.go
@@ -3,8 +3,7 @@ package stats
 import "strings"
 
 // Speaking rate presets in words per minute. These are coarse bands meant
-// to bracket likely pacing; they are not performance predictions. See
-// docs/stats.md for the rationale.
+// to bracket likely pacing; they are not performance predictions.
 const (
 	WPMSlow           = 110
 	WPMStandard       = 130

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -1,0 +1,283 @@
+// Package stats computes manuscript statistics from a parsed Downstage
+// document. The output is shared core data intended for reuse by the CLI,
+// LSP, and editor integrations. Counts are derived from the AST and are
+// deterministic for a given input.
+package stats
+
+import (
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/jscaltreto/downstage/internal/ast"
+)
+
+// Stats summarizes a manuscript.
+type Stats struct {
+	Acts                int              `json:"acts"`
+	Scenes              int              `json:"scenes"`
+	Songs               int              `json:"songs"`
+	TotalWords          int              `json:"totalWords"`
+	DialogueWords       int              `json:"dialogueWords"`
+	DialogueLines       int              `json:"dialogueLines"`
+	Speeches            int              `json:"speeches"`
+	StageDirections     int              `json:"stageDirections"`
+	StageDirectionWords int              `json:"stageDirectionWords"`
+	Characters          []CharacterStats `json:"characters"`
+	Runtime             RuntimeEstimate  `json:"runtime"`
+}
+
+// CharacterStats holds per-character tallies. Aliases listed in the
+// dramatis personae are folded into the primary name.
+type CharacterStats struct {
+	Name          string   `json:"name"`
+	Aliases       []string `json:"aliases,omitempty"`
+	Speeches      int      `json:"speeches"`
+	DialogueLines int      `json:"dialogueLines"`
+	DialogueWords int      `json:"dialogueWords"`
+}
+
+// Compute walks the document and returns manuscript statistics. The
+// runtime field is filled in using the supplied RuntimeOptions; see
+// EstimateRuntime for the heuristic.
+func Compute(doc *ast.Document, rt RuntimeOptions) Stats {
+	s := Stats{}
+	if doc == nil {
+		s.Runtime = EstimateRuntime(0, rt)
+		return s
+	}
+
+	resolver := newAliasResolver(doc)
+	perChar := make(map[string]*CharacterStats)
+
+	addCharacter := func(name string) *CharacterStats {
+		if existing, ok := perChar[name]; ok {
+			return existing
+		}
+		cs := &CharacterStats{Name: name, Aliases: resolver.aliasesFor(name)}
+		perChar[name] = cs
+		return cs
+	}
+
+	var walk func(nodes []ast.Node)
+	walk = func(nodes []ast.Node) {
+		for _, node := range nodes {
+			switch n := node.(type) {
+			case *ast.Section:
+				switch n.Kind {
+				case ast.SectionAct:
+					s.Acts++
+				case ast.SectionScene:
+					s.Scenes++
+				}
+				for _, item := range n.OrderedItems() {
+					if item.Node != nil {
+						walk([]ast.Node{item.Node})
+						continue
+					}
+					if item.Line != nil {
+						s.TotalWords += countWords(plainText(item.Line.Content))
+					}
+				}
+			case *ast.Dialogue:
+				s.Speeches++
+				name := resolver.canonical(n.Character)
+				cs := addCharacter(name)
+				cs.Speeches++
+				for _, line := range n.Lines {
+					words := countSpokenWords(line.Content)
+					if words == 0 && plainTextTrimmed(line.Content) == "" {
+						continue
+					}
+					s.DialogueLines++
+					s.DialogueWords += words
+					s.TotalWords += words
+					cs.DialogueLines++
+					cs.DialogueWords += words
+				}
+			case *ast.DualDialogue:
+				walk([]ast.Node{n.Left, n.Right})
+			case *ast.StageDirection:
+				s.StageDirections++
+				w := countWords(plainText(n.Content))
+				s.StageDirectionWords += w
+				s.TotalWords += w
+			case *ast.Callout:
+				w := countWords(plainText(n.Content))
+				s.TotalWords += w
+			case *ast.Song:
+				s.Songs++
+				walk(n.Content)
+			case *ast.VerseBlock:
+				for _, line := range n.Lines {
+					s.TotalWords += countWords(plainText(line.Content))
+				}
+			}
+		}
+	}
+
+	walk(doc.Body)
+
+	s.Characters = make([]CharacterStats, 0, len(perChar))
+	for _, cs := range perChar {
+		s.Characters = append(s.Characters, *cs)
+	}
+	sort.Slice(s.Characters, func(i, j int) bool {
+		a, b := s.Characters[i], s.Characters[j]
+		if a.Speeches != b.Speeches {
+			return a.Speeches > b.Speeches
+		}
+		if a.DialogueWords != b.DialogueWords {
+			return a.DialogueWords > b.DialogueWords
+		}
+		return a.Name < b.Name
+	})
+
+	s.Runtime = EstimateRuntime(s.DialogueWords, rt)
+	return s
+}
+
+// aliasResolver maps raw cue names (including aliases) to a canonical
+// character name using the dramatis personae. Unknown names are returned
+// upper-cased so forced cues still tally consistently.
+type aliasResolver struct {
+	canonicalByKey map[string]string
+	aliasesByName  map[string][]string
+}
+
+func newAliasResolver(doc *ast.Document) *aliasResolver {
+	r := &aliasResolver{
+		canonicalByKey: make(map[string]string),
+		aliasesByName:  make(map[string][]string),
+	}
+	if doc == nil {
+		return r
+	}
+	dp := ast.FindDramatisPersonae(doc.Body)
+	if dp == nil {
+		return r
+	}
+	for _, ch := range dp.AllCharacters() {
+		name := strings.TrimSpace(ch.Name)
+		if name == "" {
+			continue
+		}
+		r.canonicalByKey[strings.ToUpper(name)] = name
+		for _, alias := range ch.Aliases {
+			alias = strings.TrimSpace(alias)
+			if alias == "" {
+				continue
+			}
+			r.canonicalByKey[strings.ToUpper(alias)] = name
+			r.aliasesByName[name] = append(r.aliasesByName[name], alias)
+		}
+	}
+	return r
+}
+
+func (r *aliasResolver) canonical(raw string) string {
+	key := strings.ToUpper(strings.TrimSpace(raw))
+	if name, ok := r.canonicalByKey[key]; ok {
+		return name
+	}
+	return key
+}
+
+func (r *aliasResolver) aliasesFor(name string) []string {
+	aliases := r.aliasesByName[name]
+	if len(aliases) == 0 {
+		return nil
+	}
+	out := make([]string, len(aliases))
+	copy(out, aliases)
+	return out
+}
+
+// countSpokenWords returns the word count for a dialogue line, excluding
+// inline stage directions which are performance notes rather than spoken
+// text.
+func countSpokenWords(inlines []ast.Inline) int {
+	var b strings.Builder
+	appendSpokenText(&b, inlines)
+	return countWords(b.String())
+}
+
+func appendSpokenText(b *strings.Builder, inlines []ast.Inline) {
+	for _, inline := range inlines {
+		switch n := inline.(type) {
+		case *ast.TextNode:
+			b.WriteString(n.Value)
+		case *ast.BoldNode:
+			appendSpokenText(b, n.Content)
+		case *ast.ItalicNode:
+			appendSpokenText(b, n.Content)
+		case *ast.BoldItalicNode:
+			appendSpokenText(b, n.Content)
+		case *ast.UnderlineNode:
+			appendSpokenText(b, n.Content)
+		case *ast.StrikethroughNode:
+			appendSpokenText(b, n.Content)
+		case *ast.InlineDirectionNode:
+			// skip — not spoken aloud
+		}
+	}
+}
+
+func plainText(inlines []ast.Inline) string {
+	var b strings.Builder
+	appendPlainText(&b, inlines)
+	return b.String()
+}
+
+func plainTextTrimmed(inlines []ast.Inline) string {
+	return strings.TrimSpace(plainText(inlines))
+}
+
+func appendPlainText(b *strings.Builder, inlines []ast.Inline) {
+	for _, inline := range inlines {
+		switch n := inline.(type) {
+		case *ast.TextNode:
+			b.WriteString(n.Value)
+		case *ast.BoldNode:
+			appendPlainText(b, n.Content)
+		case *ast.ItalicNode:
+			appendPlainText(b, n.Content)
+		case *ast.BoldItalicNode:
+			appendPlainText(b, n.Content)
+		case *ast.UnderlineNode:
+			appendPlainText(b, n.Content)
+		case *ast.StrikethroughNode:
+			appendPlainText(b, n.Content)
+		case *ast.InlineDirectionNode:
+			b.WriteString(" ")
+			appendPlainText(b, n.Content)
+			b.WriteString(" ")
+		}
+	}
+}
+
+// countWords splits on whitespace and counts runs that contain at least
+// one letter or digit. Punctuation-only tokens (e.g. "—") do not count.
+func countWords(s string) int {
+	n := 0
+	inWord := false
+	hasAlnum := false
+	for _, r := range s {
+		if unicode.IsSpace(r) {
+			if inWord && hasAlnum {
+				n++
+			}
+			inWord = false
+			hasAlnum = false
+			continue
+		}
+		inWord = true
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			hasAlnum = true
+		}
+	}
+	if inWord && hasAlnum {
+		n++
+	}
+	return n
+}

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -218,7 +218,6 @@ func appendSpokenText(b *strings.Builder, inlines []ast.Inline) {
 		case *ast.StrikethroughNode:
 			appendSpokenText(b, n.Content)
 		case *ast.InlineDirectionNode:
-			// skip — not spoken aloud
 		}
 	}
 }

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -19,8 +19,7 @@ type Stats struct {
 	Songs               int              `json:"songs"`
 	TotalWords          int              `json:"totalWords"`
 	DialogueWords       int              `json:"dialogueWords"`
-	DialogueLines       int              `json:"dialogueLines"`
-	Speeches            int              `json:"speeches"`
+	Lines               int              `json:"lines"`
 	StageDirections     int              `json:"stageDirections"`
 	StageDirectionWords int              `json:"stageDirectionWords"`
 	Characters          []CharacterStats `json:"characters"`
@@ -32,8 +31,7 @@ type Stats struct {
 type CharacterStats struct {
 	Name          string   `json:"name"`
 	Aliases       []string `json:"aliases,omitempty"`
-	Speeches      int      `json:"speeches"`
-	DialogueLines int      `json:"dialogueLines"`
+	Lines         int      `json:"lines"`
 	DialogueWords int      `json:"dialogueWords"`
 }
 
@@ -80,19 +78,17 @@ func Compute(doc *ast.Document, rt RuntimeOptions) Stats {
 					}
 				}
 			case *ast.Dialogue:
-				s.Speeches++
+				s.Lines++
 				name := resolver.canonical(n.Character)
 				cs := addCharacter(name)
-				cs.Speeches++
-				for _, line := range n.Lines {
-					words := countSpokenWords(line.Content)
-					if words == 0 && plainTextTrimmed(line.Content) == "" {
+				cs.Lines++
+				for _, dl := range n.Lines {
+					words := countSpokenWords(dl.Content)
+					if words == 0 && plainTextTrimmed(dl.Content) == "" {
 						continue
 					}
-					s.DialogueLines++
 					s.DialogueWords += words
 					s.TotalWords += words
-					cs.DialogueLines++
 					cs.DialogueWords += words
 				}
 			case *ast.DualDialogue:
@@ -124,8 +120,8 @@ func Compute(doc *ast.Document, rt RuntimeOptions) Stats {
 	}
 	sort.Slice(s.Characters, func(i, j int) bool {
 		a, b := s.Characters[i], s.Characters[j]
-		if a.Speeches != b.Speeches {
-			return a.Speeches > b.Speeches
+		if a.Lines != b.Lines {
+			return a.Lines > b.Lines
 		}
 		if a.DialogueWords != b.DialogueWords {
 			return a.DialogueWords > b.DialogueWords

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -44,11 +44,8 @@ Hi Alice.
 	if s.Scenes != 1 {
 		t.Errorf("Scenes = %d, want 1", s.Scenes)
 	}
-	if s.Speeches != 2 {
-		t.Errorf("Speeches = %d, want 2", s.Speeches)
-	}
-	if s.DialogueLines != 3 {
-		t.Errorf("DialogueLines = %d, want 3", s.DialogueLines)
+	if s.Lines != 2 {
+		t.Errorf("Lines = %d, want 2", s.Lines)
 	}
 	if s.DialogueWords != 9 {
 		t.Errorf("DialogueWords = %d, want 9 (\"Hello world This is a second line Hi Alice\")", s.DialogueWords)
@@ -62,8 +59,8 @@ Hi Alice.
 	if s.Characters[0].Name != "ALICE" {
 		t.Errorf("top character = %q, want ALICE", s.Characters[0].Name)
 	}
-	if s.Characters[0].Speeches != 1 || s.Characters[0].DialogueLines != 2 {
-		t.Errorf("ALICE stats = %+v", s.Characters[0])
+	if s.Characters[0].Lines != 1 {
+		t.Errorf("ALICE lines = %d, want 1", s.Characters[0].Lines)
 	}
 }
 
@@ -90,8 +87,8 @@ Line two.
 	if ch.Name != "JAMES" {
 		t.Errorf("Name = %q, want JAMES", ch.Name)
 	}
-	if ch.Speeches != 2 || ch.DialogueLines != 2 {
-		t.Errorf("JAMES stats = %+v, want 2 speeches / 2 lines", ch)
+	if ch.Lines != 2 {
+		t.Errorf("JAMES lines = %d, want 2", ch.Lines)
 	}
 	if len(ch.Aliases) != 1 || ch.Aliases[0] != "JIM" {
 		t.Errorf("Aliases = %v, want [JIM]", ch.Aliases)
@@ -138,8 +135,8 @@ SONG END
 	if s.Songs != 1 {
 		t.Errorf("Songs = %d, want 1", s.Songs)
 	}
-	if s.Speeches != 1 {
-		t.Errorf("Speeches = %d, want 1 (dialogue inside song counts)", s.Speeches)
+	if s.Lines != 1 {
+		t.Errorf("Lines = %d, want 1 (dialogue inside song counts)", s.Lines)
 	}
 	if s.DialogueWords != 4 {
 		t.Errorf("DialogueWords = %d, want 4", s.DialogueWords)

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -1,0 +1,241 @@
+package stats_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/parser"
+	"github.com/jscaltreto/downstage/internal/stats"
+)
+
+func compute(t *testing.T, src string) stats.Stats {
+	t.Helper()
+	doc, errs := parser.Parse([]byte(src))
+	for _, e := range errs {
+		t.Fatalf("parse error: %s", e.Message)
+	}
+	return stats.Compute(doc, stats.RuntimeOptions{})
+}
+
+func TestComputeBasicCounts(t *testing.T) {
+	src := `## Dramatis Personae
+
+ALICE - A lead
+BOB - Her friend
+
+## ACT I
+
+### SCENE 1
+
+> Alice enters.
+
+ALICE
+Hello world.
+This is a second line.
+
+BOB
+Hi Alice.
+`
+	s := compute(t, src)
+
+	if s.Acts != 1 {
+		t.Errorf("Acts = %d, want 1", s.Acts)
+	}
+	if s.Scenes != 1 {
+		t.Errorf("Scenes = %d, want 1", s.Scenes)
+	}
+	if s.Speeches != 2 {
+		t.Errorf("Speeches = %d, want 2", s.Speeches)
+	}
+	if s.DialogueLines != 3 {
+		t.Errorf("DialogueLines = %d, want 3", s.DialogueLines)
+	}
+	if s.DialogueWords != 9 {
+		t.Errorf("DialogueWords = %d, want 9 (\"Hello world This is a second line Hi Alice\")", s.DialogueWords)
+	}
+	if s.StageDirections != 1 {
+		t.Errorf("StageDirections = %d, want 1", s.StageDirections)
+	}
+	if len(s.Characters) != 2 {
+		t.Fatalf("Characters = %d, want 2", len(s.Characters))
+	}
+	if s.Characters[0].Name != "ALICE" {
+		t.Errorf("top character = %q, want ALICE", s.Characters[0].Name)
+	}
+	if s.Characters[0].Speeches != 1 || s.Characters[0].DialogueLines != 2 {
+		t.Errorf("ALICE stats = %+v", s.Characters[0])
+	}
+}
+
+func TestComputeAliasFolding(t *testing.T) {
+	src := `## Dramatis Personae
+
+JAMES/JIM - Son
+
+## ACT I
+
+### SCENE 1
+
+JAMES
+Line one.
+
+JIM
+Line two.
+`
+	s := compute(t, src)
+	if len(s.Characters) != 1 {
+		t.Fatalf("Characters = %d, want 1 (JIM folded into JAMES)", len(s.Characters))
+	}
+	ch := s.Characters[0]
+	if ch.Name != "JAMES" {
+		t.Errorf("Name = %q, want JAMES", ch.Name)
+	}
+	if ch.Speeches != 2 || ch.DialogueLines != 2 {
+		t.Errorf("JAMES stats = %+v, want 2 speeches / 2 lines", ch)
+	}
+	if len(ch.Aliases) != 1 || ch.Aliases[0] != "JIM" {
+		t.Errorf("Aliases = %v, want [JIM]", ch.Aliases)
+	}
+}
+
+func TestComputeInlineDirectionExcluded(t *testing.T) {
+	src := `## Dramatis Personae
+
+ALICE - A lead
+
+## ACT I
+
+### SCENE 1
+
+ALICE
+Hello (softly) world.
+`
+	s := compute(t, src)
+	// "Hello" + "world" = 2 spoken words. "softly" is an inline direction
+	// and must not be counted as spoken dialogue.
+	if s.DialogueWords != 2 {
+		t.Errorf("DialogueWords = %d, want 2 (inline direction should be excluded)", s.DialogueWords)
+	}
+}
+
+func TestComputeSongDialogue(t *testing.T) {
+	src := `## Dramatis Personae
+
+ALICE - A lead
+
+## ACT I
+
+### SCENE 1
+
+SONG: Test
+
+ALICE
+  A song line here.
+
+SONG END
+`
+	s := compute(t, src)
+	if s.Songs != 1 {
+		t.Errorf("Songs = %d, want 1", s.Songs)
+	}
+	if s.Speeches != 1 {
+		t.Errorf("Speeches = %d, want 1 (dialogue inside song counts)", s.Speeches)
+	}
+	if s.DialogueWords != 4 {
+		t.Errorf("DialogueWords = %d, want 4", s.DialogueWords)
+	}
+}
+
+func TestComputeGenericSectionProseCounted(t *testing.T) {
+	// Prose under a non-act/scene heading is stored as Section.Lines, not
+	// as child nodes. Those words must still count toward the manuscript
+	// total — otherwise playwright's notes, credits, etc. are silently
+	// dropped from TotalWords.
+	src := `# Playwright's Notes
+
+This play was written over four months.
+It draws on several conversations with retired actors.
+`
+	s := compute(t, src)
+	if s.TotalWords != 15 {
+		t.Errorf("TotalWords = %d, want 15 (generic section prose must count)", s.TotalWords)
+	}
+}
+
+func TestComputeEmptyDocument(t *testing.T) {
+	s := stats.Compute(nil, stats.RuntimeOptions{})
+	if s.TotalWords != 0 || s.Runtime.Minutes != 0 {
+		t.Errorf("empty doc should produce zeros, got %+v", s)
+	}
+}
+
+func TestRuntimePresets(t *testing.T) {
+	cases := []struct {
+		preset  string
+		wpm     int
+		pause   float64
+		setZero bool
+		words   int
+		want    float64
+	}{
+		{"standard", 130, stats.DefaultPauseFactor, false, 1300, 1300.0 / 130 * 1.10},
+		{"slow", 110, stats.DefaultPauseFactor, false, 1100, 1100.0 / 110 * 1.10},
+		{"conversational", 150, stats.DefaultPauseFactor, false, 1500, 1500.0 / 150 * 1.10},
+		{"", 130, stats.DefaultPauseFactor, false, 130, 1.10},
+		{"unknown", 130, stats.DefaultPauseFactor, false, 130, 1.10},
+	}
+	for _, tc := range cases {
+		opts := stats.RuntimeOptions{Preset: tc.preset}
+		got := stats.EstimateRuntime(tc.words, opts)
+		if got.WordsPerMinute != tc.wpm {
+			t.Errorf("preset %q wpm = %d, want %d", tc.preset, got.WordsPerMinute, tc.wpm)
+		}
+		if math.Abs(got.Minutes-tc.want) > 1e-6 {
+			t.Errorf("preset %q minutes = %v, want %v", tc.preset, got.Minutes, tc.want)
+		}
+	}
+}
+
+func TestRuntimeOverrides(t *testing.T) {
+	opts := stats.RuntimeOptions{WordsPerMinute: 200}
+	opts = opts.WithPauseFactor(0)
+	got := stats.EstimateRuntime(400, opts)
+	if got.WordsPerMinute != 200 {
+		t.Errorf("wpm = %d, want 200", got.WordsPerMinute)
+	}
+	if got.PauseFactor != 0 {
+		t.Errorf("pauseFactor = %v, want 0 (explicit zero)", got.PauseFactor)
+	}
+	if math.Abs(got.Minutes-2.0) > 1e-6 {
+		t.Errorf("minutes = %v, want 2.0", got.Minutes)
+	}
+	if got.Preset != "custom" {
+		t.Errorf("preset = %q, want custom", got.Preset)
+	}
+}
+
+// A preset name supplied alongside --wpm should not leak into the
+// surfaced metadata: any explicit wpm is always "custom".
+func TestRuntimeWPMOverrideReportsCustom(t *testing.T) {
+	got := stats.EstimateRuntime(260, stats.RuntimeOptions{
+		Preset:         "standard",
+		WordsPerMinute: 200,
+	})
+	if got.Preset != "custom" {
+		t.Errorf("preset = %q, want custom when --wpm overrides", got.Preset)
+	}
+	if got.WordsPerMinute != 200 {
+		t.Errorf("wpm = %d, want 200", got.WordsPerMinute)
+	}
+}
+
+func TestRuntimeNegativePauseClamped(t *testing.T) {
+	opts := stats.RuntimeOptions{}.WithPauseFactor(-0.5)
+	got := stats.EstimateRuntime(130, opts)
+	if got.PauseFactor != 0 {
+		t.Errorf("pauseFactor = %v, want 0 (negative clamped)", got.PauseFactor)
+	}
+	if math.Abs(got.Minutes-1.0) > 1e-6 {
+		t.Errorf("minutes = %v, want 1.0", got.Minutes)
+	}
+}


### PR DESCRIPTION
## Summary
- New `internal/stats` package computes word/dialogue counts, per-character tallies, scene/act/song counts, and a runtime estimate from the parsed AST. Shared core data — CLI, LSP, and editors can all consume the same shape.
- New `downstage stats <file.ds>` CLI with `--format text|json`, `--rate {slow,standard,conversational}`, `--wpm`, and `--pause` flags.
- Runtime heuristic: `dialogue_words / wpm * (1 + pause_factor)`. Presets are 110 / 130 / 150 wpm; default pause factor is 10%. Stage directions and prose do not contribute to the runtime estimate. `--wpm` overrides are always surfaced as `preset: custom` so the reported metadata matches the rate in use.
- Alias folding via dramatis personae (e.g. `JAMES/JIM` collapses to JAMES). Inline stage directions inside dialogue are excluded from spoken word counts.

Closes #105
Closes #108

Follow-up #157 (web editor drawer tab) is intentionally out of scope.

## Test plan
- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [x] Smoke: `downstage stats testdata/full_play.ds` (text + `--format json`)
- [ ] Reviewer sanity-checks the runtime defaults against a real script