### PR TITLE
feat(web): replace quick reference with help drawer

### DIFF
--- a/web/src/AppWeb.vue
+++ b/web/src/AppWeb.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, provide, onMounted, ref, watch, onUnmounted } from 'vue';
 import {
-    Plus, FolderOpen, FileText, Download, Copy, ExternalLink, Trash2, X, FileOutput, Upload, AlertTriangle
+    Plus, FolderOpen, FileText, Download, Copy, ExternalLink, Trash2, FileOutput, Upload, AlertTriangle
 } from 'lucide-vue-next';
 import { Store } from './core/store';
 import type { EditorEnv, SavedDraft } from './core/types';
@@ -19,12 +19,10 @@ const props = defineProps<{
 const store = new Store(props.env);
 provide('store', store);
 
-const quickReferenceStorageKey = "downstage-quick-reference-hidden";
 const welcomeStorageKey = "downstage-editor-welcome-dismissed";
 
 const isLoaded = ref(false);
 const showDrafts = ref(false);
-const showQuickReference = ref(false);
 const showWelcome = ref(false);
 const showNewPlayConfirm = ref(false);
 const activeContent = ref("");
@@ -155,7 +153,6 @@ onMounted(async () => {
     showPendingPlaceholder("The Example Play", exampleContent);
   }
 
-  showQuickReference.value = localStorage.getItem(quickReferenceStorageKey) === "false";
   showWelcome.value = localStorage.getItem(welcomeStorageKey) !== "true";
   isLoaded.value = true;
 
@@ -230,11 +227,6 @@ function flushDrafts() {
 function dismissWelcome() {
   showWelcome.value = false;
   localStorage.setItem(welcomeStorageKey, "true");
-}
-
-function openQuickReferenceFromWelcome() {
-  showQuickReference.value = true;
-  dismissWelcome();
 }
 
 function handleNewPlay() {
@@ -345,9 +337,6 @@ watch(activeContent, (newContent) => {
     }
 });
 
-watch(showQuickReference, (val) => {
-    localStorage.setItem(quickReferenceStorageKey, String(!val));
-});
 </script>
 
 <template>
@@ -386,88 +375,13 @@ watch(showQuickReference, (val) => {
     </div>
 
     <main v-else class="flex-1 overflow-hidden flex flex-col">
-      <section
-        v-if="showQuickReference"
-        class="border-b border-border bg-[var(--color-page-surface)] px-4 py-3 shadow-sm"
-      >
-        <div class="mx-auto flex max-w-7xl flex-col gap-3">
-          <div class="flex items-start justify-between gap-4">
-            <div>
-              <h2 class="text-[10px] font-bold uppercase tracking-[0.2em] text-brass-500">Quick Reference</h2>
-              <p class="mt-1 text-sm text-text-muted">
-                The basics only. Keep writing, and open the
-                <button
-                  class="font-bold text-brass-500 underline decoration-brass-500/40 underline-offset-2 hover:text-brass-400"
-                  @click="env.openURL('https://www.getdownstage.com/syntax/')"
-                >
-                  Syntax Guide
-                </button>
-                for the full spec.
-              </p>
-            </div>
-            <button
-              class="rounded-full p-2 text-text-muted transition-colors hover:bg-black/5 hover:text-text-main dark:hover:bg-white/5"
-              @click="showQuickReference = false"
-              aria-label="Close quick reference"
-            >
-              <X class="h-5 w-5" />
-            </button>
-          </div>
-
-          <dl class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
-            <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-              <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Play Header</dt>
-              <dd>
-                <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code># My Play
-Subtitle: A Play in One Act
-Author: Your Name
-Draft: First</code></pre>
-              </dd>
-            </div>
-
-            <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-              <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Cue + Dialogue</dt>
-              <dd>
-                <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>ALICE
-I know this looks reckless.</code></pre>
-              </dd>
-            </div>
-
-            <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-              <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Stage Direction</dt>
-              <dd>
-                <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>&gt; The lights cut to black.</code></pre>
-              </dd>
-            </div>
-
-            <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-              <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Structure</dt>
-              <dd>
-                <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>## ACT I
-### SCENE 1</code></pre>
-              </dd>
-            </div>
-
-            <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-              <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Emphasis</dt>
-              <dd>
-                <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>**bold**
-*italic*
-_underline_</code></pre>
-              </dd>
-            </div>
-          </dl>
-        </div>
-      </section>
-
-      <Editor 
+      <Editor
         :env="env"
         v-model:content="activeContent"
         v-model:style="pageStyle"
         :get-spell-allowlist="() => activeSavedDraft?.spellAllowlist || []"
         :add-spell-allowlist-word="addSpellAllowlistWord"
         :remove-spell-allowlist-word="removeSpellAllowlistWord"
-        @toggle-help="showQuickReference = !showQuickReference"
         @migration-state-change="isV1Document = $event"
       />
     </main>
@@ -569,7 +483,6 @@ _underline_</code></pre>
     <WelcomeModal
         :open="showWelcome"
         @close="dismissWelcome"
-        @open-quick-reference="openQuickReferenceFromWelcome"
     />
 
     <ToastManager ref="toastManager" />

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -20,6 +20,7 @@ import FindReplaceTab from './FindReplaceTab.vue';
 import OutlineTab from './OutlineTab.vue';
 import StatsTab from './StatsTab.vue';
 import HelpTab from './HelpTab.vue';
+import { shortcuts as sc } from '../../core/platform';
 
 const props = defineProps<{
   env: EditorEnv;
@@ -395,9 +396,9 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
   <div class="flex-1 flex flex-col overflow-hidden bg-[var(--color-page-bg)]">
     <div class="px-4 py-2 border-b border-border bg-[var(--color-toolbar-bg)] flex items-center justify-between gap-2 shadow-sm z-10">
         <div class="flex items-center gap-1.5 overflow-x-auto no-scrollbar">
-            <ToolbarButton @click="handleFormat('bold')" title="Bold"><template #icon><Bold class="w-4 h-4" /></template></ToolbarButton>
-            <ToolbarButton @click="handleFormat('italic')" title="Italic"><template #icon><Italic class="w-4 h-4" /></template></ToolbarButton>
-            <ToolbarButton @click="handleFormat('underline')" title="Underline"><template #icon><Underline class="w-4 h-4" /></template></ToolbarButton>
+            <ToolbarButton @click="handleFormat('bold')" :title="sc.bold.tooltip"><template #icon><Bold class="w-4 h-4" /></template></ToolbarButton>
+            <ToolbarButton @click="handleFormat('italic')" :title="sc.italic.tooltip"><template #icon><Italic class="w-4 h-4" /></template></ToolbarButton>
+            <ToolbarButton @click="handleFormat('underline')" :title="sc.underline.tooltip"><template #icon><Underline class="w-4 h-4" /></template></ToolbarButton>
             
             <div class="w-px h-4 bg-black/10 dark:bg-white/10 mx-1"></div>
             
@@ -423,7 +424,7 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
                 </template>
             </ToolbarButton>
 
-            <ToolbarButton @click="toggleSearch" title="Find &amp; Replace (Ctrl/Cmd+F)">
+            <ToolbarButton @click="toggleSearch" :title="sc.find.tooltip">
                 <template #icon><Search class="w-4 h-4" /></template>
             </ToolbarButton>
 
@@ -445,7 +446,7 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
         </div>
 
         <div class="flex items-center gap-1.5 border-l border-black/10 dark:border-white/10 pl-2">
-            <ToolbarButton @click="toggleHelp" :active="drawerOpen && drawerTab === 'help'" title="Help" class="w-8 h-8 !p-0 rounded-full font-bold" transparent>
+            <ToolbarButton @click="toggleHelp" :active="drawerOpen && drawerTab === 'help'" :title="sc.help.tooltip" class="w-8 h-8 !p-0 rounded-full font-bold" transparent>
                 <template #icon><HelpCircle class="w-5 h-5" /></template>
             </ToolbarButton>
 
@@ -475,7 +476,7 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
 
             <ToolbarButton 
                 @click="previewVisible = !previewVisible" 
-                :title="previewVisible ? 'Hide Preview' : 'Show Preview'"
+                :title="(previewVisible ? 'Hide Preview' : 'Show Preview') + ` (${sc.preview.keys})`"
                 class="w-8 h-8 !p-0 rounded-full"
                 :active="previewVisible"
                 transparent
@@ -522,7 +523,7 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
                         v-if="!previewVisible"
                         @click="previewVisible = true"
                         class="w-12 h-12 rounded-full bg-brass-500 text-ember-950 shadow-2xl flex items-center justify-center hover:bg-brass-400 transition-all transform hover:scale-110"
-                        title="Show Preview"
+                        :title="`Show Preview (${sc.preview.keys})`"
                     >
                         <Eye class="w-6 h-6 text-ember-950" />
                     </button>

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -251,6 +251,10 @@ onMounted(async () => {
       (next) => { diagnostics.value = next; },
       openSearch,
       applySearchSummary,
+      (action) => {
+        if (action === 'toggle-preview') previewVisible.value = !previewVisible.value;
+        if (action === 'toggle-help') toggleHelp();
+      },
     );
     engine.init(props.content, store.state.isDark, spellcheckEnabled.value);
     scheduleRender(props.content, props.style);

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -19,6 +19,7 @@ import IssuesTab from './IssuesTab.vue';
 import FindReplaceTab from './FindReplaceTab.vue';
 import OutlineTab from './OutlineTab.vue';
 import StatsTab from './StatsTab.vue';
+import HelpTab from './HelpTab.vue';
 
 const props = defineProps<{
   env: EditorEnv;
@@ -32,7 +33,6 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'update:content', value: string): void;
   (e: 'update:style', value: string): void;
-  (e: 'toggle-help'): void;
   (e: 'migration-state-change', value: boolean): void;
 }>();
 
@@ -362,6 +362,10 @@ function toggleStats() {
     openWorkbenchTab('stats');
 }
 
+function toggleHelp() {
+    openWorkbenchTab('help');
+}
+
 function openIssuesTab() {
     openWorkbenchTab('issues');
 }
@@ -437,7 +441,7 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
         </div>
 
         <div class="flex items-center gap-1.5 border-l border-black/10 dark:border-white/10 pl-2">
-            <ToolbarButton @click="emit('toggle-help')" title="Help" class="w-8 h-8 !p-0 rounded-full font-bold" transparent>
+            <ToolbarButton @click="toggleHelp" :active="drawerOpen && drawerTab === 'help'" title="Help" class="w-8 h-8 !p-0 rounded-full font-bold" transparent>
                 <template #icon><HelpCircle class="w-5 h-5" /></template>
             </ToolbarButton>
 
@@ -561,6 +565,9 @@ function onJumpMatch(index: number) { engine?.selectMatch(index); }
                 </template>
                 <template #stats>
                     <StatsTab :stats="manuscriptStats" :loading="manuscriptStatsLoading" />
+                </template>
+                <template #help>
+                    <HelpTab :open-link="props.env.openURL" />
                 </template>
             </WorkbenchDrawer>
         </div>

--- a/web/src/components/shared/HelpTab.vue
+++ b/web/src/components/shared/HelpTab.vue
@@ -14,8 +14,13 @@ type HelpSection = 'syntax' | 'tools' | 'shortcuts';
 const activeSection = ref<HelpSection>('syntax');
 
 const shortcuts = [
+  { keys: ['Ctrl/⌘', 'B'], desc: 'Bold' },
+  { keys: ['Ctrl/⌘', 'I'], desc: 'Italic' },
+  { keys: ['Ctrl/⌘', 'U'], desc: 'Underline' },
   { keys: ['Ctrl/⌘', 'F'], desc: 'Open Find' },
   { keys: ['Ctrl/⌘', 'H'], desc: 'Open Find & Replace' },
+  { keys: ['Ctrl/⌘', 'Shift', 'P'], desc: 'Show / Hide Preview' },
+  { keys: ['Ctrl/⌘', 'Shift', '/'], desc: 'Open Help' },
 ];
 
 const tools: { icon: Component; name: string; desc: string }[] = [

--- a/web/src/components/shared/HelpTab.vue
+++ b/web/src/components/shared/HelpTab.vue
@@ -5,6 +5,7 @@ import {
   Eye, ListTree, BarChart3, AlertTriangle, Search, SpellCheck, ScrollText,
 } from 'lucide-vue-next';
 import type { Component } from 'vue';
+import { shortcuts as sc } from '../../core/platform';
 
 const props = defineProps<{
   openLink: (url: string) => Promise<void>;
@@ -13,14 +14,10 @@ const props = defineProps<{
 type HelpSection = 'syntax' | 'tools' | 'shortcuts';
 const activeSection = ref<HelpSection>('syntax');
 
-const shortcuts = [
-  { keys: ['Ctrl/⌘', 'B'], desc: 'Bold' },
-  { keys: ['Ctrl/⌘', 'I'], desc: 'Italic' },
-  { keys: ['Ctrl/⌘', 'U'], desc: 'Underline' },
-  { keys: ['Ctrl/⌘', 'F'], desc: 'Open Find' },
-  { keys: ['Ctrl/⌘', 'H'], desc: 'Open Find & Replace' },
-  { keys: ['Ctrl/⌘', 'Shift', 'P'], desc: 'Show / Hide Preview' },
-  { keys: ['Ctrl/⌘', 'Shift', '/'], desc: 'Open Help' },
+const shortcutList = [
+  sc.bold, sc.italic, sc.underline,
+  sc.find, sc.findReplace,
+  sc.preview, sc.help,
 ];
 
 const tools: { icon: Component; name: string; desc: string }[] = [
@@ -151,18 +148,12 @@ _underline_  ~strikethrough~</code></pre>
           Everything else is in the toolbar — these are the keyboard shortcuts.
         </p>
         <div
-          v-for="s in shortcuts"
-          :key="s.desc"
+          v-for="s in shortcutList"
+          :key="s.label"
           class="flex items-center justify-between rounded-md bg-black/[0.03] px-3 py-2 dark:bg-white/[0.03]"
         >
-          <span class="text-xs text-text-main">{{ s.desc }}</span>
-          <span class="flex items-center gap-1">
-            <kbd
-              v-for="(k, i) in s.keys"
-              :key="i"
-              class="rounded border border-border bg-[var(--color-page-surface)] px-1.5 py-0.5 text-[10px] font-mono font-bold text-text-muted shadow-sm"
-            >{{ k }}</kbd>
-          </span>
+          <span class="text-xs text-text-main">{{ s.label }}</span>
+          <kbd class="rounded border border-border bg-[var(--color-page-surface)] px-1.5 py-0.5 text-[10px] font-mono font-bold text-text-muted shadow-sm">{{ s.keys }}</kbd>
         </div>
       </div>
     </div>

--- a/web/src/components/shared/HelpTab.vue
+++ b/web/src/components/shared/HelpTab.vue
@@ -21,13 +21,13 @@ const shortcutList = [
 ];
 
 const tools: { icon: Component; name: string; desc: string }[] = [
-  { icon: Eye, name: 'Preview', desc: 'See the printed page side-by-side as you write.' },
+  { icon: Eye, name: 'Preview', desc: 'See the printed page beside your script.' },
   { icon: ListTree, name: 'Outline', desc: 'Jump between acts, scenes, and characters.' },
-  { icon: BarChart3, name: 'Stats', desc: 'Word counts, estimated runtime, and who talks the most.' },
-  { icon: AlertTriangle, name: 'Issues', desc: 'Catch problems — misspelled character names, missing dialogue, formatting mistakes.' },
-  { icon: Search, name: 'Find & Replace', desc: 'Search your script and fix names or lines in bulk.' },
-  { icon: SpellCheck, name: 'Spell Check', desc: 'Underlines misspelled words. You can add names and terms to a per-script allowlist.' },
-  { icon: ScrollText, name: 'Manuscript / Acting Edition', desc: 'Switch between standard manuscript format and a compact acting-edition layout.' },
+  { icon: BarChart3, name: 'Stats', desc: 'See word count, runtime estimate, and who speaks most.' },
+  { icon: AlertTriangle, name: 'Issues', desc: 'Catch typos, structural errors, and formatting mistakes.' },
+  { icon: Search, name: 'Find & Replace', desc: 'Search for a word or phrase, then replace it once or everywhere.' },
+  { icon: SpellCheck, name: 'Spell Check', desc: 'Underline misspellings and add names or terms to this script’s allowlist.' },
+  { icon: ScrollText, name: 'Manuscript / Acting Edition', desc: 'Switch between standard manuscript and a compact acting-edition layout.' },
 ];
 </script>
 
@@ -56,14 +56,14 @@ const tools: { icon: Component; name: string; desc: string }[] = [
       <!-- Writing / Syntax -->
       <div v-if="activeSection === 'syntax'" class="space-y-3">
         <p class="text-xs text-text-muted">
-          Downstage scripts are plain text. Type naturally — formatting comes from structure, not menus.
+          Downstage scripts are plain text. Write naturally. Structure does the work.
         </p>
         <dl class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
           <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
             <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Title Page</dt>
             <dd>
               <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code># My Play
-Subtitle: A Drama
+Subtitle: A Play in One Act
 Author: Your Name
 Draft: First</code></pre>
             </dd>
@@ -112,7 +112,7 @@ _underline_  ~strikethrough~</code></pre>
           </div>
         </dl>
         <p class="text-xs text-text-muted">
-          You don't need a title page to start — just dialogue works too. See the
+          You don't need a title page to start. Just dialogue works too. See the
           <button
             class="font-bold text-brass-500 underline decoration-brass-500/40 underline-offset-2 hover:text-brass-400"
             @click="props.openLink('https://www.getdownstage.com/syntax/')"
@@ -120,7 +120,7 @@ _underline_  ~strikethrough~</code></pre>
             full Syntax Guide
             <ExternalLink class="mb-0.5 inline h-3 w-3" />
           </button>
-          for everything.
+          for the full reference.
         </p>
       </div>
 
@@ -145,7 +145,7 @@ _underline_  ~strikethrough~</code></pre>
       <!-- Shortcuts -->
       <div v-if="activeSection === 'shortcuts'" class="space-y-1.5">
         <p class="mb-2 text-xs text-text-muted">
-          Everything else is in the toolbar — these are the keyboard shortcuts.
+          These are the keyboard shortcuts. Everything else lives in the toolbar.
         </p>
         <div
           v-for="s in shortcutList"

--- a/web/src/components/shared/HelpTab.vue
+++ b/web/src/components/shared/HelpTab.vue
@@ -97,30 +97,11 @@ _underline_  ~strikethrough~</code></pre>
             </dd>
           </div>
           <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Songs</dt>
-            <dd>
-              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>SONG 1: Wanderer's Lament
-
-ALICE
-  Lyric line one.
-
-SONG END</code></pre>
-            </dd>
-          </div>
-          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
             <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Page Breaks &amp; Comments</dt>
             <dd>
               <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>===
 
 // Note to self: fix this</code></pre>
-            </dd>
-          </div>
-          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Forced Cues</dt>
-            <dd>
-              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>@OFFSTAGE VOICE
-Help! Is anyone there?</code></pre>
-              <p class="mt-1.5 text-[10px] text-text-muted">Use <code class="font-mono">@</code> for one-off speakers not in the cast list.</p>
             </dd>
           </div>
         </dl>

--- a/web/src/components/shared/HelpTab.vue
+++ b/web/src/components/shared/HelpTab.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { Keyboard, Type, Clapperboard, ExternalLink } from 'lucide-vue-next';
+
+const props = defineProps<{
+  openLink: (url: string) => Promise<void>;
+}>();
+
+type HelpSection = 'shortcuts' | 'syntax' | 'features';
+const activeSection = ref<HelpSection>('shortcuts');
+
+const shortcuts = [
+  { keys: ['Ctrl/⌘', 'B'], desc: 'Bold' },
+  { keys: ['Ctrl/⌘', 'I'], desc: 'Italic' },
+  { keys: ['Ctrl/⌘', 'U'], desc: 'Underline' },
+  { keys: ['Ctrl/⌘', 'F'], desc: 'Find' },
+  { keys: ['Ctrl/⌘', 'H'], desc: 'Find & Replace' },
+  { keys: ['Ctrl/⌘', 'Alt', 'F'], desc: 'Format Document' },
+];
+
+const features = [
+  { name: 'Preview', desc: 'Live manuscript rendering alongside your source text.' },
+  { name: 'Outline', desc: 'Navigable structure tree — acts, scenes, and characters.' },
+  { name: 'Stats', desc: 'Word counts, runtime estimate, and per-character breakdowns.' },
+  { name: 'Issues', desc: 'Warnings and errors from the Downstage language server.' },
+  { name: 'Find & Replace', desc: 'Search with literal or regex matching, and bulk replace.' },
+  { name: 'Spell Check', desc: 'Browser-native spell checking with a per-draft allowlist.' },
+  { name: 'Manuscript / Acting Edition', desc: 'Toggle between standard manuscript and condensed acting-edition layout.' },
+  { name: 'Dark Mode', desc: 'Switch between light and dark editor themes.' },
+];
+</script>
+
+<template>
+  <div class="flex h-full flex-col overflow-hidden">
+    <div class="flex items-center gap-1 border-b border-border px-4 py-1.5">
+      <button
+        v-for="section in ([
+          { id: 'shortcuts' as HelpSection, icon: Keyboard, label: 'Shortcuts' },
+          { id: 'syntax' as HelpSection, icon: Type, label: 'Syntax' },
+          { id: 'features' as HelpSection, icon: Clapperboard, label: 'Features' },
+        ])"
+        :key="section.id"
+        class="flex items-center gap-1.5 rounded px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-[0.14em] transition-colors"
+        :class="activeSection === section.id
+          ? 'bg-brass-500/15 text-accent'
+          : 'text-text-muted hover:text-text-main hover:bg-black/5 dark:hover:bg-white/5'"
+        @click="activeSection = section.id"
+      >
+        <component :is="section.icon" class="h-3 w-3" />
+        {{ section.label }}
+      </button>
+    </div>
+
+    <div class="flex-1 overflow-y-auto px-4 py-3">
+      <!-- Shortcuts -->
+      <div v-if="activeSection === 'shortcuts'" class="space-y-1.5">
+        <div
+          v-for="s in shortcuts"
+          :key="s.desc"
+          class="flex items-center justify-between rounded-md bg-black/[0.03] px-3 py-2 dark:bg-white/[0.03]"
+        >
+          <span class="text-xs text-text-main">{{ s.desc }}</span>
+          <span class="flex items-center gap-1">
+            <kbd
+              v-for="(k, i) in s.keys"
+              :key="i"
+              class="rounded border border-border bg-[var(--color-page-surface)] px-1.5 py-0.5 text-[10px] font-mono font-bold text-text-muted shadow-sm"
+            >{{ k }}</kbd>
+          </span>
+        </div>
+      </div>
+
+      <!-- Syntax -->
+      <div v-if="activeSection === 'syntax'" class="space-y-3">
+        <dl class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Play Header</dt>
+            <dd>
+              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code># My Play
+Subtitle: A Play in One Act
+Author: Your Name
+Draft: First</code></pre>
+            </dd>
+          </div>
+          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Cue + Dialogue</dt>
+            <dd>
+              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>ALICE
+I know this looks reckless.</code></pre>
+            </dd>
+          </div>
+          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Stage Direction</dt>
+            <dd>
+              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>&gt; The lights cut to black.</code></pre>
+            </dd>
+          </div>
+          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Structure</dt>
+            <dd>
+              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>## ACT I
+### SCENE 1</code></pre>
+            </dd>
+          </div>
+          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Emphasis</dt>
+            <dd>
+              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>**bold**
+*italic*
+_underline_</code></pre>
+            </dd>
+          </div>
+          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Song Block</dt>
+            <dd>
+              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>ALICE (singing)
+The night is young and bright.</code></pre>
+            </dd>
+          </div>
+        </dl>
+        <p class="text-xs text-text-muted">
+          Full spec and examples in the
+          <button
+            class="font-bold text-brass-500 underline decoration-brass-500/40 underline-offset-2 hover:text-brass-400"
+            @click="props.openLink('https://www.getdownstage.com/syntax/')"
+          >
+            Syntax Guide
+            <ExternalLink class="mb-0.5 inline h-3 w-3" />
+          </button>
+        </p>
+      </div>
+
+      <!-- Features -->
+      <div v-if="activeSection === 'features'" class="space-y-1.5">
+        <div
+          v-for="f in features"
+          :key="f.name"
+          class="rounded-md bg-black/[0.03] px-3 py-2 dark:bg-white/[0.03]"
+        >
+          <span class="text-xs font-bold text-text-main">{{ f.name }}</span>
+          <span class="ml-2 text-xs text-text-muted">{{ f.desc }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/components/shared/HelpTab.vue
+++ b/web/src/components/shared/HelpTab.vue
@@ -1,32 +1,27 @@
 <script setup lang="ts">
 import { ref } from 'vue';
-import { Keyboard, Type, Clapperboard, ExternalLink } from 'lucide-vue-next';
+import { Type, Layout, Keyboard, ExternalLink } from 'lucide-vue-next';
 
 const props = defineProps<{
   openLink: (url: string) => Promise<void>;
 }>();
 
-type HelpSection = 'shortcuts' | 'syntax' | 'features';
-const activeSection = ref<HelpSection>('shortcuts');
+type HelpSection = 'syntax' | 'tools' | 'shortcuts';
+const activeSection = ref<HelpSection>('syntax');
 
 const shortcuts = [
-  { keys: ['Ctrl/⌘', 'B'], desc: 'Bold' },
-  { keys: ['Ctrl/⌘', 'I'], desc: 'Italic' },
-  { keys: ['Ctrl/⌘', 'U'], desc: 'Underline' },
-  { keys: ['Ctrl/⌘', 'F'], desc: 'Find' },
-  { keys: ['Ctrl/⌘', 'H'], desc: 'Find & Replace' },
-  { keys: ['Ctrl/⌘', 'Alt', 'F'], desc: 'Format Document' },
+  { keys: ['Ctrl/⌘', 'F'], desc: 'Open Find' },
+  { keys: ['Ctrl/⌘', 'H'], desc: 'Open Find & Replace' },
 ];
 
-const features = [
-  { name: 'Preview', desc: 'Live manuscript rendering alongside your source text.' },
-  { name: 'Outline', desc: 'Navigable structure tree — acts, scenes, and characters.' },
-  { name: 'Stats', desc: 'Word counts, runtime estimate, and per-character breakdowns.' },
-  { name: 'Issues', desc: 'Warnings and errors from the Downstage language server.' },
-  { name: 'Find & Replace', desc: 'Search with literal or regex matching, and bulk replace.' },
-  { name: 'Spell Check', desc: 'Browser-native spell checking with a per-draft allowlist.' },
-  { name: 'Manuscript / Acting Edition', desc: 'Toggle between standard manuscript and condensed acting-edition layout.' },
-  { name: 'Dark Mode', desc: 'Switch between light and dark editor themes.' },
+const tools = [
+  { name: 'Preview', desc: 'See the printed page side-by-side as you write.' },
+  { name: 'Outline', desc: 'Jump between acts, scenes, and characters.' },
+  { name: 'Stats', desc: 'Word counts, estimated runtime, and who talks the most.' },
+  { name: 'Issues', desc: 'Catch problems — misspelled character names, missing dialogue, formatting mistakes.' },
+  { name: 'Find & Replace', desc: 'Search your script and fix names or lines in bulk.' },
+  { name: 'Spell Check', desc: 'Underlines misspelled words. You can add names and terms to a per-script allowlist.' },
+  { name: 'Manuscript / Acting Edition', desc: 'Switch between standard manuscript format and a compact acting-edition layout.' },
 ];
 </script>
 
@@ -35,9 +30,9 @@ const features = [
     <div class="flex items-center gap-1 border-b border-border px-4 py-1.5">
       <button
         v-for="section in ([
+          { id: 'syntax' as HelpSection, icon: Type, label: 'Writing' },
+          { id: 'tools' as HelpSection, icon: Layout, label: 'Tools' },
           { id: 'shortcuts' as HelpSection, icon: Keyboard, label: 'Shortcuts' },
-          { id: 'syntax' as HelpSection, icon: Type, label: 'Syntax' },
-          { id: 'features' as HelpSection, icon: Clapperboard, label: 'Features' },
         ])"
         :key="section.id"
         class="flex items-center gap-1.5 rounded px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-[0.14em] transition-colors"
@@ -52,8 +47,116 @@ const features = [
     </div>
 
     <div class="flex-1 overflow-y-auto px-4 py-3">
+      <!-- Writing / Syntax -->
+      <div v-if="activeSection === 'syntax'" class="space-y-3">
+        <p class="text-xs text-text-muted">
+          Downstage scripts are plain text. Type naturally — formatting comes from structure, not menus.
+        </p>
+        <dl class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Title Page</dt>
+            <dd>
+              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code># My Play
+Subtitle: A Drama
+Author: Your Name
+Draft: First</code></pre>
+            </dd>
+          </div>
+          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Dialogue</dt>
+            <dd>
+              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>ALICE
+I know this looks reckless.
+
+BOB
+(laughing)
+You always say that.</code></pre>
+            </dd>
+          </div>
+          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Stage Directions</dt>
+            <dd>
+              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>&gt; The lights cut to black.
+
+&gt; ALICE crosses to the bench
+&gt; and sits.</code></pre>
+            </dd>
+          </div>
+          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Acts &amp; Scenes</dt>
+            <dd>
+              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>## ACT I
+### SCENE 1</code></pre>
+            </dd>
+          </div>
+          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Formatting</dt>
+            <dd>
+              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>**bold**  *italic*
+_underline_  ~strikethrough~</code></pre>
+            </dd>
+          </div>
+          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Songs</dt>
+            <dd>
+              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>SONG 1: Wanderer's Lament
+
+ALICE
+  Lyric line one.
+
+SONG END</code></pre>
+            </dd>
+          </div>
+          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Page Breaks &amp; Comments</dt>
+            <dd>
+              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>===
+
+// Note to self: fix this</code></pre>
+            </dd>
+          </div>
+          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Forced Cues</dt>
+            <dd>
+              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>@OFFSTAGE VOICE
+Help! Is anyone there?</code></pre>
+              <p class="mt-1.5 text-[10px] text-text-muted">Use <code class="font-mono">@</code> for one-off speakers not in the cast list.</p>
+            </dd>
+          </div>
+        </dl>
+        <p class="text-xs text-text-muted">
+          You don't need a title page to start — just dialogue works too. See the
+          <button
+            class="font-bold text-brass-500 underline decoration-brass-500/40 underline-offset-2 hover:text-brass-400"
+            @click="props.openLink('https://www.getdownstage.com/syntax/')"
+          >
+            full Syntax Guide
+            <ExternalLink class="mb-0.5 inline h-3 w-3" />
+          </button>
+          for everything.
+        </p>
+      </div>
+
+      <!-- Tools -->
+      <div v-if="activeSection === 'tools'" class="space-y-1.5">
+        <p class="mb-2 text-xs text-text-muted">
+          All of these are in the toolbar above the editor.
+        </p>
+        <div
+          v-for="t in tools"
+          :key="t.name"
+          class="rounded-md bg-black/[0.03] px-3 py-2 dark:bg-white/[0.03]"
+        >
+          <span class="text-xs font-bold text-text-main">{{ t.name }}</span>
+          <span class="ml-2 text-xs text-text-muted">{{ t.desc }}</span>
+        </div>
+      </div>
+
       <!-- Shortcuts -->
       <div v-if="activeSection === 'shortcuts'" class="space-y-1.5">
+        <p class="mb-2 text-xs text-text-muted">
+          Everything else is in the toolbar — these are the keyboard shortcuts.
+        </p>
         <div
           v-for="s in shortcuts"
           :key="s.desc"
@@ -67,78 +170,6 @@ const features = [
               class="rounded border border-border bg-[var(--color-page-surface)] px-1.5 py-0.5 text-[10px] font-mono font-bold text-text-muted shadow-sm"
             >{{ k }}</kbd>
           </span>
-        </div>
-      </div>
-
-      <!-- Syntax -->
-      <div v-if="activeSection === 'syntax'" class="space-y-3">
-        <dl class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Play Header</dt>
-            <dd>
-              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code># My Play
-Subtitle: A Play in One Act
-Author: Your Name
-Draft: First</code></pre>
-            </dd>
-          </div>
-          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Cue + Dialogue</dt>
-            <dd>
-              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>ALICE
-I know this looks reckless.</code></pre>
-            </dd>
-          </div>
-          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Stage Direction</dt>
-            <dd>
-              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>&gt; The lights cut to black.</code></pre>
-            </dd>
-          </div>
-          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Structure</dt>
-            <dd>
-              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>## ACT I
-### SCENE 1</code></pre>
-            </dd>
-          </div>
-          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Emphasis</dt>
-            <dd>
-              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>**bold**
-*italic*
-_underline_</code></pre>
-            </dd>
-          </div>
-          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Song Block</dt>
-            <dd>
-              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>ALICE (singing)
-The night is young and bright.</code></pre>
-            </dd>
-          </div>
-        </dl>
-        <p class="text-xs text-text-muted">
-          Full spec and examples in the
-          <button
-            class="font-bold text-brass-500 underline decoration-brass-500/40 underline-offset-2 hover:text-brass-400"
-            @click="props.openLink('https://www.getdownstage.com/syntax/')"
-          >
-            Syntax Guide
-            <ExternalLink class="mb-0.5 inline h-3 w-3" />
-          </button>
-        </p>
-      </div>
-
-      <!-- Features -->
-      <div v-if="activeSection === 'features'" class="space-y-1.5">
-        <div
-          v-for="f in features"
-          :key="f.name"
-          class="rounded-md bg-black/[0.03] px-3 py-2 dark:bg-white/[0.03]"
-        >
-          <span class="text-xs font-bold text-text-main">{{ f.name }}</span>
-          <span class="ml-2 text-xs text-text-muted">{{ f.desc }}</span>
         </div>
       </div>
     </div>

--- a/web/src/components/shared/HelpTab.vue
+++ b/web/src/components/shared/HelpTab.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { ref } from 'vue';
-import { Type, Layout, Keyboard, ExternalLink } from 'lucide-vue-next';
+import {
+  Type, Layout, Keyboard, ExternalLink,
+  Eye, ListTree, BarChart3, AlertTriangle, Search, SpellCheck, ScrollText,
+} from 'lucide-vue-next';
+import type { Component } from 'vue';
 
 const props = defineProps<{
   openLink: (url: string) => Promise<void>;
@@ -14,14 +18,14 @@ const shortcuts = [
   { keys: ['Ctrl/⌘', 'H'], desc: 'Open Find & Replace' },
 ];
 
-const tools = [
-  { name: 'Preview', desc: 'See the printed page side-by-side as you write.' },
-  { name: 'Outline', desc: 'Jump between acts, scenes, and characters.' },
-  { name: 'Stats', desc: 'Word counts, estimated runtime, and who talks the most.' },
-  { name: 'Issues', desc: 'Catch problems — misspelled character names, missing dialogue, formatting mistakes.' },
-  { name: 'Find & Replace', desc: 'Search your script and fix names or lines in bulk.' },
-  { name: 'Spell Check', desc: 'Underlines misspelled words. You can add names and terms to a per-script allowlist.' },
-  { name: 'Manuscript / Acting Edition', desc: 'Switch between standard manuscript format and a compact acting-edition layout.' },
+const tools: { icon: Component; name: string; desc: string }[] = [
+  { icon: Eye, name: 'Preview', desc: 'See the printed page side-by-side as you write.' },
+  { icon: ListTree, name: 'Outline', desc: 'Jump between acts, scenes, and characters.' },
+  { icon: BarChart3, name: 'Stats', desc: 'Word counts, estimated runtime, and who talks the most.' },
+  { icon: AlertTriangle, name: 'Issues', desc: 'Catch problems — misspelled character names, missing dialogue, formatting mistakes.' },
+  { icon: Search, name: 'Find & Replace', desc: 'Search your script and fix names or lines in bulk.' },
+  { icon: SpellCheck, name: 'Spell Check', desc: 'Underlines misspelled words. You can add names and terms to a per-script allowlist.' },
+  { icon: ScrollText, name: 'Manuscript / Acting Edition', desc: 'Switch between standard manuscript format and a compact acting-edition layout.' },
 ];
 </script>
 
@@ -126,10 +130,13 @@ _underline_  ~strikethrough~</code></pre>
         <div
           v-for="t in tools"
           :key="t.name"
-          class="rounded-md bg-black/[0.03] px-3 py-2 dark:bg-white/[0.03]"
+          class="flex items-start gap-2.5 rounded-md bg-black/[0.03] px-3 py-2 dark:bg-white/[0.03]"
         >
-          <span class="text-xs font-bold text-text-main">{{ t.name }}</span>
-          <span class="ml-2 text-xs text-text-muted">{{ t.desc }}</span>
+          <component :is="t.icon" class="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-muted" />
+          <div>
+            <span class="text-xs font-bold text-text-main">{{ t.name }}</span>
+            <span class="ml-2 text-xs text-text-muted">{{ t.desc }}</span>
+          </div>
         </div>
       </div>
 

--- a/web/src/components/shared/HelpTab.vue
+++ b/web/src/components/shared/HelpTab.vue
@@ -130,13 +130,13 @@ _underline_  ~strikethrough~</code></pre>
         <div
           v-for="t in tools"
           :key="t.name"
-          class="flex items-start gap-2.5 rounded-md bg-black/[0.03] px-3 py-2 dark:bg-white/[0.03]"
+          class="flex items-center gap-2.5 rounded-md bg-black/[0.03] px-3 py-2 dark:bg-white/[0.03]"
         >
-          <component :is="t.icon" class="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-muted" />
-          <div>
+          <component :is="t.icon" class="h-3.5 w-3.5 shrink-0 text-text-muted" />
+          <span>
             <span class="text-xs font-bold text-text-main">{{ t.name }}</span>
             <span class="ml-2 text-xs text-text-muted">{{ t.desc }}</span>
-          </div>
+          </span>
         </div>
       </div>
 

--- a/web/src/components/shared/HelpTab.vue
+++ b/web/src/components/shared/HelpTab.vue
@@ -7,12 +7,17 @@ import {
 import type { Component } from 'vue';
 import { shortcuts as sc } from '../../core/platform';
 
-const props = defineProps<{
+const { openLink } = defineProps<{
   openLink: (url: string) => Promise<void>;
 }>();
 
 type HelpSection = 'syntax' | 'tools' | 'shortcuts';
 const activeSection = ref<HelpSection>('syntax');
+const sections: { id: HelpSection; icon: Component; label: string }[] = [
+  { id: 'syntax', icon: Type, label: 'Writing' },
+  { id: 'tools', icon: Layout, label: 'Tools' },
+  { id: 'shortcuts', icon: Keyboard, label: 'Shortcuts' },
+];
 
 const shortcutList = [
   sc.bold, sc.italic, sc.underline,
@@ -35,11 +40,7 @@ const tools: { icon: Component; name: string; desc: string }[] = [
   <div class="flex h-full flex-col overflow-hidden">
     <div class="flex items-center gap-1 border-b border-border px-4 py-1.5">
       <button
-        v-for="section in ([
-          { id: 'syntax' as HelpSection, icon: Type, label: 'Writing' },
-          { id: 'tools' as HelpSection, icon: Layout, label: 'Tools' },
-          { id: 'shortcuts' as HelpSection, icon: Keyboard, label: 'Shortcuts' },
-        ])"
+        v-for="section in sections"
         :key="section.id"
         class="flex items-center gap-1.5 rounded px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-[0.14em] transition-colors"
         :class="activeSection === section.id
@@ -53,7 +54,6 @@ const tools: { icon: Component; name: string; desc: string }[] = [
     </div>
 
     <div class="flex-1 overflow-y-auto px-4 py-3">
-      <!-- Writing / Syntax -->
       <div v-if="activeSection === 'syntax'" class="space-y-3">
         <p class="text-xs text-text-muted">
           Downstage scripts are plain text. Write naturally. Structure does the work.
@@ -115,7 +115,7 @@ _underline_  ~strikethrough~</code></pre>
           You don't need a title page to start. Just dialogue works too. See the
           <button
             class="font-bold text-brass-500 underline decoration-brass-500/40 underline-offset-2 hover:text-brass-400"
-            @click="props.openLink('https://www.getdownstage.com/syntax/')"
+            @click="openLink('https://www.getdownstage.com/syntax/')"
           >
             full Syntax Guide
             <ExternalLink class="mb-0.5 inline h-3 w-3" />
@@ -124,7 +124,6 @@ _underline_  ~strikethrough~</code></pre>
         </p>
       </div>
 
-      <!-- Tools -->
       <div v-if="activeSection === 'tools'" class="space-y-1.5">
         <p class="mb-2 text-xs text-text-muted">
           All of these are in the toolbar above the editor.
@@ -142,7 +141,6 @@ _underline_  ~strikethrough~</code></pre>
         </div>
       </div>
 
-      <!-- Shortcuts -->
       <div v-if="activeSection === 'shortcuts'" class="space-y-1.5">
         <p class="mb-2 text-xs text-text-muted">
           These are the keyboard shortcuts. Everything else lives in the toolbar.

--- a/web/src/components/shared/WelcomeModal.vue
+++ b/web/src/components/shared/WelcomeModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import BaseModal from './BaseModal.vue';
-import { AlertTriangle, BookOpen, Download } from 'lucide-vue-next';
+import { AlertTriangle, BookOpen, Download, HelpCircle } from 'lucide-vue-next';
 
 defineProps<{
   open: boolean;
@@ -8,7 +8,6 @@ defineProps<{
 
 const emit = defineEmits<{
   (e: 'close'): void;
-  (e: 'open-quick-reference'): void;
 }>();
 </script>
 
@@ -57,9 +56,11 @@ const emit = defineEmits<{
             <BookOpen class="h-5 w-5 text-text-main" />
           </div>
           <div class="space-y-2">
-            <p class="text-sm font-bold text-text-main">Need a quick syntax refresher?</p>
+            <p class="text-sm font-bold text-text-main">Need help?</p>
             <p class="text-sm leading-relaxed text-text-muted">
-              Open the quick reference whenever you need it, or view the
+              Click the
+              <HelpCircle class="mb-0.5 inline h-4 w-4" />
+              button in the toolbar for syntax, shortcuts, and editor features — or view the
               <a
                 class="font-bold text-brass-500 underline decoration-brass-500/40 underline-offset-2 hover:text-brass-400"
                 href="https://www.getdownstage.com/syntax/"
@@ -68,21 +69,15 @@ const emit = defineEmits<{
               >
                 Syntax Guide
               </a>
-              for the full spec with examples.
+              for the full spec.
             </p>
           </div>
         </div>
       </div>
 
-      <div class="flex flex-col gap-3 pt-1 sm:flex-row">
+      <div class="pt-1">
         <button
-          class="flex-1 rounded-lg border border-border px-4 py-2.5 text-sm font-bold text-text-main transition-colors hover:bg-black/5 dark:hover:bg-white/5"
-          @click="emit('open-quick-reference')"
-        >
-          Open Quick Reference
-        </button>
-        <button
-          class="flex-1 rounded-lg bg-brass-500 px-4 py-2.5 text-sm font-bold text-black transition-colors hover:bg-brass-400"
+          class="w-full rounded-lg bg-brass-500 px-4 py-2.5 text-sm font-bold text-black transition-colors hover:bg-brass-400"
           @click="emit('close')"
         >
           Start Writing

--- a/web/src/components/shared/WorkbenchDrawer.vue
+++ b/web/src/components/shared/WorkbenchDrawer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { X, AlertTriangle, Search, ListTree, BarChart3 } from 'lucide-vue-next';
+import { X, AlertTriangle, Search, ListTree, BarChart3, HelpCircle } from 'lucide-vue-next';
 
-export type WorkbenchTab = 'issues' | 'find' | 'outline' | 'stats';
+export type WorkbenchTab = 'issues' | 'find' | 'outline' | 'stats' | 'help';
 
 defineProps<{
   open: boolean;
@@ -86,6 +86,19 @@ function switchTab(tab: WorkbenchTab) {
           <Search class="h-3.5 w-3.5" />
           <span>Find &amp; Replace</span>
         </button>
+        <button
+          type="button"
+          role="tab"
+          :aria-selected="activeTab === 'help'"
+          class="flex items-center gap-2 px-3 py-2.5 text-[10px] font-bold uppercase tracking-[0.2em] border-b-2 transition-colors"
+          :class="activeTab === 'help'
+            ? 'border-brass-500 text-accent'
+            : 'border-transparent text-text-muted hover:text-text-main'"
+          @click="switchTab('help')"
+        >
+          <HelpCircle class="h-3.5 w-3.5" />
+          <span>Help</span>
+        </button>
       </div>
       <button
         type="button"
@@ -109,6 +122,9 @@ function switchTab(tab: WorkbenchTab) {
       </div>
       <div v-show="activeTab === 'find'" class="flex h-full min-w-0 flex-col overflow-hidden">
         <slot name="find" />
+      </div>
+      <div v-show="activeTab === 'help'" class="flex h-full min-w-0 flex-col overflow-hidden">
+        <slot name="help" />
       </div>
     </div>
   </section>

--- a/web/src/core/engine.ts
+++ b/web/src/core/engine.ts
@@ -78,6 +78,7 @@ export class Engine {
     private onDiagnosticsChange: (diagnostics: EditorDiagnostic[]) => void = () => {},
     private onOpenSearch: (mode: SearchMode) => void = () => {},
     private onSearchChange: (summary: SearchSummary, matches: SearchMatch[]) => void = () => {},
+    private onAction: (action: string) => void = () => {},
   ) {}
 
   init(initialContent: string, isDark: boolean, spellcheckEnabled = false) {
@@ -103,30 +104,46 @@ export class Engine {
       },
     });
 
-    const searchKeymap = keymap.of([
+    const editorKeymap = keymap.of([
       {
         key: "Mod-f",
         preventDefault: true,
-        run: () => {
-          this.onOpenSearch("find");
-          return true;
-        },
+        run: () => { this.onOpenSearch("find"); return true; },
       },
       {
         key: "Mod-h",
         preventDefault: true,
-        run: () => {
-          this.onOpenSearch("replace");
-          return true;
-        },
+        run: () => { this.onOpenSearch("replace"); return true; },
       },
       {
         key: "Mod-Alt-f",
         preventDefault: true,
-        run: () => {
-          this.onOpenSearch("replace");
-          return true;
-        },
+        run: () => { this.onOpenSearch("replace"); return true; },
+      },
+      {
+        key: "Mod-b",
+        preventDefault: true,
+        run: () => { this.applyFormat("bold"); return true; },
+      },
+      {
+        key: "Mod-i",
+        preventDefault: true,
+        run: () => { this.applyFormat("italic"); return true; },
+      },
+      {
+        key: "Mod-u",
+        preventDefault: true,
+        run: () => { this.applyFormat("underline"); return true; },
+      },
+      {
+        key: "Mod-Shift-p",
+        preventDefault: true,
+        run: () => { this.onAction("toggle-preview"); return true; },
+      },
+      {
+        key: "Mod-Shift-/",
+        preventDefault: true,
+        run: () => { this.onAction("toggle-help"); return true; },
       },
     ]);
 
@@ -136,7 +153,7 @@ export class Engine {
         extensions: [
           lineNumbers(),
           history(),
-          searchKeymap,
+          editorKeymap,
           keymap.of([...completionKeymap, ...defaultKeymap, ...historyKeymap]),
           themeCompartment.of(isDark ? oneDark : lightTheme),
           lintCompartment.of(this.createLintExtension()),

--- a/web/src/core/engine.ts
+++ b/web/src/core/engine.ts
@@ -136,7 +136,7 @@ export class Engine {
         run: () => { this.applyFormat("underline"); return true; },
       },
       {
-        key: "Mod-Shift-p",
+        key: "Mod-\\",
         preventDefault: true,
         run: () => { this.onAction("toggle-preview"); return true; },
       },

--- a/web/src/core/platform.ts
+++ b/web/src/core/platform.ts
@@ -17,12 +17,11 @@ function formatKeys(parts: string[]): string {
 }
 
 export const shortcuts: Record<string, Shortcut> = {
-  bold:           { label: "Bold",                keys: formatKeys([mod, "B"]),            tooltip: `Bold (${formatKeys([mod, "B"])})` },
-  italic:        { label: "Italic",              keys: formatKeys([mod, "I"]),            tooltip: `Italic (${formatKeys([mod, "I"])})` },
-  underline:     { label: "Underline",           keys: formatKeys([mod, "U"]),            tooltip: `Underline (${formatKeys([mod, "U"])})` },
-  find:          { label: "Find",                keys: formatKeys([mod, "F"]),            tooltip: `Find (${formatKeys([mod, "F"])})` },
-  findReplace:   { label: "Find & Replace",      keys: formatKeys([mod, "H"]),            tooltip: `Find & Replace (${formatKeys([mod, "H"])})` },
-  findReplaceAlt:{ label: "Find & Replace",      keys: formatKeys([mod, alt, "F"]),       tooltip: `Find & Replace (${formatKeys([mod, alt, "F"])})` },
-  preview:       { label: "Show / Hide Preview", keys: formatKeys([mod, shift, "P"]),     tooltip: `Toggle Preview (${formatKeys([mod, shift, "P"])})` },
-  help:          { label: "Help",                keys: formatKeys([mod, shift, "/"]),     tooltip: `Help (${formatKeys([mod, shift, "/"])})` },
+  bold:        { label: "Bold",                keys: formatKeys([mod, "B"]),        tooltip: `Bold (${formatKeys([mod, "B"])})` },
+  italic:      { label: "Italic",              keys: formatKeys([mod, "I"]),        tooltip: `Italic (${formatKeys([mod, "I"])})` },
+  underline:   { label: "Underline",           keys: formatKeys([mod, "U"]),        tooltip: `Underline (${formatKeys([mod, "U"])})` },
+  find:        { label: "Find",                keys: formatKeys([mod, "F"]),        tooltip: `Find (${formatKeys([mod, "F"])})` },
+  findReplace: { label: "Find & Replace",      keys: formatKeys([mod, alt, "F"]),   tooltip: `Find & Replace (${formatKeys([mod, alt, "F"])})` },
+  preview:     { label: "Show / Hide Preview", keys: formatKeys([mod, "\\"]),       tooltip: `Toggle Preview (${formatKeys([mod, "\\"])})` },
+  help:        { label: "Help",                keys: formatKeys([mod, shift, "/"]), tooltip: `Help (${formatKeys([mod, shift, "/"])})` },
 };

--- a/web/src/core/platform.ts
+++ b/web/src/core/platform.ts
@@ -1,0 +1,28 @@
+export const isMac =
+  typeof navigator !== "undefined" &&
+  /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+
+const mod = isMac ? "\u2318" : "Ctrl";
+const shift = isMac ? "\u21E7" : "Shift";
+const alt = isMac ? "\u2325" : "Alt";
+
+export interface Shortcut {
+  label: string;
+  keys: string;
+  tooltip: string;
+}
+
+function formatKeys(parts: string[]): string {
+  return isMac ? parts.join("") : parts.join("+");
+}
+
+export const shortcuts: Record<string, Shortcut> = {
+  bold:           { label: "Bold",                keys: formatKeys([mod, "B"]),            tooltip: `Bold (${formatKeys([mod, "B"])})` },
+  italic:        { label: "Italic",              keys: formatKeys([mod, "I"]),            tooltip: `Italic (${formatKeys([mod, "I"])})` },
+  underline:     { label: "Underline",           keys: formatKeys([mod, "U"]),            tooltip: `Underline (${formatKeys([mod, "U"])})` },
+  find:          { label: "Find",                keys: formatKeys([mod, "F"]),            tooltip: `Find (${formatKeys([mod, "F"])})` },
+  findReplace:   { label: "Find & Replace",      keys: formatKeys([mod, "H"]),            tooltip: `Find & Replace (${formatKeys([mod, "H"])})` },
+  findReplaceAlt:{ label: "Find & Replace",      keys: formatKeys([mod, alt, "F"]),       tooltip: `Find & Replace (${formatKeys([mod, alt, "F"])})` },
+  preview:       { label: "Show / Hide Preview", keys: formatKeys([mod, shift, "P"]),     tooltip: `Toggle Preview (${formatKeys([mod, shift, "P"])})` },
+  help:          { label: "Help",                keys: formatKeys([mod, shift, "/"]),     tooltip: `Help (${formatKeys([mod, shift, "/"])})` },
+};


### PR DESCRIPTION
## Summary

- Replace the top-panel quick reference with a **Help tab** in the workbench drawer, alongside Outline, Stats, Issues, and Find & Replace.
- Three sub-sections: **Writing** (syntax quick reference), **Tools** (what each toolbar button does, with matching icons), and **Shortcuts** (keyboard bindings).
- Add keyboard shortcuts for **bold** (⌘/Ctrl+B), **italic** (⌘/Ctrl+I), **underline** (⌘/Ctrl+U), **toggle preview** (⌘/Ctrl+\\), and **toggle help** (⌘/Ctrl+Shift+/).
- Platform-aware shortcut labels — Mac users see ⌘ symbols, others see Ctrl+key. Toolbar tooltips show the corresponding shortcut.
- Audited bindings against browser/OS defaults: moved preview off Mod-Shift-P (Firefox private window conflict), promoted Mod-Alt-F for Find & Replace over Mod-H (hides app on Mac).
- Simplified the Welcome modal to point at the toolbar help button instead of managing its own quick reference panel.

## Test plan

- [x] Click the help (?) button in the toolbar — drawer opens to Help tab, Writing section
- [x] Toggle between Writing, Tools, and Shortcuts sub-tabs
- [x] Verify syntax examples render correctly in Writing tab
- [x] Verify Tools tab icons match their corresponding toolbar buttons
- [x] Test keyboard shortcuts: Ctrl/⌘+B/I/U, Ctrl/⌘+F, Ctrl/⌘+Alt+F, Ctrl/⌘+\\, Ctrl/⌘+Shift+/
- [x] Hover toolbar buttons and confirm tooltips show platform-appropriate shortcut
- [x] Check on Mac that symbols show ⌘/⇧/⌥; on Windows/Linux that they show Ctrl/Shift/Alt
- [x] First visit: welcome modal no longer has "Open Quick Reference" button, points to toolbar help instead
- [x] Dark mode: help tab renders correctly