### PR TITLE
feat(web): add stats drawer tab and toolbar toggle

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jscaltreto/downstage/internal/render"
 	htmlrender "github.com/jscaltreto/downstage/internal/render/html"
 	pdfrender "github.com/jscaltreto/downstage/internal/render/pdf"
+	"github.com/jscaltreto/downstage/internal/stats"
 	"go.lsp.dev/protocol"
 )
 
@@ -30,6 +31,7 @@ func main() {
 	ds.Set("renderHTML", js.FuncOf(renderHTML))
 	ds.Set("renderPDF", js.FuncOf(renderPDF))
 	ds.Set("semanticTokens", js.FuncOf(semanticTokens))
+	ds.Set("stats", js.FuncOf(computeStats))
 	ds.Set("tokenTypeNames", tokenTypeNamesArray())
 
 	js.Global().Set("downstage", ds)
@@ -315,6 +317,14 @@ func tokenTypeNamesArray() js.Value {
 		arr.SetIndex(i, name)
 	}
 	return arr
+}
+
+func computeStats(_ js.Value, args []js.Value) any {
+	source := args[0].String()
+	doc, _ := parser.Parse([]byte(source))
+	s := stats.Compute(doc, stats.RuntimeOptions{})
+	data, _ := json.Marshal(s)
+	return js.Global().Get("JSON").Call("parse", string(data))
 }
 
 func diagnosticSeverity(severity protocol.DiagnosticSeverity) string {

--- a/internal/stats/runtime.go
+++ b/internal/stats/runtime.go
@@ -2,48 +2,35 @@ package stats
 
 import "strings"
 
-// Speaking rate presets in words per minute. These are coarse bands meant
-// to bracket likely pacing; they are not performance predictions.
+// Speaking rate presets in words per minute.
 const (
 	WPMSlow           = 110
 	WPMStandard       = 130
 	WPMConversational = 150
 
-	// DefaultPauseFactor accounts for short transitions, breaths, and
-	// beats between speeches that spoken-word timing alone does not
-	// capture. Kept intentionally small so the estimate stays anchored to
-	// the dialogue word count.
+	// DefaultPauseFactor is a small overhead for pauses between speeches.
 	DefaultPauseFactor = 0.10
 )
 
-// RuntimeOptions configures the runtime heuristic. Zero values fall back
-// to the "standard" preset and DefaultPauseFactor.
+// RuntimeOptions configures the runtime heuristic.
 type RuntimeOptions struct {
-	// Preset selects a built-in WPM band: "slow", "standard",
-	// "conversational", or "" (standard). Ignored when WordsPerMinute is
-	// set to a non-zero value.
+	// Preset selects a built-in WPM band.
 	Preset string
 	// WordsPerMinute overrides the preset when > 0.
 	WordsPerMinute int
-	// PauseFactor is a multiplicative overhead applied to the spoken-word
-	// runtime. A negative value is treated as zero.
-	PauseFactor float64
-	// pauseFactorSet disambiguates "omitted" (use default) from
-	// "explicitly zero" when PauseFactor == 0.
+	// PauseFactor is a multiplicative overhead applied to the runtime.
+	PauseFactor    float64
 	pauseFactorSet bool
 }
 
-// WithPauseFactor returns opts with PauseFactor explicitly set, including
-// zero. Use this when a caller wants to disable the pause adjustment.
+// WithPauseFactor sets PauseFactor explicitly, including zero.
 func (o RuntimeOptions) WithPauseFactor(f float64) RuntimeOptions {
 	o.PauseFactor = f
 	o.pauseFactorSet = true
 	return o
 }
 
-// RuntimeEstimate describes a rough performance length in minutes. It is
-// derived from dialogue word count and is explicitly an estimate, not a
-// prediction.
+// RuntimeEstimate describes a rough performance length in minutes.
 type RuntimeEstimate struct {
 	Preset         string  `json:"preset"`
 	WordsPerMinute int     `json:"wordsPerMinute"`
@@ -52,12 +39,7 @@ type RuntimeEstimate struct {
 	Minutes        float64 `json:"minutes"`
 }
 
-// EstimateRuntime applies the documented heuristic:
-//
-//	spoken = dialogueWords / wordsPerMinute
-//	minutes = spoken * (1 + pauseFactor)
-//
-// Only spoken dialogue contributes; stage directions and prose do not.
+// EstimateRuntime applies the documented heuristic.
 func EstimateRuntime(dialogueWords int, opts RuntimeOptions) RuntimeEstimate {
 	preset, wpm := resolvePreset(opts)
 	pause := opts.PauseFactor
@@ -82,8 +64,6 @@ func EstimateRuntime(dialogueWords int, opts RuntimeOptions) RuntimeEstimate {
 
 func resolvePreset(opts RuntimeOptions) (string, int) {
 	if opts.WordsPerMinute > 0 {
-		// A non-zero WordsPerMinute is always an explicit override; report
-		// it as "custom" so the surfaced preset matches the rate in use.
 		return "custom", opts.WordsPerMinute
 	}
 	switch strings.ToLower(strings.TrimSpace(opts.Preset)) {

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jscaltreto/downstage/internal/ast"
 )
 
-// Stats summarizes a manuscript.
 type Stats struct {
 	Acts                int              `json:"acts"`
 	Scenes              int              `json:"scenes"`
@@ -26,8 +25,7 @@ type Stats struct {
 	Runtime             RuntimeEstimate  `json:"runtime"`
 }
 
-// CharacterStats holds per-character tallies. Aliases listed in the
-// dramatis personae are folded into the primary name.
+// CharacterStats holds per-character tallies.
 type CharacterStats struct {
 	Name          string   `json:"name"`
 	Aliases       []string `json:"aliases,omitempty"`
@@ -35,9 +33,7 @@ type CharacterStats struct {
 	DialogueWords int      `json:"dialogueWords"`
 }
 
-// Compute walks the document and returns manuscript statistics. The
-// runtime field is filled in using the supplied RuntimeOptions; see
-// EstimateRuntime for the heuristic.
+// Compute returns manuscript statistics for doc.
 func Compute(doc *ast.Document, rt RuntimeOptions) Stats {
 	s := Stats{}
 	if doc == nil {
@@ -133,9 +129,7 @@ func Compute(doc *ast.Document, rt RuntimeOptions) Stats {
 	return s
 }
 
-// aliasResolver maps raw cue names (including aliases) to a canonical
-// character name using the dramatis personae. Unknown names are returned
-// upper-cased so forced cues still tally consistently.
+// aliasResolver maps raw cue names to canonical character names.
 type aliasResolver struct {
 	canonicalByKey map[string]string
 	aliasesByName  map[string][]string

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -108,8 +108,6 @@ ALICE
 Hello (softly) world.
 `
 	s := compute(t, src)
-	// "Hello" + "world" = 2 spoken words. "softly" is an inline direction
-	// and must not be counted as spoken dialogue.
 	if s.DialogueWords != 2 {
 		t.Errorf("DialogueWords = %d, want 2 (inline direction should be excluded)", s.DialogueWords)
 	}
@@ -144,10 +142,6 @@ SONG END
 }
 
 func TestComputeGenericSectionProseCounted(t *testing.T) {
-	// Prose under a non-act/scene heading is stored as Section.Lines, not
-	// as child nodes. Those words must still count toward the manuscript
-	// total — otherwise playwright's notes, credits, etc. are silently
-	// dropped from TotalWords.
 	src := `# Playwright's Notes
 
 This play was written over four months.
@@ -211,8 +205,6 @@ func TestRuntimeOverrides(t *testing.T) {
 	}
 }
 
-// A preset name supplied alongside --wpm should not leak into the
-// surfaced metadata: any explicit wpm is always "custom".
 func TestRuntimeWPMOverrideReportsCustom(t *testing.T) {
 	got := stats.EstimateRuntime(260, stats.RuntimeOptions{
 		Preset:         "standard",

--- a/web/src/__tests__/IssuesTab.test.ts
+++ b/web/src/__tests__/IssuesTab.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { mount } from "@vue/test-utils";
 import IssuesTab from "../components/shared/IssuesTab.vue";
 import type { EditorDiagnostic } from "../core/types";
+import type { FilterSeverity } from "../core/issues";
 
 function mk(overrides: Partial<EditorDiagnostic>): EditorDiagnostic {
   return {
@@ -80,7 +81,7 @@ describe("IssuesTab", () => {
     ];
 
     const wrapper = mount(IssuesTab, {
-      props: { diagnostics, hiddenSeverities: new Set() },
+      props: { diagnostics, hiddenSeverities: new Set<FilterSeverity>() },
     });
 
     expect(wrapper.findAll("li")).toHaveLength(3);
@@ -93,7 +94,7 @@ describe("IssuesTab", () => {
 
     await infoPill!.trigger("click");
 
-    const updates = wrapper.emitted("update:hiddenSeverities") as Array<[Set<string>]>;
+    const updates = wrapper.emitted("update:hiddenSeverities") as Array<[Set<FilterSeverity>]>;
     expect(updates).toBeTruthy();
     const nextSet = updates[updates.length - 1][0];
     expect(Array.from(nextSet)).toEqual(["info"]);
@@ -108,7 +109,7 @@ describe("IssuesTab", () => {
     expect(rowsText.some((t) => t.includes("stray text"))).toBe(true);
 
     await infoPill!.trigger("click");
-    const allEmits = wrapper.emitted("update:hiddenSeverities") as Array<[Set<string>]>;
+    const allEmits = wrapper.emitted("update:hiddenSeverities") as Array<[Set<FilterSeverity>]>;
     const nextNext = allEmits[allEmits.length - 1][0];
     expect(Array.from(nextNext)).toEqual([]);
     await wrapper.setProps({ hiddenSeverities: nextNext });
@@ -119,7 +120,7 @@ describe("IssuesTab", () => {
   it("shows a 'all matching issues hidden' state when every pill is toggled off", async () => {
     const diagnostics: EditorDiagnostic[] = [mk({ severity: "warning", message: "x" })];
     const wrapper = mount(IssuesTab, {
-      props: { diagnostics, hiddenSeverities: new Set(["warning"]) },
+      props: { diagnostics, hiddenSeverities: new Set<FilterSeverity>(["warning"]) },
     });
 
     expect(wrapper.findAll("li")).toHaveLength(0);

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -3,14 +3,14 @@ import { computed, onMounted, onUnmounted, ref, watch, inject, nextTick } from '
 import {
     Bold, Italic, Underline, MessageSquare, ChevronRight,
     GalleryVerticalEnd, GalleryVertical, FilePlus2, Eye, EyeOff, HelpCircle, X, Music,
-    Sun, Moon, ScrollText, BookOpenText, AlertTriangle, AlertCircle, Info, RefreshCw, SpellCheck, Trash2, Search, ListTree
+    Sun, Moon, ScrollText, BookOpenText, AlertTriangle, AlertCircle, Info, RefreshCw, SpellCheck, Trash2, Search, ListTree, BarChart3
 } from 'lucide-vue-next';
 import { Engine, type SearchMode, type SearchSummary } from '../../core/engine';
 import type { SearchMatch, SearchOptions } from '../../core/search';
 import { issuesStatus, summarizeIssues } from '../../core/issues';
 import type { FilterSeverity } from '../../core/issues';
 import type { Store } from '../../core/store';
-import type { DocumentSymbol, EditorDiagnostic, EditorEnv } from '../../core/types';
+import type { DocumentSymbol, EditorDiagnostic, EditorEnv, ManuscriptStats } from '../../core/types';
 import PreviewFrame from './PreviewFrame.vue';
 import ToolbarButton from './ToolbarButton.vue';
 import BaseModal from './BaseModal.vue';
@@ -18,6 +18,7 @@ import WorkbenchDrawer, { type WorkbenchTab } from './WorkbenchDrawer.vue';
 import IssuesTab from './IssuesTab.vue';
 import FindReplaceTab from './FindReplaceTab.vue';
 import OutlineTab from './OutlineTab.vue';
+import StatsTab from './StatsTab.vue';
 
 const props = defineProps<{
   env: EditorEnv;
@@ -53,6 +54,7 @@ const searchFocusReplace = ref(false);
 const searchFocusNonce = ref(0);
 const diagnostics = ref<EditorDiagnostic[]>([]);
 const outlineSymbols = ref<DocumentSymbol[]>([]);
+const manuscriptStats = ref<ManuscriptStats | null>(null);
 const isTyping = ref(false);
 let typingTimer: number | null = null;
 const outlineDebounceMs = 300;
@@ -95,6 +97,9 @@ let lastRenderRequestId = 0;
 let renderTimer: number | null = null;
 let outlineRequestId = 0;
 let outlineTimer: number | null = null;
+let statsRequestId = 0;
+let statsTimer: number | null = null;
+const statsDebounceMs = 500;
 const v1DiagnosticCode = "v1-document";
 
 function scheduleOutlineRefresh(content: string) {
@@ -111,6 +116,22 @@ function scheduleOutlineRefresh(content: string) {
             outlineSymbols.value = [];
         }
     }, outlineDebounceMs);
+}
+
+function scheduleStatsRefresh(content: string) {
+    if (statsTimer) window.clearTimeout(statsTimer);
+    statsTimer = window.setTimeout(async () => {
+        statsTimer = null;
+        const requestId = ++statsRequestId;
+        try {
+            const result = await props.env.stats(content);
+            if (requestId !== statsRequestId) return;
+            manuscriptStats.value = result;
+        } catch {
+            if (requestId !== statsRequestId) return;
+            manuscriptStats.value = null;
+        }
+    }, statsDebounceMs);
 }
 
 function setV1DocumentDetected(detected: boolean) {
@@ -213,6 +234,7 @@ onMounted(async () => {
         emit('update:content', content);
         scheduleRender(content, props.style);
         scheduleOutlineRefresh(content);
+        scheduleStatsRefresh(content);
         if (info.userInput) {
           markTyping();
         }
@@ -227,6 +249,7 @@ onMounted(async () => {
     engine.init(props.content, store.state.isDark, spellcheckEnabled.value);
     scheduleRender(props.content, props.style);
     scheduleOutlineRefresh(props.content);
+    scheduleStatsRefresh(props.content);
   }
 });
 
@@ -234,6 +257,7 @@ onUnmounted(() => {
   engine?.destroy();
   if (renderTimer) window.clearTimeout(renderTimer);
   if (outlineTimer) window.clearTimeout(outlineTimer);
+  if (statsTimer) window.clearTimeout(statsTimer);
   if (typingTimer) window.clearTimeout(typingTimer);
 });
 
@@ -247,6 +271,7 @@ watch(() => props.content, (newContent) => {
   }
   scheduleRender(newContent, props.style);
   scheduleOutlineRefresh(newContent);
+  scheduleStatsRefresh(newContent);
 });
 
 watch(() => store.state.activeDraftId, () => {
@@ -326,6 +351,15 @@ function toggleOutline() {
     drawerOpen.value = true;
 }
 
+function toggleStats() {
+    if (drawerOpen.value && drawerTab.value === 'stats') {
+        closeDrawer();
+        return;
+    }
+    drawerTab.value = 'stats';
+    drawerOpen.value = true;
+}
+
 function closeDrawer() {
     drawerOpen.value = false;
     engine?.clearSearch();
@@ -385,6 +419,14 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
                 title="Outline"
             >
                 <template #icon><ListTree class="w-4 h-4" /></template>
+            </ToolbarButton>
+
+            <ToolbarButton
+                @click="toggleStats"
+                :active="drawerOpen && drawerTab === 'stats'"
+                title="Stats"
+            >
+                <template #icon><BarChart3 class="w-4 h-4" /></template>
             </ToolbarButton>
         </div>
 
@@ -510,6 +552,9 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
                         :symbols="outlineSymbols"
                         @jump="jumpToSymbol"
                     />
+                </template>
+                <template #stats>
+                    <StatsTab :stats="manuscriptStats" />
                 </template>
             </WorkbenchDrawer>
         </div>

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -55,6 +55,7 @@ const searchFocusNonce = ref(0);
 const diagnostics = ref<EditorDiagnostic[]>([]);
 const outlineSymbols = ref<DocumentSymbol[]>([]);
 const manuscriptStats = ref<ManuscriptStats | null>(null);
+const manuscriptStatsLoading = ref(false);
 const isTyping = ref(false);
 let typingTimer: number | null = null;
 const outlineDebounceMs = 300;
@@ -120,6 +121,7 @@ function scheduleOutlineRefresh(content: string) {
 
 function scheduleStatsRefresh(content: string) {
     if (statsTimer) window.clearTimeout(statsTimer);
+    manuscriptStatsLoading.value = true;
     statsTimer = window.setTimeout(async () => {
         statsTimer = null;
         const requestId = ++statsRequestId;
@@ -130,6 +132,10 @@ function scheduleStatsRefresh(content: string) {
         } catch {
             if (requestId !== statsRequestId) return;
             manuscriptStats.value = null;
+        } finally {
+            if (requestId === statsRequestId) {
+                manuscriptStatsLoading.value = false;
+            }
         }
     }, statsDebounceMs);
 }
@@ -278,6 +284,7 @@ watch(() => store.state.activeDraftId, () => {
   showV1Modal.value = false;
   diagnostics.value = [];
   manuscriptStats.value = null;
+  manuscriptStatsLoading.value = true;
   engine?.refreshDiagnostics();
   engine?.clearSearch();
   searchMatches.value = [];
@@ -338,27 +345,25 @@ function jumpToSymbol(symbol: DocumentSymbol) {
     engine?.revealPosition(start.line, start.character);
 }
 
-function openIssuesTab() {
-    drawerTab.value = 'issues';
+function openWorkbenchTab(tab: WorkbenchTab) {
+    if (drawerOpen.value && drawerTab.value === tab) {
+        closeDrawer();
+        return;
+    }
+    drawerTab.value = tab;
     drawerOpen.value = true;
 }
 
 function toggleOutline() {
-    if (drawerOpen.value && drawerTab.value === 'outline') {
-        closeDrawer();
-        return;
-    }
-    drawerTab.value = 'outline';
-    drawerOpen.value = true;
+    openWorkbenchTab('outline');
 }
 
 function toggleStats() {
-    if (drawerOpen.value && drawerTab.value === 'stats') {
-        closeDrawer();
-        return;
-    }
-    drawerTab.value = 'stats';
-    drawerOpen.value = true;
+    openWorkbenchTab('stats');
+}
+
+function openIssuesTab() {
+    openWorkbenchTab('issues');
 }
 
 function closeDrawer() {
@@ -555,7 +560,7 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
                     />
                 </template>
                 <template #stats>
-                    <StatsTab :stats="manuscriptStats" />
+                    <StatsTab :stats="manuscriptStats" :loading="manuscriptStatsLoading" />
                 </template>
             </WorkbenchDrawer>
         </div>

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -277,6 +277,7 @@ watch(() => props.content, (newContent) => {
 watch(() => store.state.activeDraftId, () => {
   showV1Modal.value = false;
   diagnostics.value = [];
+  manuscriptStats.value = null;
   engine?.refreshDiagnostics();
   engine?.clearSearch();
   searchMatches.value = [];

--- a/web/src/components/shared/StatsTab.vue
+++ b/web/src/components/shared/StatsTab.vue
@@ -9,8 +9,9 @@ const props = defineProps<{
 
 function formatRuntime(minutes: number): string {
   if (minutes < 1) return '< 1 min';
-  const h = Math.floor(minutes / 60);
-  const m = Math.round(minutes % 60);
+  const total = Math.round(minutes);
+  const h = Math.floor(total / 60);
+  const m = total % 60;
   if (h === 0) return `${m} min`;
   if (m === 0) return `${h} hr`;
   return `${h} hr ${m} min`;
@@ -27,7 +28,7 @@ const topCharacters = computed(() => {
 
 const maxCharacterWords = computed(() => {
   if (topCharacters.value.length === 0) return 1;
-  return Math.max(1, topCharacters.value[0]?.dialogueWords ?? 1);
+  return Math.max(1, ...topCharacters.value.map(c => c.dialogueWords));
 });
 </script>
 

--- a/web/src/components/shared/StatsTab.vue
+++ b/web/src/components/shared/StatsTab.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { BarChart3, Clock, Users, MessageSquare, ChevronRight, Music, GalleryVerticalEnd, GalleryVertical } from 'lucide-vue-next';
+import type { ManuscriptStats } from '../../core/types';
+
+const props = defineProps<{
+  stats: ManuscriptStats | null;
+}>();
+
+function formatRuntime(minutes: number): string {
+  if (minutes < 1) return '< 1 min';
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes % 60);
+  if (h === 0) return `${m} min`;
+  if (m === 0) return `${h} hr`;
+  return `${h} hr ${m} min`;
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString();
+}
+
+const topCharacters = computed(() => {
+  if (!props.stats) return [];
+  return props.stats.characters.slice(0, 20);
+});
+
+const maxCharacterWords = computed(() => {
+  if (topCharacters.value.length === 0) return 1;
+  return Math.max(1, topCharacters.value[0]?.dialogueWords ?? 1);
+});
+</script>
+
+<template>
+  <div class="flex flex-1 flex-col overflow-hidden">
+    <div
+      v-if="!stats"
+      class="flex flex-1 flex-col items-center justify-center gap-2 text-text-muted"
+    >
+      <div class="flex h-10 w-10 items-center justify-center rounded-full bg-black/5 text-text-muted dark:bg-white/5">
+        <BarChart3 class="h-5 w-5" />
+      </div>
+      <p class="text-sm font-medium text-text-main">No stats available</p>
+      <p class="text-xs">Start writing to see manuscript statistics.</p>
+    </div>
+
+    <div v-else class="flex-1 overflow-y-auto">
+      <div class="grid grid-cols-2 gap-2 p-3 sm:grid-cols-4">
+        <div class="rounded-lg border border-border bg-black/[0.03] p-2.5 dark:bg-white/[0.03]">
+          <div class="flex items-center gap-1.5 text-text-muted">
+            <Clock class="h-3 w-3" />
+            <span class="text-[10px] font-bold uppercase tracking-[0.15em]">Runtime</span>
+          </div>
+          <p class="mt-1 text-sm font-bold text-text-main">{{ formatRuntime(stats.runtime.minutes) }}</p>
+        </div>
+        <div class="rounded-lg border border-border bg-black/[0.03] p-2.5 dark:bg-white/[0.03]">
+          <div class="flex items-center gap-1.5 text-text-muted">
+            <MessageSquare class="h-3 w-3" />
+            <span class="text-[10px] font-bold uppercase tracking-[0.15em]">Words</span>
+          </div>
+          <p class="mt-1 text-sm font-bold text-text-main">{{ formatNumber(stats.totalWords) }}</p>
+          <p class="text-[10px] text-text-muted">{{ formatNumber(stats.dialogueWords) }} dialogue</p>
+        </div>
+        <div class="rounded-lg border border-border bg-black/[0.03] p-2.5 dark:bg-white/[0.03]">
+          <div class="flex items-center gap-1.5 text-text-muted">
+            <GalleryVerticalEnd class="h-3 w-3" />
+            <span class="text-[10px] font-bold uppercase tracking-[0.15em]">Structure</span>
+          </div>
+          <p class="mt-1 text-sm font-bold text-text-main">{{ stats.acts }} act{{ stats.acts === 1 ? '' : 's' }}</p>
+          <p class="text-[10px] text-text-muted">{{ stats.scenes }} scene{{ stats.scenes === 1 ? '' : 's' }}</p>
+        </div>
+        <div class="rounded-lg border border-border bg-black/[0.03] p-2.5 dark:bg-white/[0.03]">
+          <div class="flex items-center gap-1.5 text-text-muted">
+            <ChevronRight class="h-3 w-3" />
+            <span class="text-[10px] font-bold uppercase tracking-[0.15em]">Directions</span>
+          </div>
+          <p class="mt-1 text-sm font-bold text-text-main">{{ formatNumber(stats.stageDirections) }}</p>
+          <p class="text-[10px] text-text-muted">{{ formatNumber(stats.stageDirectionWords) }} words</p>
+        </div>
+      </div>
+
+      <div v-if="stats.songs > 0" class="px-3 pb-2">
+        <div class="inline-flex items-center gap-1.5 rounded-md border border-border bg-black/[0.03] px-2.5 py-1.5 dark:bg-white/[0.03]">
+          <Music class="h-3 w-3 text-text-muted" />
+          <span class="text-xs font-medium text-text-main">{{ stats.songs }} song{{ stats.songs === 1 ? '' : 's' }}</span>
+        </div>
+      </div>
+
+      <div v-if="topCharacters.length > 0" class="border-t border-border px-3 py-2">
+        <div class="flex items-center gap-1.5 pb-2 text-text-muted">
+          <Users class="h-3 w-3" />
+          <span class="text-[10px] font-bold uppercase tracking-[0.15em]">Characters ({{ stats.characters.length }})</span>
+        </div>
+        <div class="flex flex-col gap-1">
+          <div
+            v-for="char in topCharacters"
+            :key="char.name"
+            class="group flex items-center gap-2 rounded px-1.5 py-1"
+          >
+            <span class="w-28 shrink-0 truncate text-xs font-medium text-text-main" :title="char.name">{{ char.name }}</span>
+            <div class="relative flex-1 h-3 rounded-sm bg-black/5 dark:bg-white/5 overflow-hidden">
+              <div
+                class="absolute inset-y-0 left-0 rounded-sm bg-brass-500/40"
+                :style="{ width: `${Math.max(2, (char.dialogueWords / maxCharacterWords) * 100)}%` }"
+              ></div>
+            </div>
+            <span class="shrink-0 text-[10px] tabular-nums text-text-muted">{{ char.lines }}L / {{ formatNumber(char.dialogueWords) }}W</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="border-t border-border px-3 py-2">
+        <p class="text-[10px] text-text-muted">
+          Runtime estimate based on {{ stats.runtime.wordsPerMinute }} WPM ({{ stats.runtime.preset }}) with {{ Math.round(stats.runtime.pauseFactor * 100) }}% pause factor.
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/components/shared/StatsTab.vue
+++ b/web/src/components/shared/StatsTab.vue
@@ -49,7 +49,7 @@ const maxCharacterWords = computed(() => {
         <div class="rounded-lg border border-border bg-black/[0.03] p-2.5 dark:bg-white/[0.03]">
           <div class="flex items-center gap-1.5 text-text-muted">
             <Clock class="h-3 w-3" />
-            <span class="text-[10px] font-bold uppercase tracking-[0.15em]">Runtime</span>
+            <span class="text-[10px] font-bold uppercase tracking-[0.15em]">Est. Runtime<sup class="text-text-muted">&dagger;</sup></span>
           </div>
           <p class="mt-1 text-sm font-bold text-text-main">{{ formatRuntime(stats.runtime.minutes) }}</p>
         </div>
@@ -111,7 +111,7 @@ const maxCharacterWords = computed(() => {
 
       <div class="border-t border-border px-3 py-2">
         <p class="text-[10px] text-text-muted">
-          Runtime estimate based on {{ stats.runtime.wordsPerMinute }} WPM ({{ stats.runtime.preset }}) with {{ Math.round(stats.runtime.pauseFactor * 100) }}% pause factor.
+  &dagger; Runtime estimate based on {{ stats.runtime.wordsPerMinute }} WPM ({{ stats.runtime.preset }}) with {{ Math.round(stats.runtime.pauseFactor * 100) }}% pause factor.
         </p>
       </div>
     </div>

--- a/web/src/components/shared/StatsTab.vue
+++ b/web/src/components/shared/StatsTab.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { BarChart3, Clock, Users, MessageSquare, ChevronRight, Music, GalleryVerticalEnd, GalleryVertical } from 'lucide-vue-next';
+import { BarChart3, ChevronRight, Clock, GalleryVerticalEnd, MessageSquare, Music, RefreshCw, Users } from 'lucide-vue-next';
 import type { ManuscriptStats } from '../../core/types';
 
 const props = defineProps<{
   stats: ManuscriptStats | null;
+  loading?: boolean;
 }>();
 
 function formatRuntime(minutes: number): string {
@@ -33,61 +34,72 @@ const maxCharacterWords = computed(() => {
 </script>
 
 <template>
-  <div class="flex flex-1 flex-col overflow-hidden">
+  <div class="relative flex flex-1 flex-col overflow-hidden bg-[var(--color-page-surface)]">
     <div
-      v-if="!stats"
-      class="flex flex-1 flex-col items-center justify-center gap-2 text-text-muted"
+      v-if="loading && !stats"
+      class="relative z-10 flex flex-1 flex-col items-center justify-center gap-2 px-4 text-text-muted"
     >
-      <div class="flex h-10 w-10 items-center justify-center rounded-full bg-black/5 text-text-muted dark:bg-white/5">
-        <BarChart3 class="h-5 w-5" />
+      <div class="flex h-11 w-11 items-center justify-center rounded-full border border-border/70 bg-white/70 text-accent shadow-sm backdrop-blur dark:bg-black/20">
+        <RefreshCw class="h-5 w-5 animate-spin" />
       </div>
-      <p class="text-sm font-medium text-text-main">No stats available</p>
-      <p class="text-xs">Start writing to see manuscript statistics.</p>
+      <p class="text-sm font-medium text-text-main">Calculating stats</p>
+      <p class="text-xs">This usually takes a moment after you pause typing.</p>
     </div>
 
-    <div v-else class="flex-1 overflow-y-auto">
-      <div class="grid grid-cols-2 gap-2 p-3 sm:grid-cols-4">
-        <div class="rounded-lg border border-border bg-black/[0.03] p-2.5 dark:bg-white/[0.03]">
+    <div
+      v-else-if="!stats"
+      class="relative z-10 flex flex-1 flex-col items-center justify-center gap-2 px-4 text-text-muted"
+    >
+      <div class="flex h-11 w-11 items-center justify-center rounded-full border border-border/70 bg-white/70 text-accent shadow-sm backdrop-blur dark:bg-black/20">
+        <BarChart3 class="h-5 w-5" />
+      </div>
+      <p class="text-sm font-medium text-text-main">Stats unavailable</p>
+      <p class="text-xs">Try again after making an edit.</p>
+    </div>
+
+    <div v-else class="relative z-10 flex-1 overflow-y-auto">
+      <div class="grid grid-cols-2 gap-2 px-3 pb-3 pt-3 sm:grid-cols-4">
+        <div class="rounded-xl border border-border bg-white/70 p-2.5 shadow-sm backdrop-blur dark:bg-black/20">
           <div class="flex items-center gap-1.5 text-text-muted">
             <Clock class="h-3 w-3" />
             <span class="text-[10px] font-bold uppercase tracking-[0.15em]">Est. Runtime<sup class="text-text-muted">&dagger;</sup></span>
           </div>
-          <p class="mt-1 text-sm font-bold text-text-main">{{ formatRuntime(stats.runtime.minutes) }}</p>
+          <p class="mt-1 text-base font-bold text-text-main">{{ formatRuntime(stats.runtime.minutes) }}</p>
         </div>
-        <div class="rounded-lg border border-border bg-black/[0.03] p-2.5 dark:bg-white/[0.03]">
+        <div class="rounded-xl border border-border bg-white/70 p-2.5 shadow-sm backdrop-blur dark:bg-black/20">
           <div class="flex items-center gap-1.5 text-text-muted">
             <MessageSquare class="h-3 w-3" />
             <span class="text-[10px] font-bold uppercase tracking-[0.15em]">Words</span>
           </div>
-          <p class="mt-1 text-sm font-bold text-text-main">{{ formatNumber(stats.totalWords) }}</p>
+          <p class="mt-1 text-base font-bold text-text-main">{{ formatNumber(stats.totalWords) }}</p>
           <p class="text-[10px] text-text-muted">{{ formatNumber(stats.dialogueWords) }} dialogue</p>
         </div>
-        <div class="rounded-lg border border-border bg-black/[0.03] p-2.5 dark:bg-white/[0.03]">
+        <div class="rounded-xl border border-border bg-white/70 p-2.5 shadow-sm backdrop-blur dark:bg-black/20">
           <div class="flex items-center gap-1.5 text-text-muted">
             <GalleryVerticalEnd class="h-3 w-3" />
             <span class="text-[10px] font-bold uppercase tracking-[0.15em]">Structure</span>
           </div>
-          <p class="mt-1 text-sm font-bold text-text-main">{{ stats.acts }} act{{ stats.acts === 1 ? '' : 's' }}</p>
+          <p class="mt-1 text-base font-bold text-text-main">{{ stats.acts }} act{{ stats.acts === 1 ? '' : 's' }}</p>
           <p class="text-[10px] text-text-muted">{{ stats.scenes }} scene{{ stats.scenes === 1 ? '' : 's' }}</p>
         </div>
-        <div class="rounded-lg border border-border bg-black/[0.03] p-2.5 dark:bg-white/[0.03]">
+        <div class="rounded-xl border border-border bg-white/70 p-2.5 shadow-sm backdrop-blur dark:bg-black/20">
           <div class="flex items-center gap-1.5 text-text-muted">
             <ChevronRight class="h-3 w-3" />
-            <span class="text-[10px] font-bold uppercase tracking-[0.15em]">Directions</span>
+            <span class="text-[10px] font-bold uppercase tracking-[0.15em]">Stage Directions</span>
           </div>
-          <p class="mt-1 text-sm font-bold text-text-main">{{ formatNumber(stats.stageDirections) }}</p>
+          <p class="mt-1 text-base font-bold text-text-main">{{ formatNumber(stats.stageDirections) }}</p>
           <p class="text-[10px] text-text-muted">{{ formatNumber(stats.stageDirectionWords) }} words</p>
         </div>
       </div>
 
       <div v-if="stats.songs > 0" class="px-3 pb-2">
-        <div class="inline-flex items-center gap-1.5 rounded-md border border-border bg-black/[0.03] px-2.5 py-1.5 dark:bg-white/[0.03]">
-          <Music class="h-3 w-3 text-text-muted" />
-          <span class="text-xs font-medium text-text-main">{{ stats.songs }} song{{ stats.songs === 1 ? '' : 's' }}</span>
+        <div class="inline-flex items-center gap-1.5 rounded-full border border-brass-500/20 bg-brass-500/10 px-2.5 py-1 text-[11px] font-medium text-text-main shadow-sm">
+          <Music class="h-3 w-3 text-brass-700 dark:text-brass-300" />
+          <span>{{ stats.songs }} song{{ stats.songs === 1 ? '' : 's' }}</span>
         </div>
       </div>
 
-      <div v-if="topCharacters.length > 0" class="border-t border-border px-3 py-2">
+      <div v-if="topCharacters.length > 0" class="border-t border-border/80 px-3 py-2">
         <div class="flex items-center gap-1.5 pb-2 text-text-muted">
           <Users class="h-3 w-3" />
           <span class="text-[10px] font-bold uppercase tracking-[0.15em]">Characters ({{ stats.characters.length }})</span>
@@ -96,12 +108,12 @@ const maxCharacterWords = computed(() => {
           <div
             v-for="char in topCharacters"
             :key="char.name"
-            class="group flex items-center gap-2 rounded px-1.5 py-1"
+            class="group flex items-center gap-2 rounded-lg px-1.5 py-1 transition-colors hover:bg-black/[0.03] dark:hover:bg-white/[0.04]"
           >
             <span class="w-28 shrink-0 truncate text-xs font-medium text-text-main" :title="char.name">{{ char.name }}</span>
-            <div class="relative flex-1 h-3 rounded-sm bg-black/5 dark:bg-white/5 overflow-hidden">
+            <div class="relative h-3 flex-1 overflow-hidden rounded-full bg-black/5 dark:bg-white/5">
               <div
-                class="absolute inset-y-0 left-0 rounded-sm bg-brass-500/40"
+                class="absolute inset-y-0 left-0 rounded-full bg-brass-500/40"
                 :style="{ width: `${Math.max(2, (char.dialogueWords / maxCharacterWords) * 100)}%` }"
               ></div>
             </div>
@@ -110,9 +122,9 @@ const maxCharacterWords = computed(() => {
         </div>
       </div>
 
-      <div class="border-t border-border px-3 py-2">
-        <p class="text-[10px] text-text-muted">
-  &dagger; Runtime estimate based on {{ stats.runtime.wordsPerMinute }} WPM ({{ stats.runtime.preset }}) with {{ Math.round(stats.runtime.pauseFactor * 100) }}% pause factor.
+      <div class="border-t border-border/80 px-3 py-2">
+        <p class="rounded-lg bg-black/[0.03] px-2 py-1.5 text-[10px] leading-relaxed text-text-muted dark:bg-white/[0.04]">
+          &dagger; Runtime estimate based on {{ stats.runtime.wordsPerMinute }} WPM ({{ stats.runtime.preset }}) and about {{ Math.round(stats.runtime.pauseFactor * 100) }}% extra time for pauses and beats.
         </p>
       </div>
     </div>

--- a/web/src/components/shared/WorkbenchDrawer.vue
+++ b/web/src/components/shared/WorkbenchDrawer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { X, AlertTriangle, Search, ListTree } from 'lucide-vue-next';
+import { X, AlertTriangle, Search, ListTree, BarChart3 } from 'lucide-vue-next';
 
-export type WorkbenchTab = 'issues' | 'find' | 'outline';
+export type WorkbenchTab = 'issues' | 'find' | 'outline' | 'stats';
 
 defineProps<{
   open: boolean;
@@ -73,6 +73,19 @@ function switchTab(tab: WorkbenchTab) {
           <Search class="h-3.5 w-3.5" />
           <span>Find &amp; Replace</span>
         </button>
+        <button
+          type="button"
+          role="tab"
+          :aria-selected="activeTab === 'stats'"
+          class="flex items-center gap-2 px-3 py-2.5 text-[10px] font-bold uppercase tracking-[0.2em] border-b-2 transition-colors"
+          :class="activeTab === 'stats'
+            ? 'border-brass-500 text-accent'
+            : 'border-transparent text-text-muted hover:text-text-main'"
+          @click="switchTab('stats')"
+        >
+          <BarChart3 class="h-3.5 w-3.5" />
+          <span>Stats</span>
+        </button>
       </div>
       <button
         type="button"
@@ -93,6 +106,9 @@ function switchTab(tab: WorkbenchTab) {
       </div>
       <div v-show="activeTab === 'outline'" class="flex h-full min-w-0 flex-col overflow-hidden">
         <slot name="outline" />
+      </div>
+      <div v-show="activeTab === 'stats'" class="flex h-full min-w-0 flex-col overflow-hidden">
+        <slot name="stats" />
       </div>
     </div>
   </section>

--- a/web/src/components/shared/WorkbenchDrawer.vue
+++ b/web/src/components/shared/WorkbenchDrawer.vue
@@ -46,6 +46,19 @@ function switchTab(tab: WorkbenchTab) {
         <button
           type="button"
           role="tab"
+          :aria-selected="activeTab === 'stats'"
+          class="flex items-center gap-2 px-3 py-2.5 text-[10px] font-bold uppercase tracking-[0.2em] border-b-2 transition-colors"
+          :class="activeTab === 'stats'
+            ? 'border-brass-500 text-accent'
+            : 'border-transparent text-text-muted hover:text-text-main'"
+          @click="switchTab('stats')"
+        >
+          <BarChart3 class="h-3.5 w-3.5" />
+          <span>Stats</span>
+        </button>
+        <button
+          type="button"
+          role="tab"
           :aria-selected="activeTab === 'issues'"
           class="flex items-center gap-2 px-3 py-2.5 text-[10px] font-bold uppercase tracking-[0.2em] border-b-2 transition-colors"
           :class="activeTab === 'issues'
@@ -73,19 +86,6 @@ function switchTab(tab: WorkbenchTab) {
           <Search class="h-3.5 w-3.5" />
           <span>Find &amp; Replace</span>
         </button>
-        <button
-          type="button"
-          role="tab"
-          :aria-selected="activeTab === 'stats'"
-          class="flex items-center gap-2 px-3 py-2.5 text-[10px] font-bold uppercase tracking-[0.2em] border-b-2 transition-colors"
-          :class="activeTab === 'stats'
-            ? 'border-brass-500 text-accent'
-            : 'border-transparent text-text-muted hover:text-text-main'"
-          @click="switchTab('stats')"
-        >
-          <BarChart3 class="h-3.5 w-3.5" />
-          <span>Stats</span>
-        </button>
       </div>
       <button
         type="button"
@@ -98,17 +98,17 @@ function switchTab(tab: WorkbenchTab) {
     </header>
 
     <div class="flex-1 min-h-0 min-w-0 overflow-hidden">
-      <div v-show="activeTab === 'issues'" class="flex h-full min-w-0 flex-col overflow-hidden">
-        <slot name="issues" />
-      </div>
-      <div v-show="activeTab === 'find'" class="flex h-full min-w-0 flex-col overflow-hidden">
-        <slot name="find" />
-      </div>
       <div v-show="activeTab === 'outline'" class="flex h-full min-w-0 flex-col overflow-hidden">
         <slot name="outline" />
       </div>
       <div v-show="activeTab === 'stats'" class="flex h-full min-w-0 flex-col overflow-hidden">
         <slot name="stats" />
+      </div>
+      <div v-show="activeTab === 'issues'" class="flex h-full min-w-0 flex-col overflow-hidden">
+        <slot name="issues" />
+      </div>
+      <div v-show="activeTab === 'find'" class="flex h-full min-w-0 flex-col overflow-hidden">
+        <slot name="find" />
       </div>
     </div>
   </section>

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -84,6 +84,34 @@ export interface DocumentSymbolsResult {
   symbols: DocumentSymbol[];
 }
 
+export interface CharacterStats {
+  name: string;
+  aliases?: string[];
+  lines: number;
+  dialogueWords: number;
+}
+
+export interface RuntimeEstimate {
+  preset: string;
+  wordsPerMinute: number;
+  pauseFactor: number;
+  dialogueWords: number;
+  minutes: number;
+}
+
+export interface ManuscriptStats {
+  acts: number;
+  scenes: number;
+  songs: number;
+  totalWords: number;
+  dialogueWords: number;
+  lines: number;
+  stageDirections: number;
+  stageDirectionWords: number;
+  characters: CharacterStats[];
+  runtime: RuntimeEstimate;
+}
+
 export interface SpellcheckRange {
   start: LSPPosition;
   end: LSPPosition;
@@ -123,6 +151,7 @@ export interface EditorEnv {
   documentSymbols(source: string): Promise<DocumentSymbolsResult>;
   semanticTokens(source: string): Promise<Uint32Array>;
   tokenTypeNames(): Promise<string[]>;
+  stats(source: string): Promise<ManuscriptStats>;
 
   // Rendering
   renderHTML(source: string, style?: string): Promise<string>;

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -7,6 +7,7 @@ import type {
   LSPCodeActionsResult,
   SpellcheckContext,
   DocumentSymbolsResult,
+  ManuscriptStats,
 } from "./core/types";
 
 declare class Go {
@@ -28,6 +29,7 @@ declare global {
       renderHTML(source: string, style?: string): string;
       renderPDF(source: string, style?: string): Uint8Array;
       semanticTokens(source: string): Uint32Array;
+      stats(source: string): ManuscriptStats;
       tokenTypeNames: string[];
     };
   }
@@ -136,6 +138,10 @@ export function renderHTML(source: string, style?: string): string {
 
 export function renderPDF(source: string, style?: string): Uint8Array {
   return window.downstage.renderPDF(source, style);
+}
+
+export function stats(source: string): ManuscriptStats {
+  return window.downstage.stats(source);
 }
 
 export function semanticTokens(source: string): Uint32Array {

--- a/web/src/web-app.ts
+++ b/web/src/web-app.ts
@@ -11,6 +11,7 @@ import type {
   LSPCodeActionsResult,
   SpellcheckContext,
   DocumentSymbolsResult,
+  ManuscriptStats,
 } from "./core/types";
 
 declare const __APP_VERSION__: string;
@@ -81,6 +82,10 @@ class WebEnv implements EditorEnv {
 
   async tokenTypeNames(): Promise<string[]> {
     return Array.from(window.downstage.tokenTypeNames);
+  }
+
+  async stats(source: string): Promise<ManuscriptStats> {
+    return window.downstage.stats(source);
   }
 
   async renderHTML(source: string, style?: string): Promise<string> {


### PR DESCRIPTION
## Summary
- Expose `stats.Compute` through the WASM bridge so the web editor can compute manuscript statistics without duplicating logic.
- Add a **Stats** tab to the workbench drawer (between Outline and Issues) showing estimated runtime, word counts, structural breakdown, song count, and a per-character dialogue chart.
- Add a toolbar toggle button (bar-chart icon) that opens/closes the stats drawer.
- Wire a loading state so draft switches show a spinner instead of stale data from the previous manuscript.

Also includes:
- Fix pre-existing type errors in `IssuesTab.test.ts` (missing `FilterSeverity` generics).
- Trim verbose Go doc comments in the stats package.

Closes #157

## Test plan
- [x] `go test ./internal/stats/...` passes
- [x] `vue-tsc --noEmit` clean (no new errors)
- [x] `vitest run` — 8 files, 54 tests pass
- [x] `npm run build` succeeds
- [x] Manual: open the web editor, write a script with multiple characters, verify stats tab shows correct counts and runtime
- [x] Manual: switch drafts and confirm stats clear + reload without showing stale data
- [x] Manual: verify toolbar toggle highlights when stats tab is active and deactivates on close