### PR TITLE
feat(pdf): add Letter and A4 page sizes across export surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,11 @@ Both formats support two styles via `--style`:
 - **`condensed`** (Acting Edition) — Acting edition format designed for rehearsal use. Character
   names inline with dialogue (e.g. `HAMLET. To be or not...`), tighter spacing.
 
-PDF uses Courier 12pt on letter-size pages for manuscript, and Libre Baskerville
-10pt on half-letter for acting edition. HTML produces a self-contained document with
-embedded CSS using semantic `.downstage-*` class names for custom styling.
+PDF also supports `--page-size letter` (default) and `--page-size a4`.
+Manuscript output renders on the selected sheet size. Acting edition output
+derives its logical page from that sheet size: half-letter for Letter, A5 for
+A4. HTML produces a self-contained document with embedded CSS using semantic
+`.downstage-*` class names for custom styling.
 
 ### Statistics
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -572,6 +572,12 @@ Both formats support `--style standard` (default) and `--style condensed`:
 - **standard**: manuscript-oriented layout. Monospace font, centered character names above dialogue, indented dialogue margins.
 - **condensed**: compact reading layout. Serif font, inline character names (bold, followed by dialogue on the same line), tighter spacing.
 
+### PDF Page Size
+
+PDF output supports `--page-size letter` (default) and `--page-size a4`.
+Manuscript layout renders on the selected physical sheet. Condensed layout
+derives its logical page from that sheet: half-letter for Letter, A5 for A4.
+
 ### HTML Output
 
 HTML rendering produces a single self-contained `.html` file with an embedded stylesheet. The output uses semantic HTML with stable CSS class names for all major structures:

--- a/cmd/render_validate_test.go
+++ b/cmd/render_validate_test.go
@@ -87,6 +87,60 @@ func TestRunRenderRejectsHTMLOnlyPDFFlags(t *testing.T) {
 	}
 }
 
