### PR TITLE
test(web): add Playwright e2e suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,64 @@ jobs:
           echo "| WASM   | \`${{ steps.wasm.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Web tests | \`${{ steps.web-test.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Site   | \`${{ steps.site.outcome }}\` |" >> "$GITHUB_STEP_SUMMARY"
+
+  web-e2e:
+    name: Web E2E (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+          check-latest: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install web editor dependencies
+        run: npm --prefix web ci
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('web/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        run: npx --prefix web playwright install --with-deps chromium
+
+      - name: Build WASM
+        run: make wasm
+
+      - name: Build web bundle
+        run: npm --prefix web run build
+
+      - name: Run Playwright tests
+        run: npm --prefix web run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          retention-days: 14
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: web/test-results/
+          retention-days: 14

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test lint fmt vet check clean render release-check release-snapshot wasm web web-dev web-clean
+.PHONY: all test lint fmt vet check clean render release-check release-snapshot wasm web web-dev web-e2e web-clean
 
 BINARY := downstage
 BUILD_DIR := build
@@ -58,6 +58,9 @@ web: wasm
 web-dev: wasm
 	@echo "Serving web editor at http://localhost:5173/editor/"
 	cd web && npm run dev -- --host 0.0.0.0
+
+web-e2e: web
+	npm --prefix web run test:e2e
 
 web-clean:
 	rm -rf web/build web/dist web/node_modules

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,4 @@
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -26,3 +26,6 @@ compiled from `cmd/wasm/main.go`.
 
 - `npm run build` must succeed after any TypeScript or Vue changes.
 - WASM changes require rebuilding via `make wasm` and manual browser testing.
+- Run `make web-e2e` when touching UI, editor integration, or WASM bindings.
+  New contributors need a one-time `npx --prefix web playwright install chromium`
+  before the E2E suite will run.

--- a/web/README.md
+++ b/web/README.md
@@ -63,6 +63,45 @@ make web-dev
 
 After Go changes, rebuild with `make wasm` and refresh the browser.
 
+## End-to-End Tests
+
+The web editor has a Playwright-based E2E suite in `web/e2e/` that runs the
+built bundle in real Chromium and exercises user flows — drafts, import /
+export, workbench tabs, share links, and V1 migration.
+
+### First-time setup
+
+```bash
+npm --prefix web ci
+npx --prefix web playwright install chromium
+```
+
+The `playwright install` step is not triggered by `npm ci`, so new contributors
+must run it once to fetch the browser binary into `~/.cache/ms-playwright/`.
+
+### Running the suite
+
+From the repo root:
+
+```bash
+# Full chain: rebuild WASM, rebuild the bundle, then run Playwright.
+make web-e2e
+
+# Interactive debug UI (assumes `make web` has already run):
+npm --prefix web run test:e2e:ui
+```
+
+Running `npm run test:e2e` directly is unsupported — it assumes
+`web/build/downstage.wasm` and `web/dist/` already exist. Use `make web-e2e`
+as the entrypoint.
+
+### CI
+
+The `web-e2e` job in `.github/workflows/ci.yml` caches the Playwright
+browser install keyed on `web/package-lock.json`, builds WASM + bundle, runs
+the suite in headless Chromium, and uploads `playwright-report/` and
+`test-results/` as artifacts when any spec fails.
+
 ## Architecture
 
 ```

--- a/web/e2e/drafts.spec.ts
+++ b/web/e2e/drafts.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "@playwright/test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { EditorPage } from "./pages/EditorPage";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(__dirname, "fixtures");
+
+test.describe("drafts", () => {
+  test("welcome modal appears on first visit and is dismissed by Start Writing", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+
+    await expect(editor.welcomeModalHeading).toBeVisible();
+    await editor.welcomeStartButton.click();
+    await expect(editor.welcomeModalHeading).toBeHidden();
+
+    await page.reload();
+    await page.waitForFunction(
+      () => typeof (window as unknown as { downstage?: { parse?: unknown } }).downstage?.parse === "function",
+    );
+    await expect(editor.welcomeModalHeading).toBeHidden();
+  });
+
+  test("pending placeholder promotes to a saved draft on first edit", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+
+    await editor.typeIntoEditor("\n\nNew line from typing");
+
+    await editor.myDraftsButton.click();
+    const myDraftsDialog = page.locator("dialog", {
+      has: page.getByRole("heading", { name: "My Drafts", exact: true }),
+    });
+    await expect(myDraftsDialog).toBeVisible();
+    await expect(myDraftsDialog.locator("div.group").first()).toContainText("The Example Play");
+  });
+
+  test("drafts survive a reload via localStorage", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.typeIntoEditor("\n\nLine to persist across reload");
+
+    // saveDrafts is debounced (schedulePersist fires after ~250ms), so poll
+    // localStorage rather than asserting immediately.
+    await expect
+      .poll(() => page.evaluate(() => window.localStorage.getItem("downstage-editor-drafts")), {
+        timeout: 5_000,
+      })
+      .toContain("Line to persist across reload");
+
+    await page.reload();
+    await page.waitForFunction(
+      () => typeof (window as unknown as { downstage?: { parse?: unknown } }).downstage?.parse === "function",
+    );
+    await expect(editor.editor).toContainText("Line to persist across reload");
+  });
+
+  test("New Play with a saved draft shows confirmation modal", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.typeIntoEditor("\n\nCommit to draft");
+
+    await editor.newPlayButton.click();
+    const confirm = page.getByRole("heading", { name: "Start a new play?" });
+    await expect(confirm).toBeVisible();
+
+    await page.getByRole("button", { name: "Start New Play" }).click();
+    await expect(confirm).toBeHidden();
+
+    await expect(editor.editor).toContainText("Untitled Play");
+  });
+
+  test("import .ds via filechooser loads the fixture content", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.myDraftsButton.click();
+
+    const chooserPromise = page.waitForEvent("filechooser");
+    await page.getByRole("button", { name: /Import \.ds File/ }).click();
+    const chooser = await chooserPromise;
+    await chooser.setFiles(path.join(fixturesDir, "sample-play.ds"));
+
+    await expect(editor.editor).toContainText("The Playwright's Test");
+  });
+
+  test("delete draft flow removes the draft from the list", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.typeIntoEditor("\n\nDoomed draft");
+
+    await editor.myDraftsButton.click();
+    const modalDialog = page.locator("dialog", { has: page.getByRole("heading", { name: "My Drafts" }) });
+    const draftRow = modalDialog.locator("div.group").first();
+    await draftRow.hover();
+    await draftRow.getByRole("button", { name: "Delete Draft" }).click();
+
+    await page.getByRole("button", { name: "Delete", exact: true }).click();
+
+    // After deletion there are no saved drafts, so the empty state (only the
+    // Import button) should be what's left inside the modal.
+    await expect(modalDialog.locator("div.group")).toHaveCount(0);
+  });
+});

--- a/web/e2e/editor.spec.ts
+++ b/web/e2e/editor.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+import { EditorPage } from "./pages/EditorPage";
+
+test.describe("editor", () => {
+  test("typing updates editor content", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+
+    await editor.typeIntoEditor("\n\nA fresh line from the test");
+    await expect(editor.editor).toContainText("A fresh line from the test");
+  });
+
+  test("bold toolbar button wraps selection in markdown bold", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+
+    await editor.setEditorContent("ALICE\nHello world\n");
+
+    // Select the word "Hello"
+    await editor.editor.click();
+    await page.keyboard.press("Control+Home");
+    await page.keyboard.press("ArrowDown");
+    for (let i = 0; i < 5; i++) await page.keyboard.press("Shift+ArrowRight");
+
+    await page.getByRole("button", { name: "Bold (Ctrl+B)" }).click();
+    await expect(editor.editor).toContainText("**Hello**");
+  });
+
+  test("issues badge button appears for a document with warnings", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+
+    // Document with an unknown character — produces a warning diagnostic.
+    await editor.setEditorContent(
+      [
+        "# Troubled Play",
+        "",
+        "## Dramatis Personae",
+        "",
+        "ALICE - The known protagonist",
+        "",
+        "## ACT I",
+        "",
+        "### SCENE 1",
+        "",
+        "UNKNOWN_STRANGER",
+        "I was never introduced.",
+        "",
+      ].join("\n"),
+    );
+
+    // The floating issues button is visible only when issues exist AND the
+    // user is not actively typing; wait past the typing indicator window.
+    const issuesButton = page.getByRole("button", { name: /script issue/ });
+    await expect(issuesButton).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("spellcheck modal adds and removes a custom dictionary word", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    // Promote to a saved draft so the allowlist can persist.
+    await editor.typeIntoEditor("\n\nA fresh line");
+
+    await page.getByRole("button", { name: "Spell Check" }).click();
+    const spellDialog = page.locator("dialog", {
+      has: page.getByRole("heading", { name: "Spell Check", exact: true }),
+    });
+    await expect(spellDialog).toBeVisible();
+
+    await spellDialog.getByPlaceholder("Add a custom word").fill("FLORIZEL");
+    await spellDialog.getByRole("button", { name: "Add", exact: true }).click();
+
+    await expect(spellDialog.getByText("FLORIZEL", { exact: true })).toBeVisible();
+
+    await spellDialog
+      .getByRole("button", { name: "Remove FLORIZEL from this script dictionary" })
+      .click();
+
+    await expect(spellDialog.getByText("No custom words yet.")).toBeVisible();
+  });
+});

--- a/web/e2e/export.spec.ts
+++ b/web/e2e/export.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+import { EditorPage } from "./pages/EditorPage";
+
+const body = [
+  "# Export Target",
+  "Author: E2E Suite",
+  "",
+  "## Dramatis Personae",
+  "",
+  "ALICE - The protagonist",
+  "",
+  "## ACT I",
+  "",
+  "### SCENE 1",
+  "",
+  "ALICE",
+  "A line of dialogue.",
+  "",
+].join("\n");
+
+test.describe("export", () => {
+  test("Copy writes the document to the clipboard", async ({ page, context }) => {
+    // Clipboard permissions are also granted at the context level, but confirm
+    // they're in effect for this origin.
+    await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin: "http://127.0.0.1:4173",
+    });
+
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.setEditorContent(body);
+
+    await editor.copyButton.click();
+
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toContain("# Export Target");
+    expect(clipboard).toContain("ALICE");
+  });
+
+  test("Save .ds produces a download with the expected filename and content", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.setEditorContent(body);
+
+    const downloadPromise = page.waitForEvent("download");
+    await editor.saveDsButton.click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toBe("export-target.ds");
+    const savedPath = await download.path();
+    const saved = await readFile(savedPath!, "utf8");
+    expect(saved).toContain("# Export Target");
+    expect(saved).toContain("ALICE");
+  });
+
+  test("Export PDF yields a downloadable %PDF- file", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.setEditorContent(body);
+
+    // PDF render uses diagnostics + render; wait for them to settle so the
+    // V1-document guard doesn't fire falsely.
+    await expect(editor.exportPdfButton).toBeEnabled();
+
+    const download = await editor.downloadPdf();
+    expect(download.suggestedFilename()).toMatch(/export-target-.*\.pdf$/);
+
+    const pdfPath = await download.path();
+    const buf = await readFile(pdfPath!);
+    expect(buf.slice(0, 5).toString("utf8")).toBe("%PDF-");
+    expect(buf.byteLength).toBeGreaterThan(1000);
+  });
+});

--- a/web/e2e/fixtures/sample-play.ds
+++ b/web/e2e/fixtures/sample-play.ds
@@ -1,0 +1,29 @@
+# The Playwright's Test
+Subtitle: A Play in One Act
+Author: E2E Suite
+Date: 2026
+Draft: First
+
+## Dramatis Personae
+
+ALICE - A curious young woman
+BOB - Her steadfast companion
+
+## ACT I
+
+### SCENE 1
+
+> A sunny park. Birds sing. A bench sits center stage.
+
+ALICE
+(excited)
+Have you ever noticed how the world looks different
+when you pay **attention** to the *small things*?
+
+BOB
+I suppose I haven't given it much thought.
+
+> ALICE crosses to the bench and sits.
+
+ALICE
+That's precisely the problem, Bob.

--- a/web/e2e/fixtures/v1-doc.ds
+++ b/web/e2e/fixtures/v1-doc.ds
@@ -1,0 +1,12 @@
+Title: A V1 Legacy Play
+Author: Old Format
+Date: 2020
+
+# Dramatis Personae
+
+ALICE - A character from another era
+
+# Act I
+
+ALICE
+I was written in V1 syntax.

--- a/web/e2e/fixtures/with-errors.ds
+++ b/web/e2e/fixtures/with-errors.ds
@@ -1,0 +1,16 @@
+# Troubled Play
+Author: E2E Suite
+
+## Dramatis Personae
+
+ALICE - The known protagonist
+
+## ACT I
+
+### SCENE 1
+
+UNKNOWN_STRANGER
+I was never introduced.
+
+BOB
+Neither was I.

--- a/web/e2e/pages/EditorPage.ts
+++ b/web/e2e/pages/EditorPage.ts
@@ -1,0 +1,150 @@
+import type { Download, Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+export type DrawerTab = "outline" | "stats" | "issues" | "find" | "help";
+
+export class EditorPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  // --- Header toolbar ---
+
+  get newPlayButton(): Locator {
+    return this.page.getByRole("button", { name: /New Play/ });
+  }
+
+  get myDraftsButton(): Locator {
+    return this.page.getByRole("button", { name: /My Drafts/ });
+  }
+
+  get copyButton(): Locator {
+    return this.page.getByRole("button", { name: /^Copy$/ });
+  }
+
+  get saveDsButton(): Locator {
+    return this.page.getByRole("button", { name: /Save \.ds/ });
+  }
+
+  get exportPdfButton(): Locator {
+    return this.page.getByRole("button", { name: /Export PDF/ });
+  }
+
+  // --- Workbench drawer ---
+
+  get drawer(): Locator {
+    return this.page.locator('section[aria-label="Workbench"]');
+  }
+
+  drawerTab(tab: DrawerTab): Locator {
+    const name = {
+      outline: "Outline",
+      stats: "Stats",
+      issues: /^Issues/,
+      find: /Find & Replace/,
+      help: "Help",
+    }[tab];
+    return this.page.getByRole("tab", { name: name as string });
+  }
+
+  // --- Editor toolbar buttons (inside Editor.vue) ---
+
+  get outlineToolbarButton(): Locator {
+    return this.page.getByRole("button", { name: "Outline", exact: true });
+  }
+
+  get statsToolbarButton(): Locator {
+    return this.page.getByRole("button", { name: "Stats", exact: true });
+  }
+
+  get findToolbarButton(): Locator {
+    return this.page.getByRole("button", { name: /Find .*\(/ });
+  }
+
+  get helpToolbarButton(): Locator {
+    return this.page.getByRole("button", { name: /Help .*\(/ });
+  }
+
+  // --- CodeMirror editor ---
+
+  get editor(): Locator {
+    return this.page.locator(".cm-editor .cm-content");
+  }
+
+  // --- Modals ---
+
+  get welcomeModalHeading(): Locator {
+    return this.page.getByRole("heading", { name: "Welcome to Downstage" });
+  }
+
+  get welcomeStartButton(): Locator {
+    return this.page.getByRole("button", { name: "Start Writing" });
+  }
+
+  async gotoReady(options: { clearStorage?: boolean } = {}): Promise<void> {
+    const { clearStorage = true } = options;
+    if (clearStorage) {
+      // Clear localStorage once per tab so intra-test reloads still see the
+      // state the user just set (e.g. welcome-dismissed flag).
+      await this.page.addInitScript(() => {
+        try {
+          if (!window.sessionStorage.getItem("__e2e_cleared")) {
+            window.localStorage.clear();
+            window.sessionStorage.setItem("__e2e_cleared", "1");
+          }
+        } catch {}
+      });
+    }
+    await this.page.goto("/editor/");
+    await this.page.waitForFunction(
+      () => typeof (window as unknown as { downstage?: { parse?: unknown } }).downstage?.parse === "function",
+      undefined,
+      { timeout: 30_000 },
+    );
+    await expect(this.newPlayButton).toBeVisible();
+  }
+
+  async typeIntoEditor(text: string): Promise<void> {
+    await this.editor.click();
+    await this.page.keyboard.type(text);
+  }
+
+  async setEditorContent(text: string): Promise<void> {
+    await this.editor.click();
+    await this.page.keyboard.press("ControlOrMeta+a");
+    await this.page.keyboard.press("Delete");
+    if (text.length > 0) {
+      await this.page.keyboard.type(text);
+    }
+  }
+
+  async openDrawer(tab: DrawerTab): Promise<void> {
+    const toolbarToggle: Record<Exclude<DrawerTab, "issues">, Locator> = {
+      outline: this.outlineToolbarButton,
+      stats: this.statsToolbarButton,
+      find: this.findToolbarButton,
+      help: this.helpToolbarButton,
+    };
+
+    if (tab === "issues") {
+      // Issues tab has no dedicated toolbar toggle — open Outline then switch.
+      await toolbarToggle.outline.click();
+      await expect(this.drawer).toHaveAttribute("aria-hidden", "false");
+      await this.drawerTab("issues").click();
+      await expect(this.drawerTab("issues")).toHaveAttribute("aria-selected", "true");
+      return;
+    }
+
+    await toolbarToggle[tab].click();
+    await expect(this.drawer).toHaveAttribute("aria-hidden", "false");
+    await expect(this.drawerTab(tab)).toHaveAttribute("aria-selected", "true");
+  }
+
+  async downloadPdf(): Promise<Download> {
+    const downloadPromise = this.page.waitForEvent("download");
+    await this.exportPdfButton.click();
+    return downloadPromise;
+  }
+}

--- a/web/e2e/share.spec.ts
+++ b/web/e2e/share.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/test";
+import { EditorPage } from "./pages/EditorPage";
+
+// Matches the parent AppWeb.vue decoder:
+//   decodeURIComponent(escape(atob(encoded)))
+// which is the inverse of:
+//   btoa(unescape(encodeURIComponent(raw)))
+function encodeShared(raw: string): string {
+  return btoa(unescape(encodeURIComponent(raw)));
+}
+
+const sharedBody = "# Shared From URL\n\nALICE\nHello traveller.\n";
+
+test.describe("share links", () => {
+  test("?content=<b64> promotes to a saved draft and clears the URL", async ({ page }) => {
+    const editor = new EditorPage(page);
+    const encoded = encodeShared(sharedBody);
+
+    await page.addInitScript(() => {
+      try {
+        if (!window.sessionStorage.getItem("__e2e_cleared")) {
+          window.localStorage.clear();
+          window.sessionStorage.setItem("__e2e_cleared", "1");
+        }
+      } catch {}
+    });
+    await page.goto(`/editor/?content=${encodeURIComponent(encoded)}`);
+    await page.waitForFunction(
+      () => typeof (window as unknown as { downstage?: { parse?: unknown } }).downstage?.parse === "function",
+    );
+
+    await expect(editor.editor).toContainText("Shared From URL");
+
+    // The URL is stripped of the ?content= param on successful import.
+    await expect.poll(() => page.url()).not.toContain("content=");
+
+    // The shared content landed as a real saved draft (persisted).
+    await expect
+      .poll(() => page.evaluate(() => window.localStorage.getItem("downstage-editor-drafts")))
+      .toContain("Shared From URL");
+  });
+
+  test("?try=<b64> shows a placeholder that is not persisted until edited", async ({ page }) => {
+    const editor = new EditorPage(page);
+    const encoded = encodeShared("# Snippet Preview\n\nALICE\nTry it out.\n");
+
+    await page.addInitScript(() => {
+      try {
+        if (!window.sessionStorage.getItem("__e2e_cleared")) {
+          window.localStorage.clear();
+          window.sessionStorage.setItem("__e2e_cleared", "1");
+        }
+      } catch {}
+    });
+    await page.goto(`/editor/?try=${encodeURIComponent(encoded)}`);
+    await page.waitForFunction(
+      () => typeof (window as unknown as { downstage?: { parse?: unknown } }).downstage?.parse === "function",
+    );
+
+    await expect(editor.editor).toContainText("Snippet Preview");
+
+    // Nothing is persisted until the user edits.
+    const drafts = await page.evaluate(() => window.localStorage.getItem("downstage-editor-drafts"));
+    expect(drafts === null || drafts === "[]").toBe(true);
+
+    // The ?try= param is intentionally preserved on initial load so reloads
+    // re-hydrate the snippet.
+    expect(page.url()).toContain("try=");
+  });
+});

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+import { EditorPage } from "./pages/EditorPage";
+
+test.describe("smoke", () => {
+  test("editor boots and WASM is ready", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+
+    await expect(editor.newPlayButton).toBeVisible();
+    await expect(editor.saveDsButton).toBeVisible();
+    await expect(editor.editor).toBeVisible();
+
+    await expect.poll(() =>
+      page.evaluate(
+        () =>
+          typeof (window as unknown as { downstage?: { renderPDF?: unknown; renderHTML?: unknown } })
+            .downstage?.renderPDF === "function"
+          && typeof (window as unknown as { downstage?: { renderHTML?: unknown } })
+            .downstage?.renderHTML === "function",
+      ),
+    ).toBe(true);
+  });
+
+  test("app header shows Downstage branding", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+
+    await expect(page.getByRole("heading", { name: "Downstage", exact: true })).toBeVisible();
+  });
+});

--- a/web/e2e/v1-migration.spec.ts
+++ b/web/e2e/v1-migration.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { EditorPage } from "./pages/EditorPage";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function encodeShared(raw: string): string {
+  return btoa(unescape(encodeURIComponent(raw)));
+}
+
+test.describe("v1 migration", () => {
+  test("V1 document disables Export PDF and upgrading re-enables it", async ({ page }) => {
+    const editor = new EditorPage(page);
+    const v1Source = await readFile(path.join(__dirname, "fixtures", "v1-doc.ds"), "utf8");
+
+    await page.addInitScript(() => {
+      try {
+        if (!window.sessionStorage.getItem("__e2e_cleared")) {
+          window.localStorage.clear();
+          // Pre-dismiss the welcome modal so it cannot stack above the V1
+          // migration modal and block clicks.
+          window.localStorage.setItem("downstage-editor-welcome-dismissed", "true");
+          window.sessionStorage.setItem("__e2e_cleared", "1");
+        }
+      } catch {}
+    });
+    // Seed the editor with a V1 document via the share-link path so we land
+    // on V1 content immediately, without first running Example Play through
+    // the pending-placeholder flow.
+    await page.goto(`/editor/?content=${encodeURIComponent(encodeShared(v1Source))}`);
+    await page.waitForFunction(
+      () => typeof (window as unknown as { downstage?: { parse?: unknown } }).downstage?.parse === "function",
+    );
+    await expect(editor.newPlayButton).toBeVisible();
+
+    // The V1 migration modal auto-opens when V1 content is detected. Dismiss
+    // it via "Keep Raw Editing" so the toolbar/preview are unobstructed for
+    // the guard assertions.
+    const migrationModal = page.locator("dialog", {
+      has: page.getByRole("heading", { name: /This looks like a V1 Downstage document/ }),
+    });
+    await expect(migrationModal).toBeVisible({ timeout: 15_000 });
+    await migrationModal.getByRole("button", { name: "Keep Raw Editing" }).click();
+    await expect(migrationModal).toBeHidden();
+
+    // Guard 1: Export PDF button is disabled (toolbar-level `:disabled`).
+    await expect(editor.exportPdfButton).toBeDisabled({ timeout: 15_000 });
+
+    // Guard 2: clicking Export PDF after force-enabling it in the DOM still
+    // fires the handleExport toast-block path, proving the second guard
+    // rejects V1 exports.
+    await editor.exportPdfButton.evaluate((el) => el.removeAttribute("disabled"));
+    await editor.exportPdfButton.click();
+    await expect(page.getByText(/Upgrade this V1 document/i)).toBeVisible();
+
+    // Run the upgrade via the preview-pane banner. The modal is dismissed,
+    // so there is only one "Update Script to V2" button left on the page.
+    await page.getByRole("button", { name: /Update Script to V2/ }).click();
+
+    // Post-upgrade: the toolbar re-enables, and exporting yields a PDF. Give
+    // the render debounce time to settle before clicking.
+    await expect(editor.exportPdfButton).toBeEnabled({ timeout: 15_000 });
+    await expect(editor.exportPdfButton).toHaveAttribute(
+      "title",
+      /Export to PDF/,
+    );
+
+    const downloadPromise = page.waitForEvent("download", { timeout: 30_000 });
+    await editor.exportPdfButton.click();
+    const download = await downloadPromise;
+    const pdf = await readFile((await download.path())!);
+    expect(pdf.slice(0, 5).toString("utf8")).toBe("%PDF-");
+  });
+});

--- a/web/e2e/workbench.spec.ts
+++ b/web/e2e/workbench.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "@playwright/test";
+import { EditorPage } from "./pages/EditorPage";
+
+const samplePlay = [
+  "# Workbench Smoke",
+  "Author: E2E Suite",
+  "",
+  "## Dramatis Personae",
+  "",
+  "ALICE - The protagonist",
+  "",
+  "## ACT I",
+  "",
+  "### SCENE 1",
+  "",
+  "ALICE",
+  "Hello world, this is a line of dialogue.",
+  "",
+].join("\n");
+
+test.describe("workbench", () => {
+  test("Outline tab lists headings from the document", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.setEditorContent(samplePlay);
+
+    await editor.openDrawer("outline");
+
+    const drawer = editor.drawer;
+    await expect(drawer).toContainText("Workbench Smoke");
+    await expect(drawer).toContainText("ACT I");
+    await expect(drawer).toContainText("SCENE 1");
+  });
+
+  test("Stats tab shows manuscript counts", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.setEditorContent(samplePlay);
+
+    await editor.openDrawer("stats");
+
+    const drawer = editor.drawer;
+    await expect(drawer.getByText(/Est\. Runtime/)).toBeVisible();
+    await expect(drawer.getByText(/^Words$/)).toBeVisible();
+    await expect(drawer.getByText("1 act")).toBeVisible();
+  });
+
+  test("Issues tab surfaces diagnostics from the document", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    // ALICE is declared in Dramatis Personae but never speaks — produces an
+    // info-severity `dp-character-no-dialogue` diagnostic.
+    await editor.setEditorContent(
+      [
+        "# Troubled Play",
+        "",
+        "## Dramatis Personae",
+        "",
+        "ALICE - Declared but silent",
+        "",
+        "## ACT I",
+        "",
+        "### SCENE 1",
+        "",
+        "> A stage direction with no dialogue.",
+        "",
+      ].join("\n"),
+    );
+
+    // The floating issues button opens the Issues tab when diagnostics arrive.
+    const issuesFab = page.getByRole("button", { name: /script issue/ });
+    await expect(issuesFab).toBeVisible({ timeout: 15_000 });
+    await issuesFab.click();
+
+    await expect(editor.drawer).toHaveAttribute("aria-hidden", "false");
+    await expect(editor.drawerTab("issues")).toHaveAttribute("aria-selected", "true");
+    await expect(editor.drawer).toContainText(/ALICE.*never speaks|dp-character-no-dialogue/i, {
+      timeout: 15_000,
+    });
+  });
+
+  test("Find & Replace finds and replaces text", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.setEditorContent("ALICE\nBanana banana banana.\n");
+
+    await editor.openDrawer("find");
+    const drawer = editor.drawer;
+
+    await drawer.getByLabel("Find", { exact: true }).fill("banana");
+    await drawer.getByLabel("Replace with", { exact: true }).fill("apple");
+    await drawer.getByLabel("Replace all matches").click();
+
+    await expect(editor.editor).toContainText("apple apple apple");
+  });
+
+  test("Help tab renders the Writing/Tools/Shortcuts sections", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+
+    await editor.openDrawer("help");
+
+    const drawer = editor.drawer;
+    await expect(drawer.getByRole("button", { name: "Writing" })).toBeVisible();
+    await expect(drawer.getByRole("button", { name: "Tools" })).toBeVisible();
+    await expect(drawer.getByRole("button", { name: "Shortcuts" })).toBeVisible();
+
+    await drawer.getByRole("button", { name: "Shortcuts" }).click();
+    await expect(drawer).toContainText(/Bold|Italic|Find/);
+  });
+
+  test("drawer close button collapses the drawer", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+
+    await editor.openDrawer("outline");
+    await expect(editor.drawer).toBeVisible();
+
+    await editor.drawer.getByRole("button", { name: "Close workbench" }).click();
+    await expect(editor.drawer).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,6 +29,7 @@
         "vue": "^3.5.32"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@vue/test-utils": "^2.4.6",
         "happy-dom": "^20.8.9",
         "typescript": "^5.8.0",
@@ -899,6 +900,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2752,6 +2769,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,8 +6,11 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite",
+    "preview:strict": "vite preview --host 127.0.0.1 --port 4173 --strictPort",
     "typecheck": "tsc --noEmit",
-    "test": "npm run typecheck && vitest run"
+    "test": "npm run typecheck && vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.1",
@@ -31,6 +34,7 @@
     "vue": "^3.5.32"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@vue/test-utils": "^2.4.6",
     "happy-dom": "^20.8.9",
     "typescript": "^5.8.0",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const isCI = !!process.env.CI;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 2 : undefined,
+  reporter: isCI ? [["list"], ["html", { open: "never" }]] : "list",
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+
+  use: {
+    baseURL: "http://127.0.0.1:4173/editor/",
+    trace: "on-first-retry",
+    video: "retain-on-failure",
+    screenshot: "only-on-failure",
+    permissions: ["clipboard-read", "clipboard-write"],
+    testIdAttribute: "data-testid",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        colorScheme: "light",
+        reducedMotion: "reduce",
+      },
+    },
+  ],
+
+  webServer: {
+    command: "npm run preview:strict",
+    url: "http://127.0.0.1:4173/editor/",
+    reuseExistingServer: !isCI,
+    timeout: 60_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { execSync } from "node:child_process";
 import { resolve } from "node:path";
 import { defineConfig } from "vite";
@@ -42,5 +43,10 @@ export default defineConfig({
         main: resolve(__dirname, "index.html"),
       },
     },
+  },
+  // Keep Vitest from picking up Playwright specs under `e2e/` — those run
+  // against a real browser via `playwright test`, not happy-dom.
+  test: {
+    exclude: ["node_modules", "dist", "e2e/**"],
   },
 });


### PR DESCRIPTION
## Summary

- Adds a browser-driven Playwright E2E suite for `web/` with 24 specs covering smoke boot, drafts (welcome modal, new-play, pending-to-saved promotion, reload persistence, delete, `.ds` import via filechooser), editor actions (typing, Bold toolbar, diagnostics FAB, spellcheck allowlist), workbench tabs (Outline, Stats, Issues, Find & Replace, Help), export (Copy, Save `.ds`, PDF magic-bytes sniff), share links (`?content=` and `?try=`), and V1 migration (asserts both the toolbar `disabled` guard and the `handleExport` toast guard, then verifies post-upgrade re-enable).
- Wires a new `web-e2e` CI job with a Playwright browser cache keyed on `web/package-lock.json`, a `make web-e2e` repo-level entrypoint (wasm → bundle → test), and a `preview:strict` script pinned to `127.0.0.1:4173` so Playwright's `baseURL` can't drift. Vitest excludes `web/e2e/**` so unit and e2e runs stay separate.
- Adds contributor docs in `web/README.md` and `web/AGENTS.md`, including the one-time `npx playwright install chromium` bootstrap that isn't triggered by `npm ci`.

## Test plan

- [x] `make web-e2e` — 24/24 specs pass in ~15s locally (headless Chromium)
- [x] `npm --prefix web test` — typecheck + 54 Vitest unit tests still pass (e2e excluded)
- [x] `make check` — Go tests still pass
- [x] Verify the `web-e2e` CI job runs and uploads artifacts on failure