### PR TITLE
fix(web): pin empty PostCSS config so vite stops walking up the tree

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -31,6 +31,14 @@ export default defineConfig({
     vue(),
     tailwindcss(),
   ],
+  // Tailwind v4 runs via its Vite plugin — we don't need PostCSS. But
+  // Vite's PostCSS loader walks up looking for `postcss.config.js`, and
+  // the repo root has one for the Eleventy site that pulls Tailwind v3.
+  // On machines where the root `node_modules` isn't populated (e.g. any
+  // Windows contributor who only ran `npm install` in `web/`), that
+  // config fails to resolve `tailwindcss` and the build dies. An inline
+  // empty PostCSS config tells Vite to stop searching.
+  css: { postcss: {} },
   define: {
     __APP_VERSION__: JSON.stringify(resolveAppVersion()),
   },


### PR DESCRIPTION
## Summary

- Backports commit `5b9e76d` from the long-lived `feat/desktop-app-wails` branch as a standalone bugfix.
- Stops Vite's PostCSS loader in `web/` from walking up and finding the repo-root `postcss.config.js` (which is the Eleventy site's Tailwind v3 config).
- Fixes a cross-platform contributor-setup hazard: anyone who runs `npm install` only inside `web/` (common on Windows, or for anyone working just on the editor) would hit `Error: Cannot find module 'tailwindcss'` on every `vite` invocation.

Tailwind v4 in `web/` runs via `@tailwindcss/vite` — we never needed PostCSS — so an inline empty PostCSS config tells Vite to stop searching. Additive 8-line change; does not alter runtime behavior.

## Test plan

- [x] `npm --prefix web run test` — 54 vitest cases green.
- [x] `make web` — production bundle builds in a clean environment (fresh worktree, no repo-root `node_modules`).
- [x] `make web-e2e` — 24 Playwright tests green in headless Chromium.
- [ ] Windows contributor re-verification: fresh checkout → `npm --prefix web ci && npm --prefix web run build` should no longer fail on module resolution.

## Known tradeoff

`css: { postcss: {} }` disables PostCSS loading for `web/` entirely, not just the upward walk. Fine today — `web/` doesn't use a local PostCSS pipeline — but any future web-side PostCSS plugin would be silently ignored until revisited. Future fix if needed: replace `{}` with a real `web/postcss.config.js`.

Cherry-picked from 5b9e76d0add6eba45a1d6eaadf35fdb2f68b32db (on `feat/desktop-app-wails`).