+func TestRunRenderRejectsUnsupportedPageSize(t *testing.T) {
+	resetRenderFlags()
+
+	input := t.TempDir() + "/play.ds"
+	if err := os.WriteFile(input, []byte("ALICE\nHello.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	renderPageSize = "legal"
+	renderOutput = t.TempDir() + "/out.pdf"
+
+	err := runRender(&cobra.Command{}, []string{input})
+	if err == nil || !strings.Contains(err.Error(), "unsupported page size") {
+		t.Fatalf("expected unsupported page size error, got %v", err)
+	}
+}
+
+func TestRunRenderSupportsA4CondensedPDF(t *testing.T) {
+	resetRenderFlags()
+
+	input := t.TempDir() + "/play.ds"
+	if err := os.WriteFile(input, []byte("# Test\n\nALICE\nHello.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	renderStyle = "condensed"
+	renderPageSize = "a4"
+	renderStdout = true
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	renderErr := runRender(&cobra.Command{}, []string{input})
+
+	w.Close()
+	os.Stdout = origStdout
+
+	if renderErr != nil {
+		t.Fatalf("expected A4 condensed PDF render to succeed, got: %v", renderErr)
+	}
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(buf.String(), "%PDF-") {
+		t.Fatalf("expected PDF magic bytes, got %q", buf.String()[:20])
+	}
+}
+
 func TestRunRenderStdoutAcceptsPDF(t *testing.T) {
 	resetRenderFlags()
 

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -258,6 +258,13 @@ func renderPDF(_ js.Value, args []js.Value) any {
 	if len(args) > 1 && args[1].String() == "condensed" {
 		cfg.Style = render.StyleCondensed
 	}
+	if len(args) > 2 && args[2].Truthy() {
+		pageSize, err := render.ParsePageSize(args[2].String())
+		if err != nil {
+			return js.Null()
+		}
+		cfg.PageSize = pageSize
+	}
 
 	var nr render.NodeRenderer
 	if cfg.Style == render.StyleCondensed {

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -35,8 +35,9 @@ not blocked on file setup.
 ### PDF export
 
 Export the current script to either a Manuscript PDF or an Acting Edition PDF
-from the command palette. The generated file opens automatically unless you
-turn that off.
+from the command palette. Set `downstage.render.pageSize` to choose `letter`
+or `a4` for export and preview. The generated file opens automatically unless
+you turn that off.
 
 ### Writing Help
 
@@ -88,6 +89,7 @@ parentheticals, character cues, aliases, verse, and comments.
 | `downstage.server.trace` | string | `"off"` | Extra diagnostic logging for troubleshooting |
 | `downstage.editor.autoSuggestCharacterCues` | boolean | `true` | Auto-trigger cue suggestions on empty lines |
 | `downstage.render.style` | string | `"standard"` | Default export style. `standard` means Manuscript. `condensed` means Acting Edition |
+| `downstage.render.pageSize` | string | `"letter"` | Default PDF page size for manuscript and acting edition export. Supports `letter` and `a4` |
 | `downstage.render.openAfterRender` | boolean | `true` | Open PDF after rendering |
 | `downstage.preview.debounceMs` | number | `300` | Delay before re-rendering live preview (ms) |
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -113,6 +113,15 @@
           "default": "standard",
           "markdownDescription": "Default export style. `standard` creates a Manuscript PDF. `condensed` creates an Acting Edition PDF."
         },
+        "downstage.render.pageSize": {
+          "type": "string",
+          "enum": [
+            "letter",
+            "a4"
+          ],
+          "default": "letter",
+          "markdownDescription": "Default PDF page size for manuscript and acting edition export."
+        },
         "downstage.render.openAfterRender": {
           "type": "boolean",
           "default": true,

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -10,13 +10,17 @@ import {
 	Trace,
 } from "vscode-languageclient/node";
 import {
+	buildPDFPreviewArgs,
+	buildPDFRenderArgs,
 	type VscodeFactories,
 	DownstageRenderError,
 	findTitleValueSelection,
 	getNewPlayTemplate,
+	getPageSizeDisplayName,
 	getPreviewHtml,
 	getRenderStyleDisplayName,
 	getSamplePlayTemplate,
+	getValidatedPageSize,
 	getValidatedRenderStyle,
 	isCueSuggestionLine,
 	parseRenderDiagnostics,
@@ -41,6 +45,7 @@ const settingServerPath = "server.path";
 const settingServerTrace = "server.trace";
 const settingAutoSuggestCues = "editor.autoSuggestCharacterCues";
 const settingRenderStyle = "render.style";
+const settingRenderPageSize = "render.pageSize";
 const settingOpenAfterRender = "render.openAfterRender";
 const settingPreviewDebounce = "preview.debounceMs";
 
@@ -506,6 +511,13 @@ function getRenderStyleSetting(): string {
 	);
 }
 
+function getRenderPageSizeSetting(): string {
+	return vscode.workspace.getConfiguration(configSection).get<string>(
+		settingRenderPageSize,
+		"letter",
+	);
+}
+
 function getOpenAfterRenderSetting(): boolean {
 	return vscode.workspace.getConfiguration(configSection).get<boolean>(
 		settingOpenAfterRender,
@@ -618,13 +630,17 @@ async function renderCurrentScript(styleOverride?: string): Promise<void> {
 	try {
 		const serverPath = await resolveServerCommand();
 		const style = getValidatedRenderStyle(styleOverride ?? getRenderStyleSetting());
+		const pageSize = getValidatedPageSize(getRenderPageSizeSetting());
 		const styleName = getRenderStyleDisplayName(style);
-		outputChannel.appendLine(`Running: ${serverPath.expectedLocation} render --style ${style} ${inputPath}`);
+		const pageSizeName = getPageSizeDisplayName(pageSize);
+		outputChannel.appendLine(
+			`Running: ${serverPath.expectedLocation} render --style ${style} --page-size ${pageSize} ${inputPath}`,
+		);
 		outputChannel.show(true);
 		renderDiagnostics?.delete(editor.document.uri);
 
-		await runDownstageRender(serverPath.command, style, inputPath, outputChannel);
-		const message = `Rendered ${styleName} PDF: ${path.basename(outputPath)}`;
+		await runDownstageRender(serverPath.command, style, pageSize, inputPath, outputChannel);
+		const message = `Rendered ${styleName} PDF (${pageSizeName}): ${path.basename(outputPath)}`;
 
 		if (!getOpenAfterRenderSetting()) {
 			void vscode.window.showInformationMessage(message);
@@ -669,7 +685,9 @@ async function previewCurrentScriptPdf(styleOverride?: string): Promise<void> {
 	try {
 		const serverPath = await resolveServerCommand();
 		const style = getValidatedRenderStyle(styleOverride ?? getRenderStyleSetting());
+		const pageSize = getValidatedPageSize(getRenderPageSizeSetting());
 		const styleName = getRenderStyleDisplayName(style);
+		const pageSizeName = getPageSizeDisplayName(pageSize);
 		const sourceName = path.basename(inputPath);
 		const tempPath = path.join(
 			os.tmpdir(),
@@ -677,7 +695,7 @@ async function previewCurrentScriptPdf(styleOverride?: string): Promise<void> {
 		);
 
 		outputChannel.appendLine(
-			`Running: ${serverPath.expectedLocation} render --stdin --stdout --format pdf --style ${style} --source-name ${sourceName}`,
+			`Running: ${serverPath.expectedLocation} render --stdin --stdout --format pdf --style ${style} --page-size ${pageSize} --source-name ${sourceName}`,
 		);
 		outputChannel.show(true);
 		renderDiagnostics?.delete(editor.document.uri);
@@ -686,12 +704,7 @@ async function previewCurrentScriptPdf(styleOverride?: string): Promise<void> {
 			let stderr = "";
 			const chunks: Buffer[] = [];
 
-			const child = spawn(serverPath.command, [
-				"render", "--stdin", "--stdout",
-				"--format", "pdf",
-				"--style", style,
-				"--source-name", sourceName,
-			], {
+			const child = spawn(serverPath.command, buildPDFPreviewArgs(style, pageSize, sourceName), {
 				cwd: path.dirname(inputPath),
 			});
 
@@ -736,7 +749,7 @@ async function previewCurrentScriptPdf(styleOverride?: string): Promise<void> {
 
 		await openRenderedPdf(vscode.Uri.file(tempPath));
 		void vscode.window.showInformationMessage(
-			`${styleName} preview: ${path.basename(inputPath)}`,
+			`${styleName} preview (${pageSizeName}): ${path.basename(inputPath)}`,
 		);
 	} catch (error) {
 		if (error instanceof DownstageRenderError) {
@@ -764,12 +777,13 @@ function getRenderOutputChannel(): vscode.OutputChannel {
 async function runDownstageRender(
 	serverPath: string,
 	style: string,
+	pageSize: string,
 	inputPath: string,
 	outputChannel: vscode.OutputChannel,
 ): Promise<void> {
 	await new Promise<void>((resolve, reject) => {
 		let stderr = "";
-		const child = spawn(serverPath, ["render", "--style", style, inputPath], {
+		const child = spawn(serverPath, buildPDFRenderArgs(style, pageSize, inputPath), {
 			cwd: path.dirname(inputPath),
 		});
 

--- a/editors/vscode/src/lib.test.ts
+++ b/editors/vscode/src/lib.test.ts
@@ -1,6 +1,8 @@
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+	buildPDFPreviewArgs,
+	buildPDFRenderArgs,
 	type DiagnosticLike,
 	type FoldingRangeLike,
 	type RangeLike,
@@ -10,9 +12,11 @@ import {
 	DownstageRenderError,
 	findTitleValueSelection,
 	getNewPlayTemplate,
+	getPageSizeDisplayName,
 	getPreviewHtml,
 	getRenderStyleDisplayName,
 	getSamplePlayTemplate,
+	getValidatedPageSize,
 	getValidatedRenderStyle,
 	isCueSuggestionLine,
 	parseRenderDiagnostics,
@@ -190,6 +194,54 @@ describe("getRenderStyleDisplayName", () => {
 
 	it("maps condensed to Acting Edition", () => {
 		expect(getRenderStyleDisplayName("condensed")).toBe("Acting Edition");
+	});
+});
+
+describe("getValidatedPageSize", () => {
+	it("accepts letter", () => {
+		expect(getValidatedPageSize("letter")).toBe("letter");
+	});
+
+	it("accepts a4", () => {
+		expect(getValidatedPageSize("a4")).toBe("a4");
+	});
+
+	it("rejects unknown page sizes", () => {
+		expect(() => getValidatedPageSize("legal")).toThrow("Unsupported page size");
+	});
+});
+
+describe("getPageSizeDisplayName", () => {
+	it("maps letter to Letter", () => {
+		expect(getPageSizeDisplayName("letter")).toBe("Letter");
+	});
+
+	it("maps a4 to A4", () => {
+		expect(getPageSizeDisplayName("a4")).toBe("A4");
+	});
+});
+
+describe("buildPDFRenderArgs", () => {
+	it("includes page size in render args", () => {
+		expect(buildPDFRenderArgs("condensed", "a4", "/tmp/play.ds")).toEqual([
+			"render",
+			"--style", "condensed",
+			"--page-size", "a4",
+			"/tmp/play.ds",
+		]);
+	});
+});
+
+describe("buildPDFPreviewArgs", () => {
+	it("includes page size in preview args", () => {
+		expect(buildPDFPreviewArgs("standard", "letter", "play.ds")).toEqual([
+			"render",
+			"--stdin", "--stdout",
+			"--format", "pdf",
+			"--style", "standard",
+			"--page-size", "letter",
+			"--source-name", "play.ds",
+		]);
 	});
 });
 

--- a/editors/vscode/src/lib.ts
+++ b/editors/vscode/src/lib.ts
@@ -143,6 +143,7 @@ export function findTitleValueSelection(documentText: string): SelectionTarget {
 }
 
 const allowedRenderStyles = new Set(["standard", "condensed"]);
+const allowedPageSizes = new Set(["letter", "a4"]);
 
 export function getValidatedRenderStyle(style: string): string {
 	if (!allowedRenderStyles.has(style)) {
@@ -155,6 +156,45 @@ export function getRenderStyleDisplayName(style: string): string {
 	return getValidatedRenderStyle(style) === "condensed"
 		? "Acting Edition"
 		: "Manuscript";
+}
+
+export function getValidatedPageSize(pageSize: string): string {
+	if (!allowedPageSizes.has(pageSize)) {
+		throw new Error(`Unsupported page size: ${pageSize}`);
+	}
+	return pageSize;
+}
+
+export function getPageSizeDisplayName(pageSize: string): string {
+	return getValidatedPageSize(pageSize) === "a4" ? "A4" : "Letter";
+}
+
+export function buildPDFRenderArgs(
+	style: string,
+	pageSize: string,
+	inputPath: string,
+): string[] {
+	return [
+		"render",
+		"--style", getValidatedRenderStyle(style),
+		"--page-size", getValidatedPageSize(pageSize),
+		inputPath,
+	];
+}
+
+export function buildPDFPreviewArgs(
+	style: string,
+	pageSize: string,
+	sourceName: string,
+): string[] {
+	return [
+		"render",
+		"--stdin", "--stdout",
+		"--format", "pdf",
+		"--style", getValidatedRenderStyle(style),
+		"--page-size", getValidatedPageSize(pageSize),
+		"--source-name", sourceName,
+	];
 }
 
 export function getPreviewHtml(body: string): string {

--- a/internal/render/config.go
+++ b/internal/render/config.go
@@ -3,6 +3,7 @@ package render
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // Style represents a rendering style variant.
@@ -28,18 +29,51 @@ type PageSize string
 
 const (
 	PageLetter PageSize = "letter"
-	PageA4     PageSize = "A4"
+	PageA4     PageSize = "a4"
 )
 
-// ParsePageSize converts a string to a PageSize.
+// Dimensions describes a physical or logical page size in millimeters.
+type Dimensions struct {
+	WidthMM  float64
+	HeightMM float64
+}
+
+// ParsePageSize converts a string to a PageSize. Accepts both "a4" and "A4"
+// spellings but normalizes to the canonical lowercase constant.
 func ParsePageSize(s string) (PageSize, error) {
-	switch s {
-	case "letter", "Letter":
+	switch {
+	case strings.EqualFold(s, string(PageLetter)):
 		return PageLetter, nil
-	case "a4", "A4":
+	case strings.EqualFold(s, string(PageA4)):
 		return PageA4, nil
 	default:
 		return "", fmt.Errorf("unsupported page size: %q", s)
+	}
+}
+
+// SheetDimensions returns the physical sheet size in millimeters for standard
+// PDF rendering.
+func (p PageSize) SheetDimensions() (Dimensions, error) {
+	switch p {
+	case PageLetter:
+		return Dimensions{WidthMM: 215.9, HeightMM: 279.4}, nil
+	case PageA4:
+		return Dimensions{WidthMM: 210, HeightMM: 297}, nil
+	default:
+		return Dimensions{}, fmt.Errorf("unsupported page size: %q", p)
+	}
+}
+
+// CondensedPageDimensions returns the acting-edition logical page size derived
+// from the selected physical sheet: half-letter for Letter, A5 for A4.
+func (p PageSize) CondensedPageDimensions() (Dimensions, error) {
+	switch p {
+	case PageLetter:
+		return Dimensions{WidthMM: 139.7, HeightMM: 215.9}, nil
+	case PageA4:
+		return Dimensions{WidthMM: 148, HeightMM: 210}, nil
+	default:
+		return Dimensions{}, fmt.Errorf("unsupported page size: %q", p)
 	}
 }
 

--- a/internal/render/config_test.go
+++ b/internal/render/config_test.go
@@ -72,6 +72,54 @@ func TestParsePageSize(t *testing.T) {
 	}
 }
 
+func TestPageSizeSheetDimensions(t *testing.T) {
+	tests := []struct {
+		name string
+		size PageSize
+		want Dimensions
+	}{
+		{name: "letter", size: PageLetter, want: Dimensions{WidthMM: 215.9, HeightMM: 279.4}},
+		{name: "a4", size: PageA4, want: Dimensions{WidthMM: 210, HeightMM: 297}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.size.SheetDimensions()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPageSizeSheetDimensionsRejectsUnknown(t *testing.T) {
+	_, err := PageSize("legal").SheetDimensions()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported page size")
+}
+
+func TestPageSizeCondensedDimensions(t *testing.T) {
+	tests := []struct {
+		name string
+		size PageSize
+		want Dimensions
+	}{
+		{name: "letter", size: PageLetter, want: Dimensions{WidthMM: 139.7, HeightMM: 215.9}},
+		{name: "a4", size: PageA4, want: Dimensions{WidthMM: 148, HeightMM: 210}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.size.CondensedPageDimensions()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPageSizeCondensedDimensionsRejectsUnknown(t *testing.T) {
+	_, err := PageSize("legal").CondensedPageDimensions()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported page size")
+}
+
 func TestDefaultConfig(t *testing.T) {
 	got := DefaultConfig()
 

--- a/internal/render/pdf/base.go
+++ b/internal/render/pdf/base.go
@@ -69,13 +69,12 @@ type dialogueTextRun struct {
 	style string
 }
 
-func (b *pdfBase) initPDF(fontLoader func(*fpdf.Fpdf), defaultFamily string) {
-	size := string(b.cfg.PageSize)
-	if b.cfg.PageSize == render.PageLetter {
-		size = "Letter"
+func (b *pdfBase) initPDF(fontLoader func(*fpdf.Fpdf), defaultFamily string) error {
+	dim, err := b.cfg.PageSize.SheetDimensions()
+	if err != nil {
+		return err
 	}
-
-	b.pdf = fpdf.New("P", "mm", size, "")
+	b.pdf = newCustomSizePDF(dim.WidthMM, dim.HeightMM)
 
 	b.marginL = b.cfg.MarginLeft * pointsToMM
 	b.marginR = b.cfg.MarginRight * pointsToMM
@@ -117,6 +116,7 @@ func (b *pdfBase) initPDF(fontLoader func(*fpdf.Fpdf), defaultFamily string) {
 	b.pendingInlinePlayFirstBodyPage = false
 	b.inlinePlaySections = nil
 	b.activeTopLevelSection = nil
+	return nil
 }
 
 func (b *pdfBase) installPageNumberFooter(offset, height float64) {

--- a/internal/render/pdf/condensed.go
+++ b/internal/render/pdf/condensed.go
@@ -13,18 +13,13 @@ const condensedLineHeight = 4.5 // mm
 const halfInchPt = 36.0         // 0.5 inch in points
 const condensedSmallGapFactor = 0.25
 
-// Half-letter page size: 5.5" x 8.5"
-const (
-	halfLetterW = 139.7 // mm
-	halfLetterH = 215.9 // mm
-)
-
 var _ render.NodeRenderer = (*condensedRenderer)(nil)
 var _ dialoguePaginationStrategy = (*condensedRenderer)(nil)
 
 // NewCondensedRenderer creates an acting-edition PDF NodeRenderer.
-// Uses half-letter page, Libre Baskerville serif font, and compact layout
-// with character name + dialogue on the same line.
+// Uses a half-sheet logical page derived from the selected sheet size
+// (half-letter for Letter, A5 for A4), Libre Baskerville serif font, and a
+// compact layout with character name + dialogue on the same line.
 func NewCondensedRenderer(cfg render.Config) render.NodeRenderer {
 	// Override config for acting edition defaults
 	cfg.FontSize = 10
@@ -55,7 +50,9 @@ func (r *condensedRenderer) BeginDocument(doc *ast.Document, w io.Writer) error 
 	r.hasTitlePage = tp != nil
 	r.hasBody = render.DocumentHasRenderableBody(doc)
 	r.titlePageTitle = titlePageTitle(tp)
-	r.initCondensedPDF()
+	if err := r.initCondensedPDF(); err != nil {
+		return err
+	}
 	applyDocumentMetadata(&r.pdfBase, tp)
 	r.outlineLevels = buildOutlineLevels(doc)
 	r.inlinePlaySections = make(map[*ast.Section]bool)
@@ -71,8 +68,12 @@ func (r *condensedRenderer) EndDocument(_ *ast.Document) error {
 	return r.pdf.Output(r.w)
 }
 
-func (r *condensedRenderer) initCondensedPDF() {
-	r.pdf = newCustomSizePDF(halfLetterW, halfLetterH)
+func (r *condensedRenderer) initCondensedPDF() error {
+	dim, err := r.cfg.PageSize.CondensedPageDimensions()
+	if err != nil {
+		return err
+	}
+	r.pdf = newCustomSizePDF(dim.WidthMM, dim.HeightMM)
 
 	r.marginL = r.cfg.MarginLeft * pointsToMM
 	r.marginR = r.cfg.MarginRight * pointsToMM
@@ -106,6 +107,7 @@ func (r *condensedRenderer) initCondensedPDF() {
 
 	r.pdf.AddPage()
 	r.fontStyle = ""
+	return nil
 }
 
 // --- Front matter ---

--- a/internal/render/pdf/pdf.go
+++ b/internal/render/pdf/pdf.go
@@ -31,7 +31,9 @@ func (r *pdfRenderer) BeginDocument(doc *ast.Document, w io.Writer) error {
 	r.hasTitlePage = tp != nil
 	r.hasBody = render.DocumentHasRenderableBody(doc)
 	r.titlePageTitle = titlePageTitle(tp)
-	r.initPDF(loadBundledFont, defaultFontFamily)
+	if err := r.initPDF(loadBundledFont, defaultFontFamily); err != nil {
+		return err
+	}
 	applyDocumentMetadata(&r.pdfBase, tp)
 	r.outlineLevels = buildOutlineLevels(doc)
 	r.inlinePlaySections = make(map[*ast.Section]bool)

--- a/internal/render/pdf/pdf_test.go
+++ b/internal/render/pdf/pdf_test.go
@@ -518,6 +518,25 @@ func TestRender_A4PageSize(t *testing.T) {
 	assert.True(t, buf.Len() > 0)
 }
 
+func TestCondensedRenderer_UsesLetterDerivedPageSize(t *testing.T) {
+	r := NewCondensedRenderer(render.DefaultConfig()).(*condensedRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	assert.InDelta(t, 139.7, r.pageW, 0.01)
+	assert.InDelta(t, 215.9, r.pageH, 0.01)
+}
+
+func TestCondensedRenderer_UsesA5ForA4ParentSheet(t *testing.T) {
+	cfg := render.DefaultConfig()
+	cfg.PageSize = render.PageA4
+
+	r := NewCondensedRenderer(cfg).(*condensedRenderer)
+	require.NoError(t, r.BeginDocument(&ast.Document{}, &bytes.Buffer{}))
+
+	assert.InDelta(t, 148, r.pageW, 0.01)
+	assert.InDelta(t, 210, r.pageH, 0.01)
+}
+
 func TestRender_InlineFormatting(t *testing.T) {
 	r := NewRenderer(render.DefaultConfig())
 	doc := &ast.Document{

--- a/web/README.md
+++ b/web/README.md
@@ -3,8 +3,8 @@
 A browser-based Downstage editor with live preview, syntax highlighting,
 LSP-powered autocomplete and quick-fix code actions, browser-local draft
 storage, script-local spellcheck dictionaries, an Open Draft picker, and PDF
-export. The entire parsing and rendering pipeline runs client-side via
-WebAssembly — no server required.
+export with a page-size dialog. The entire parsing and rendering pipeline
+runs client-side via WebAssembly — no server required.
 
 ## Draft Storage
 
@@ -126,7 +126,7 @@ The WASM module exposes a global `downstage` object:
 | `completion(source, line, col)` | Source + 0-based LSP position | LSP `CompletionList` (`{isIncomplete, items[]}`) |
 | `codeActions(source, line, col, codes?)` | Source + 0-based LSP position + optional diagnostic-code filter | `{uri, actions: LSPCodeAction[]}` |
 | `renderHTML(source, style?)` | Source + optional style (`"standard"`/Manuscript or `"condensed"`/Acting Edition) | HTML string |
-| `renderPDF(source, style?)` | Source + optional style | `Uint8Array` (PDF bytes) |
+| `renderPDF(source, style?, pageSize?)` | Source + optional style and page size (`"letter"`/`"a4"`) | `Uint8Array` (PDF bytes) |
 | `semanticTokens(source)` | Source string | `Uint32Array` (delta-encoded LSP tokens) |
 | `tokenTypeNames` | — | `string[]` (token type legend) |
 

--- a/web/e2e/export.spec.ts
+++ b/web/e2e/export.spec.ts
@@ -74,4 +74,28 @@ test.describe("export", () => {
     expect(buf.slice(0, 5).toString("utf8")).toBe("%PDF-");
     expect(buf.byteLength).toBeGreaterThan(1000);
   });
+
+  test("Export PDF dialog respects A4 selection and persists it", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.setEditorContent(body);
+    await expect(editor.exportPdfButton).toBeEnabled();
+
+    const download = await editor.downloadPdf("a4");
+    const pdfPath = await download.path();
+    const buf = await readFile(pdfPath!);
+    expect(buf.slice(0, 5).toString("utf8")).toBe("%PDF-");
+    expect(buf.byteLength).toBeGreaterThan(1000);
+
+    const stored = await page.evaluate(() =>
+      window.localStorage.getItem("downstage-editor-export-page-size"),
+    );
+    expect(stored).toBe("a4");
+
+    // Reopen the dialog to confirm the prior selection is preselected.
+    await editor.exportPdfButton.click();
+    await expect(editor.exportDialog).toBeVisible();
+    await expect(editor.pageSizeOption("a4")).toHaveAttribute("aria-checked", "true");
+  });
 });

--- a/web/e2e/pages/EditorPage.ts
+++ b/web/e2e/pages/EditorPage.ts
@@ -29,7 +29,24 @@ export class EditorPage {
   }
 
   get exportPdfButton(): Locator {
-    return this.page.getByRole("button", { name: /Export PDF/ });
+    // The toolbar toggle and the confirm button inside the export dialog both
+    // read "Export PDF". Scope this accessor to the header so tests can still
+    // target the toolbar trigger unambiguously.
+    return this.page.locator("header").getByRole("button", { name: /Export PDF/ });
+  }
+
+  get exportDialog(): Locator {
+    return this.page.locator("dialog", {
+      has: this.page.getByRole("heading", { name: "Export PDF" }),
+    });
+  }
+
+  get exportConfirmButton(): Locator {
+    return this.exportDialog.locator('[data-testid="export-confirm"]');
+  }
+
+  pageSizeOption(value: "letter" | "a4"): Locator {
+    return this.exportDialog.locator(`button[data-page-size="${value}"]`);
   }
 
   // --- Workbench drawer ---
@@ -142,9 +159,15 @@ export class EditorPage {
     await expect(this.drawerTab(tab)).toHaveAttribute("aria-selected", "true");
   }
 
-  async downloadPdf(): Promise<Download> {
-    const downloadPromise = this.page.waitForEvent("download");
+  async downloadPdf(pageSize?: "letter" | "a4"): Promise<Download> {
     await this.exportPdfButton.click();
+    await expect(this.exportDialog).toBeVisible();
+    if (pageSize) {
+      await this.pageSizeOption(pageSize).click();
+      await expect(this.pageSizeOption(pageSize)).toHaveAttribute("aria-checked", "true");
+    }
+    const downloadPromise = this.page.waitForEvent("download");
+    await this.exportConfirmButton.click();
     return downloadPromise;
   }
 }

--- a/web/e2e/v1-migration.spec.ts
+++ b/web/e2e/v1-migration.spec.ts
@@ -67,9 +67,7 @@ test.describe("v1 migration", () => {
       /Export to PDF/,
     );
 
-    const downloadPromise = page.waitForEvent("download", { timeout: 30_000 });
-    await editor.exportPdfButton.click();
-    const download = await downloadPromise;
+    const download = await editor.downloadPdf();
     const pdf = await readFile((await download.path())!);
     expect(pdf.slice(0, 5).toString("utf8")).toBe("%PDF-");
   });

--- a/web/src/AppWeb.vue
+++ b/web/src/AppWeb.vue
@@ -4,10 +4,11 @@ import {
     Plus, FolderOpen, FileText, Download, Copy, ExternalLink, Trash2, FileOutput, Upload, AlertTriangle
 } from 'lucide-vue-next';
 import { Store } from './core/store';
-import type { EditorEnv, SavedDraft } from './core/types';
+import type { EditorEnv, ExportPdfOptions, PdfPageSize, SavedDraft } from './core/types';
 import ToolbarButton from './components/shared/ToolbarButton.vue';
 import BaseModal from './components/shared/BaseModal.vue';
 import DeleteConfirmationModal from './components/shared/DeleteConfirmationModal.vue';
+import ExportPdfModal from './components/shared/ExportPdfModal.vue';
 import ToastManager from './components/shared/ToastManager.vue';
 import Editor from './components/shared/Editor.vue';
 import WelcomeModal from './components/shared/WelcomeModal.vue';
@@ -20,11 +21,41 @@ const store = new Store(props.env);
 provide('store', store);
 
 const welcomeStorageKey = "downstage-editor-welcome-dismissed";
+const pageSizeStorageKey = "downstage-editor-export-page-size";
+const letterRegions = new Set(["CA", "MX", "PH", "US"]);
+
+function guessDefaultPageSize(): PdfPageSize {
+  if (typeof navigator === "undefined") return "a4";
+  const locales = navigator.languages && navigator.languages.length > 0
+    ? navigator.languages
+    : [navigator.language ?? ""];
+  for (const locale of locales) {
+    const region = locale.match(/-([A-Z]{2})$/u)?.[1];
+    if (region && letterRegions.has(region)) {
+      return "letter";
+    }
+  }
+  return "a4";
+}
+
+function readStoredPageSize(): PdfPageSize {
+  try {
+    const stored = localStorage.getItem(pageSizeStorageKey);
+    if (stored === "letter" || stored === "a4") {
+      return stored;
+    }
+  } catch {
+    // ignore storage errors
+  }
+  return guessDefaultPageSize();
+}
 
 const isLoaded = ref(false);
 const showDrafts = ref(false);
 const showWelcome = ref(false);
 const showNewPlayConfirm = ref(false);
+const showExportDialog = ref(false);
+const exportPageSize = ref<PdfPageSize>(readStoredPageSize());
 const activeContent = ref("");
 const pageStyle = ref("standard");
 const isV1Document = ref(false);
@@ -266,17 +297,29 @@ async function handleSave() {
     ]);
 }
 
-async function handleExport() {
+function handleExport() {
     if (isV1Document.value) {
         toastManager.value?.addToast("Upgrade this V1 document to V2 before exporting PDF", "error", 5000);
         return;
     }
 
+    showExportDialog.value = true;
+}
+
+async function handleExportConfirmed(opts: ExportPdfOptions) {
+    showExportDialog.value = false;
+    exportPageSize.value = opts.pageSize;
+    try {
+        localStorage.setItem(pageSizeStorageKey, opts.pageSize);
+    } catch {
+        // ignore storage errors
+    }
+
     const title = extractDocumentTitle(activeContent.value) || "untitled";
-    const styleSlug = pageStyle.value === "condensed" ? "acting-edition" : "manuscript";
+    const styleSlug = opts.style === "condensed" ? "acting-edition" : "manuscript";
     const filename = `${title.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}-${styleSlug}.pdf`;
-    
-    const pdfBytes = await props.env.renderPDF(activeContent.value, pageStyle.value);
+
+    const pdfBytes = await props.env.renderPDF(activeContent.value, opts.style, opts.pageSize);
     await props.env.saveFile(filename, pdfBytes, [
         { displayName: "PDF Files (*.pdf)", pattern: "*.pdf" }
     ]);
@@ -483,6 +526,13 @@ watch(activeContent, (newContent) => {
     <WelcomeModal
         :open="showWelcome"
         @close="dismissWelcome"
+    />
+
+    <ExportPdfModal
+        :open="showExportDialog"
+        :initial-options="{ pageSize: exportPageSize, style: pageStyle === 'condensed' ? 'condensed' : 'standard' }"
+        @close="showExportDialog = false"
+        @confirm="handleExportConfirmed"
     />
 
     <ToastManager ref="toastManager" />

--- a/web/src/components/shared/ExportPdfModal.vue
+++ b/web/src/components/shared/ExportPdfModal.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import BaseModal from './BaseModal.vue';
+import type { ExportPdfOptions, PdfExportStyle, PdfPageSize } from '../../core/types';
+
+const props = defineProps<{
+  open: boolean;
+  initialOptions: ExportPdfOptions;
+}>();
+
+const emit = defineEmits<{
+  (e: 'close'): void;
+  (e: 'confirm', options: ExportPdfOptions): void;
+}>();
+
+const pageSize = ref<PdfPageSize>(props.initialOptions.pageSize);
+const style = ref<PdfExportStyle>(props.initialOptions.style);
+
+watch(
+  () => [props.open, props.initialOptions.pageSize, props.initialOptions.style] as const,
+  ([isOpen, initialSize, initialStyle]) => {
+    if (isOpen) {
+      pageSize.value = initialSize;
+      style.value = initialStyle;
+    }
+  },
+);
+
+const condensedDerivedSize = computed(() =>
+  pageSize.value === 'a4' ? 'A5 (148 × 210 mm)' : 'half-letter (5.5 × 8.5 in)',
+);
+
+function selectPageSize(value: PdfPageSize) {
+  pageSize.value = value;
+}
+
+function selectStyle(value: PdfExportStyle) {
+  style.value = value;
+}
+
+function handleConfirm() {
+  emit('confirm', { pageSize: pageSize.value, style: style.value });
+}
+</script>
+
+<template>
+  <BaseModal
+    :open="open"
+    title="Export PDF"
+    message="Choose the format and sheet size for this export."
+    @close="emit('close')"
+  >
+    <div class="flex flex-col py-2 w-[392px]">
+      <label class="text-xs font-bold uppercase tracking-[0.15em] text-text-muted mb-2">
+        Page size
+      </label>
+      <div
+        role="radiogroup"
+        aria-label="Page size"
+        class="grid grid-cols-2 gap-2 mb-5 p-1 rounded-lg bg-black/5 dark:bg-white/5 border border-border"
+      >
+        <button
+          type="button"
+          role="radio"
+          :aria-checked="pageSize === 'letter'"
+          data-page-size="letter"
+          class="px-4 py-2 rounded-md text-sm font-bold transition-colors"
+          :class="pageSize === 'letter'
+            ? 'bg-brass-500 text-ember-850 shadow-sm'
+            : 'text-text-muted hover:text-text-main hover:bg-black/5 dark:hover:bg-white/10'"
+          @click="selectPageSize('letter')"
+        >
+          Letter
+        </button>
+        <button
+          type="button"
+          role="radio"
+          :aria-checked="pageSize === 'a4'"
+          data-page-size="a4"
+          class="px-4 py-2 rounded-md text-sm font-bold transition-colors"
+          :class="pageSize === 'a4'
+            ? 'bg-brass-500 text-ember-850 shadow-sm'
+            : 'text-text-muted hover:text-text-main hover:bg-black/5 dark:hover:bg-white/10'"
+          @click="selectPageSize('a4')"
+        >
+          A4
+        </button>
+      </div>
+
+      <label class="text-xs font-bold uppercase tracking-[0.15em] text-text-muted mb-2">
+        Format
+      </label>
+      <div
+        role="radiogroup"
+        aria-label="Export format"
+        class="grid grid-cols-2 gap-2 p-1 rounded-lg bg-black/5 dark:bg-white/5 border border-border"
+      >
+        <button
+          type="button"
+          role="radio"
+          :aria-checked="style === 'standard'"
+          data-export-style="standard"
+          class="px-4 py-2 rounded-md text-sm font-bold transition-colors"
+          :class="style === 'standard'
+            ? 'bg-brass-500 text-ember-850 shadow-sm'
+            : 'text-text-muted hover:text-text-main hover:bg-black/5 dark:hover:bg-white/10'"
+          @click="selectStyle('standard')"
+        >
+          Manuscript
+        </button>
+        <button
+          type="button"
+          role="radio"
+          :aria-checked="style === 'condensed'"
+          data-export-style="condensed"
+          class="px-4 py-2 rounded-md text-sm font-bold transition-colors"
+          :class="style === 'condensed'
+            ? 'bg-brass-500 text-ember-850 shadow-sm'
+            : 'text-text-muted hover:text-text-main hover:bg-black/5 dark:hover:bg-white/10'"
+          @click="selectStyle('condensed')"
+        >
+          Acting Edition
+        </button>
+      </div>
+
+      <div
+        v-if="style === 'condensed'"
+        data-testid="condensed-sheet-note"
+        class="mt-3 mb-6 px-3 py-2 rounded-lg border border-brass-500/30 bg-brass-500/5 text-xs text-text-muted leading-relaxed"
+      >
+        Acting edition renders on <strong class="font-semibold text-text-main">{{ condensedDerivedSize }}</strong> —
+        the half-sheet derived from the selected page size.
+      </div>
+      <div v-else class="mb-6" />
+
+      <div class="flex gap-3 w-full">
+        <button
+          type="button"
+          class="flex-1 px-4 py-2.5 rounded-lg border border-border text-sm font-bold hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+          @click="emit('close')"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          data-testid="export-confirm"
+          class="flex-1 px-4 py-2.5 rounded-lg bg-brass-500 text-ember-850 text-sm font-bold hover:brightness-110 transition-all shadow-lg"
+          @click="handleConfirm"
+        >
+          Export PDF
+        </button>
+      </div>
+    </div>
+  </BaseModal>
+</template>

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -132,6 +132,14 @@ export interface EditorDiagnostic {
   code?: string;
 }
 
+export type PdfPageSize = "letter" | "a4";
+export type PdfExportStyle = "standard" | "condensed";
+
+export interface ExportPdfOptions {
+  pageSize: PdfPageSize;
+  style: PdfExportStyle;
+}
+
 export interface SavedDraft {
   id: string;
   title: string;
@@ -155,7 +163,7 @@ export interface EditorEnv {
 
   // Rendering
   renderHTML(source: string, style?: string): Promise<string>;
-  renderPDF(source: string, style?: string): Promise<Uint8Array>;
+  renderPDF(source: string, style?: string, pageSize?: PdfPageSize): Promise<Uint8Array>;
 
   // Persistence (Drafts)
   loadDrafts(): Promise<SavedDraft[]>;

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -27,7 +27,7 @@ declare global {
       codeActions(source: string, line: number, col: number, codes?: string[]): LSPCodeActionsResult;
       documentSymbols(source: string): DocumentSymbolsResult;
       renderHTML(source: string, style?: string): string;
-      renderPDF(source: string, style?: string): Uint8Array;
+      renderPDF(source: string, style?: string, pageSize?: string): Uint8Array;
       semanticTokens(source: string): Uint32Array;
       stats(source: string): ManuscriptStats;
       tokenTypeNames: string[];
@@ -136,8 +136,8 @@ export function renderHTML(source: string, style?: string): string {
   return window.downstage.renderHTML(source, style);
 }
 
-export function renderPDF(source: string, style?: string): Uint8Array {
-  return window.downstage.renderPDF(source, style);
+export function renderPDF(source: string, style?: string, pageSize?: string): Uint8Array {
+  return window.downstage.renderPDF(source, style, pageSize);
 }
 
 export function stats(source: string): ManuscriptStats {

--- a/web/src/web-app.ts
+++ b/web/src/web-app.ts
@@ -92,8 +92,8 @@ class WebEnv implements EditorEnv {
     return window.downstage.renderHTML(source, style);
   }
 
-  async renderPDF(source: string, style?: string): Promise<Uint8Array> {
-    return window.downstage.renderPDF(source, style);
+  async renderPDF(source: string, style?: string, pageSize?: string): Promise<Uint8Array> {
+    return window.downstage.renderPDF(source, style, pageSize);
   }
 
   async loadDrafts(): Promise<SavedDraft[]> {


### PR DESCRIPTION
Closes #122.

## Summary

- Core renderer models page size once in `render.Config` and derives PDF dimensions from it. Standard PDF renders on the selected physical sheet (Letter 215.9×279.4mm, A4 210×297mm). Condensed PDF derives its logical page from the parent sheet: half-letter (Letter) or A5 (A4), replacing the hardcoded half-letter assumption.
- `render.PageA4` canonical string is now `"a4"` (was `"A4"`) to match CLI/WASM input shape. `ParsePageSize` remains case-insensitive, so string *input* handling is preserved.
- CLI `--page-size` already existed; added tests for invalid values and A4+condensed rendering.
- WASM `renderPDF` accepts an optional third `pageSize` arg.
- VS Code gains a `downstage.render.pageSize` setting (enum `letter`/`a4`, default `letter`) threaded through render and preview commands.
- Web editor switches PDF export from fire-and-download to a new `ExportPdfModal.vue` that exposes **Page size** (Letter / A4) and **Format** (Manuscript / Acting Edition). Format defaults to the current preview style. When Acting Edition is selected a callout shows the derived half-sheet (half-letter or A5). Page-size choice persists in localStorage; default seeds via locale heuristic (Letter for US/CA/MX/PH, else A4). Confirm payload is a typed `ExportPdfOptions` so imposition controls from #121 can extend it without event-signature churn.
- e2e suite updated for the new modal: `EditorPage.downloadPdf(pageSize?)` helper drives the dialog; `export.spec` adds an A4-selection + persistence test; `v1-migration.spec` routes through the updated helper.
- Docs updated in `README.md`, `SPEC.md`, `editors/vscode/README.md`, and `web/README.md`.

## Breaking change

The `render.PageA4` constant value is now `"a4"` (was `"A4"`). External Go callers that assigned the raw string `"A4"` directly to `Config.PageSize` must switch to `render.PageA4` or `ParsePageSize`. Downstage is pre-1.0 and issue #122 canonicalizes lowercase across the stack.

## Test plan

- [x] `go test ./...`
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `make wasm` + `make web` build cleanly
- [x] `npm --prefix editors/vscode test` (51 passed) + `npm --prefix editors/vscode run compile`
- [x] `npm --prefix web test` (54 passed, incl. typecheck)
- [x] `npm --prefix web run test:e2e` (25 passed, incl. the new A4-persistence spec and updated v1-migration)
- [x] Manual CLI smoke: `pdfinfo` confirms Letter=612×792, A4=595.28×841.89, half-letter=396×612, A5=419.53×595.28
- [x] Manual CLI reject: `--page-size legal` errors with "unsupported page size"