### PR TITLE
feat(pdf): add 2-up and booklet layouts for acting edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,17 @@ Both formats support two styles via `--style`:
 PDF also supports `--page-size letter` (default) and `--page-size a4`.
 Manuscript output renders on the selected sheet size. Acting edition output
 derives its logical page from that sheet size: half-letter for Letter, A5 for
-A4. HTML produces a self-contained document with embedded CSS using semantic
+A4.
+
+Acting edition can be imposed for print via `--pdf-layout`:
+
+- `single` (default) — one logical page per sheet
+- `2up` — two logical pages per landscape sheet
+- `booklet` — duplex booklet order, padded to a multiple of 4. Print double-sided,
+  then fold in half. `--gutter <measurement>` sets the inside gap (default
+  `0.125in`; accepts `in` and `mm`).
+
+HTML produces a self-contained document with embedded CSS using semantic
 `.downstage-*` class names for custom styling.
 
 ### Statistics

--- a/SPEC.md
+++ b/SPEC.md
@@ -578,6 +578,24 @@ PDF output supports `--page-size letter` (default) and `--page-size a4`.
 Manuscript layout renders on the selected physical sheet. Condensed layout
 derives its logical page from that sheet: half-letter for Letter, A5 for A4.
 
+### PDF Layout
+
+PDF output supports three layouts via `--pdf-layout`:
+
+- **single** (default): one logical page per sheet. Valid for both styles.
+- **2up**: two logical pages side-by-side on a landscape sheet. Condensed only.
+- **booklet**: landscape sheets in duplex booklet order; pages are padded to a
+  multiple of four and reordered so that printing double-sided and folding in
+  half yields a booklet. The back-cover slot is always reserved as blank —
+  when the source page count is already a multiple of four, an extra sheet of
+  padding is added so the last content page never lands opposite the title
+  page on the outer sheet. Condensed only.
+
+Booklet layout accepts `--gutter <measurement>` to control the inside gap
+between the two imposed pages on each sheet. Default `0.125in`. Accepts `in`
+and `mm` suffixes (e.g. `3mm`, `0.25in`). Booklet output preserves logical
+page numbers in footers so cross-references in the script remain readable.
+
 ### HTML Output
 
 HTML rendering produces a single self-contained `.html` file with an embedded stylesheet. The output uses semantic HTML with stable CSS class names for all major structures:

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -167,10 +167,14 @@ func runRender(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer closer()
 
 	if err := renderTo(writer, nr, doc, cfg); err != nil {
+		closer() // best-effort; don't clobber the render error
 		return fmt.Errorf("rendering: %w", err)
+	}
+
+	if err := closer(); err != nil {
+		return fmt.Errorf("closing output: %w", err)
 	}
 
 	if renderStdout {
@@ -192,9 +196,12 @@ func gutterExplicitlySet(cmd *cobra.Command) bool {
 	return renderGutter != defaultGutter
 }
 
-func openOutput(filename string) (io.Writer, func(), error) {
+// openOutput returns the target writer and a closer that surfaces any
+// Close() error (so disk flush failures don't pass silently). For stdout
+// the closer is a no-op.
+func openOutput(filename string) (io.Writer, func() error, error) {
 	if renderStdout {
-		return os.Stdout, func() {}, nil
+		return os.Stdout, func() error { return nil }, nil
 	}
 	if renderOutput == "" {
 		renderOutput = strings.TrimSuffix(filename, filepath.Ext(filename)) + "." + renderFormat
@@ -203,7 +210,7 @@ func openOutput(filename string) (io.Writer, func(), error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating output file: %w", err)
 	}
-	return f, func() { f.Close() }, nil
+	return f, f.Close, nil
 }
 
 // renderTo writes the rendered document to w. For non-single PDF layouts it

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -184,11 +184,11 @@ func runRender(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// defaultGutter matches the flag default; anything else is treated as an
-// explicit user override. Tests invoke runRender with ad-hoc cobra commands
-// that do not carry flag-changed metadata, so we fall back to a value check.
 const defaultGutter = "0.125in"
 
+// gutterExplicitlySet reports whether the user set --gutter. The ad-hoc
+// cobra.Command instances used in unit tests don't carry flag-changed
+// metadata, so we fall back to a value comparison against the default.
 func gutterExplicitlySet(cmd *cobra.Command) bool {
 	if flag := cmd.Flags().Lookup("gutter"); flag != nil && flag.Changed {
 		return true
@@ -196,9 +196,6 @@ func gutterExplicitlySet(cmd *cobra.Command) bool {
 	return renderGutter != defaultGutter
 }
 
-// openOutput returns the target writer and a closer that surfaces any
-// Close() error (so disk flush failures don't pass silently). For stdout
-// the closer is a no-op.
 func openOutput(filename string) (io.Writer, func() error, error) {
 	if renderStdout {
 		return os.Stdout, func() error { return nil }, nil
@@ -213,9 +210,6 @@ func openOutput(filename string) (io.Writer, func() error, error) {
 	return f, f.Close, nil
 }
 
-// renderTo writes the rendered document to w. For non-single PDF layouts it
-// renders into an in-memory buffer and post-processes through the impose
-// package to compose 2-up or booklet sheets.
 func renderTo(w io.Writer, nr render.NodeRenderer, doc *ast.Document, cfg render.Config) error {
 	if cfg.Layout == render.LayoutSingle {
 		return render.Walk(nr, doc, w)

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log/slog"
@@ -8,10 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/jscaltreto/downstage/internal/ast"
 	"github.com/jscaltreto/downstage/internal/parser"
 	"github.com/jscaltreto/downstage/internal/render"
 	htmlrender "github.com/jscaltreto/downstage/internal/render/html"
 	"github.com/jscaltreto/downstage/internal/render/pdf"
+	"github.com/jscaltreto/downstage/internal/render/pdf/impose"
 	"github.com/spf13/cobra"
 )
 
@@ -20,6 +23,8 @@ var (
 	renderOutput        string
 	renderPageSize      string
 	renderStyle         string
+	renderLayout        string
+	renderGutter        string
 	renderFont          string
 	renderStdin         bool
 	renderStdout        bool
@@ -40,6 +45,8 @@ func init() {
 	renderCmd.Flags().StringVarP(&renderOutput, "output", "o", "", "output file (default: input name with format extension)")
 	renderCmd.Flags().StringVar(&renderPageSize, "page-size", "letter", "page size: letter, a4")
 	renderCmd.Flags().StringVar(&renderStyle, "style", "standard", "rendering style: standard (Manuscript), condensed (Acting Edition)")
+	renderCmd.Flags().StringVar(&renderLayout, "pdf-layout", "single", "PDF layout: single, 2up, booklet (2up and booklet are condensed-only)")
+	renderCmd.Flags().StringVar(&renderGutter, "gutter", defaultGutter, "booklet inner gutter (e.g. 0.125in or 3mm); only valid with --pdf-layout booklet")
 	renderCmd.Flags().StringVar(&renderFont, "font", "", "path to a custom TTF font file")
 	renderCmd.Flags().BoolVar(&renderStdin, "stdin", false, "read input from stdin instead of a file")
 	renderCmd.Flags().BoolVar(&renderStdout, "stdout", false, "write output to stdout instead of a file")
@@ -102,6 +109,11 @@ func runRender(cmd *cobra.Command, args []string) error {
 	cfg.Style = style
 	cfg.SourceAnchors = renderSourceAnchors
 
+	layout, err := render.ParsePDFLayout(renderLayout)
+	if err != nil {
+		return err
+	}
+
 	var nr render.NodeRenderer
 	switch renderFormat {
 	case "pdf":
@@ -110,7 +122,19 @@ func runRender(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		cfg.PageSize = pageSize
+		cfg.Layout = layout
 		cfg.FontPath = renderFont
+
+		if layout == render.LayoutBooklet {
+			gutterMM, err := render.ParseMeasurement(renderGutter)
+			if err != nil {
+				return fmt.Errorf("--gutter: %w", err)
+			}
+			cfg.BookletGutterMM = gutterMM
+		} else if gutterExplicitlySet(cmd) {
+			return fmt.Errorf("--gutter is only valid with --pdf-layout booklet")
+		}
+
 		switch cfg.Style {
 		case render.StyleCondensed:
 			nr = pdf.NewCondensedRenderer(cfg)
@@ -120,6 +144,12 @@ func runRender(cmd *cobra.Command, args []string) error {
 	case "html":
 		if renderPageSize != "letter" {
 			return fmt.Errorf("--page-size is only supported for pdf output")
+		}
+		if layout != render.LayoutSingle {
+			return fmt.Errorf("--pdf-layout is only supported for pdf output")
+		}
+		if gutterExplicitlySet(cmd) {
+			return fmt.Errorf("--gutter is only supported for pdf output")
 		}
 		if renderFont != "" {
 			return fmt.Errorf("--font is only supported for pdf output")
@@ -133,32 +163,73 @@ func runRender(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid render config: %w", err)
 	}
 
-	if renderStdout {
-		if err := render.Walk(nr, doc, os.Stdout); err != nil {
-			return fmt.Errorf("rendering: %w", err)
-		}
-		return nil
-	}
-
-	output := renderOutput
-	if output == "" {
-		output = strings.TrimSuffix(filename, filepath.Ext(filename)) + "." + renderFormat
-	}
-
-	f, err := os.Create(output)
+	writer, closer, err := openOutput(filename)
 	if err != nil {
-		return fmt.Errorf("creating output file: %w", err)
+		return err
 	}
+	defer closer()
 
-	if err := render.Walk(nr, doc, f); err != nil {
-		f.Close()
+	if err := renderTo(writer, nr, doc, cfg); err != nil {
 		return fmt.Errorf("rendering: %w", err)
 	}
 
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("closing output file: %w", err)
+	if renderStdout {
+		return nil
+	}
+	slog.Info("rendered", "output", renderOutput, "format", renderFormat)
+	return nil
+}
+
+// defaultGutter matches the flag default; anything else is treated as an
+// explicit user override. Tests invoke runRender with ad-hoc cobra commands
+// that do not carry flag-changed metadata, so we fall back to a value check.
+const defaultGutter = "0.125in"
+
+func gutterExplicitlySet(cmd *cobra.Command) bool {
+	if flag := cmd.Flags().Lookup("gutter"); flag != nil && flag.Changed {
+		return true
+	}
+	return renderGutter != defaultGutter
+}
+
+func openOutput(filename string) (io.Writer, func(), error) {
+	if renderStdout {
+		return os.Stdout, func() {}, nil
+	}
+	if renderOutput == "" {
+		renderOutput = strings.TrimSuffix(filename, filepath.Ext(filename)) + "." + renderFormat
+	}
+	f, err := os.Create(renderOutput)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating output file: %w", err)
+	}
+	return f, func() { f.Close() }, nil
+}
+
+// renderTo writes the rendered document to w. For non-single PDF layouts it
+// renders into an in-memory buffer and post-processes through the impose
+// package to compose 2-up or booklet sheets.
+func renderTo(w io.Writer, nr render.NodeRenderer, doc *ast.Document, cfg render.Config) error {
+	if cfg.Layout == render.LayoutSingle {
+		return render.Walk(nr, doc, w)
 	}
 
-	slog.Info("rendered", "output", output, "format", renderFormat)
-	return nil
+	var buf bytes.Buffer
+	if err := render.Walk(nr, doc, &buf); err != nil {
+		return err
+	}
+
+	sheet, err := cfg.PageSize.SheetDimensions()
+	if err != nil {
+		return err
+	}
+
+	switch cfg.Layout {
+	case render.Layout2Up:
+		return impose.TwoUp(bytes.NewReader(buf.Bytes()), sheet, w)
+	case render.LayoutBooklet:
+		return impose.Booklet(bytes.NewReader(buf.Bytes()), sheet, cfg.BookletGutterMM, w)
+	default:
+		return fmt.Errorf("unsupported layout %q", cfg.Layout)
+	}
 }

--- a/cmd/render_validate_test.go
+++ b/cmd/render_validate_test.go
@@ -15,6 +15,8 @@ func resetRenderFlags() {
 	renderOutput = ""
 	renderPageSize = "letter"
 	renderStyle = "standard"
+	renderLayout = "single"
+	renderGutter = "0.125in"
 	renderFont = ""
 	renderStdin = false
 	renderStdout = false
@@ -84,6 +86,181 @@ func TestRunRenderRejectsHTMLOnlyPDFFlags(t *testing.T) {
 	err = runRender(&cobra.Command{}, []string{input})
 	if err == nil || !strings.Contains(err.Error(), "--font is only supported for pdf output") {
 		t.Fatalf("expected html font rejection, got %v", err)
+	}
+}
+
+func TestRunRenderRejectsStandard2Up(t *testing.T) {
+	resetRenderFlags()
+
+	input := t.TempDir() + "/play.ds"
+	if err := os.WriteFile(input, []byte("# Play\n\nALICE\nHello.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	renderStyle = "standard"
+	renderLayout = "2up"
+	renderOutput = t.TempDir() + "/out.pdf"
+
+	err := runRender(&cobra.Command{}, []string{input})
+	if err == nil || !strings.Contains(err.Error(), "only supported for style") {
+		t.Fatalf("expected condensed-only rejection, got %v", err)
+	}
+}
+
+func TestRunRenderRejectsStandardBooklet(t *testing.T) {
+	resetRenderFlags()
+
+	input := t.TempDir() + "/play.ds"
+	if err := os.WriteFile(input, []byte("# Play\n\nALICE\nHello.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	renderStyle = "standard"
+	renderLayout = "booklet"
+	renderOutput = t.TempDir() + "/out.pdf"
+
+	err := runRender(&cobra.Command{}, []string{input})
+	if err == nil || !strings.Contains(err.Error(), "only supported for style") {
+		t.Fatalf("expected condensed-only rejection, got %v", err)
+	}
+}
+
+func TestRunRenderRejectsGutterOnNonBooklet(t *testing.T) {
+	resetRenderFlags()
+
+	input := t.TempDir() + "/play.ds"
+	if err := os.WriteFile(input, []byte("# Play\n\nALICE\nHello.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	renderStyle = "condensed"
+	renderLayout = "2up"
+	renderGutter = "3mm"
+	renderOutput = t.TempDir() + "/out.pdf"
+
+	err := runRender(&cobra.Command{}, []string{input})
+	if err == nil || !strings.Contains(err.Error(), "--gutter is only valid") {
+		t.Fatalf("expected gutter/2up rejection, got %v", err)
+	}
+}
+
+func TestRunRenderRejectsLayoutForHTML(t *testing.T) {
+	resetRenderFlags()
+
+	input := t.TempDir() + "/play.ds"
+	if err := os.WriteFile(input, []byte("# Play\n\nALICE\nHello.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	renderFormat = "html"
+	renderLayout = "2up"
+	renderOutput = t.TempDir() + "/out.html"
+
+	err := runRender(&cobra.Command{}, []string{input})
+	if err == nil || !strings.Contains(err.Error(), "--pdf-layout is only supported for pdf output") {
+		t.Fatalf("expected html layout rejection, got %v", err)
+	}
+}
+
+func TestRunRenderRejectsInvalidLayout(t *testing.T) {
+	resetRenderFlags()
+
+	input := t.TempDir() + "/play.ds"
+	if err := os.WriteFile(input, []byte("# Play\n\nALICE\nHello.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	renderLayout = "4up"
+
+	err := runRender(&cobra.Command{}, []string{input})
+	if err == nil || !strings.Contains(err.Error(), "unsupported pdf layout") {
+		t.Fatalf("expected layout parse error, got %v", err)
+	}
+}
+
+func TestRunRenderRejectsInvalidGutter(t *testing.T) {
+	resetRenderFlags()
+
+	input := t.TempDir() + "/play.ds"
+	if err := os.WriteFile(input, []byte("# Play\n\nALICE\nHello.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	renderStyle = "condensed"
+	renderLayout = "booklet"
+	renderGutter = "3cm"
+	renderOutput = t.TempDir() + "/out.pdf"
+
+	err := runRender(&cobra.Command{}, []string{input})
+	if err == nil || !strings.Contains(err.Error(), "--gutter") {
+		t.Fatalf("expected gutter parse error, got %v", err)
+	}
+}
+
+func TestRunRenderSupportsCondensed2Up(t *testing.T) {
+	resetRenderFlags()
+
+	input := t.TempDir() + "/play.ds"
+	body := "# Test\n\n## ACT I\n\n### SCENE 1\n\nALICE\nLine 1.\n\nBOB\nLine 2.\n\n"
+	if err := os.WriteFile(input, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	renderStyle = "condensed"
+	renderLayout = "2up"
+	renderStdout = true
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	renderErr := runRender(&cobra.Command{}, []string{input})
+
+	w.Close()
+	os.Stdout = origStdout
+
+	if renderErr != nil {
+		t.Fatalf("expected condensed 2up to succeed, got: %v", renderErr)
+	}
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(buf.String(), "%PDF-") {
+		t.Fatalf("expected PDF magic bytes, got %q", buf.String()[:20])
+	}
+}
+
+func TestRunRenderSupportsCondensedBooklet(t *testing.T) {
+	resetRenderFlags()
+
+	input := t.TempDir() + "/play.ds"
+	body := "# Test\n\n## ACT I\n\n### SCENE 1\n\nALICE\nLine 1.\n\nBOB\nLine 2.\n\n"
+	if err := os.WriteFile(input, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	renderStyle = "condensed"
+	renderLayout = "booklet"
+	renderGutter = "3mm"
+	renderStdout = true
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	renderErr := runRender(&cobra.Command{}, []string{input})
+
+	w.Close()
+	os.Stdout = origStdout
+
+	if renderErr != nil {
+		t.Fatalf("expected condensed booklet to succeed, got: %v", renderErr)
+	}
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(buf.String(), "%PDF-") {
+		t.Fatalf("expected PDF magic bytes, got %q", buf.String()[:20])
 	}
 }
 

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jscaltreto/downstage/internal/render"
 	htmlrender "github.com/jscaltreto/downstage/internal/render/html"
 	pdfrender "github.com/jscaltreto/downstage/internal/render/pdf"
+	"github.com/jscaltreto/downstage/internal/render/pdf/impose"
 	"github.com/jscaltreto/downstage/internal/stats"
 	"go.lsp.dev/protocol"
 )
@@ -255,15 +256,53 @@ func renderPDF(_ js.Value, args []js.Value) any {
 	}
 
 	cfg := render.DefaultConfig()
-	if len(args) > 1 && args[1].String() == "condensed" {
-		cfg.Style = render.StyleCondensed
+
+	// Legacy positional args are still accepted for one release, so existing
+	// callers keep working: renderPDF(source, style?, pageSize?). The preferred
+	// shape is renderPDF(source, {style, pageSize, layout, gutter}).
+	if len(args) > 1 {
+		if args[1].Type() == js.TypeObject {
+			cfgObj := args[1]
+			if v := cfgObj.Get("style"); v.Truthy() {
+				if v.String() == "condensed" {
+					cfg.Style = render.StyleCondensed
+				}
+			}
+			if v := cfgObj.Get("pageSize"); v.Truthy() {
+				ps, err := render.ParsePageSize(v.String())
+				if err != nil {
+					return js.Null()
+				}
+				cfg.PageSize = ps
+			}
+			if v := cfgObj.Get("layout"); v.Truthy() {
+				layout, err := render.ParsePDFLayout(v.String())
+				if err != nil {
+					return js.Null()
+				}
+				cfg.Layout = layout
+			}
+			if v := cfgObj.Get("gutter"); v.Truthy() {
+				gutterMM, err := render.ParseMeasurement(v.String())
+				if err != nil {
+					return js.Null()
+				}
+				cfg.BookletGutterMM = gutterMM
+			}
+		} else if args[1].String() == "condensed" {
+			cfg.Style = render.StyleCondensed
+		}
 	}
-	if len(args) > 2 && args[2].Truthy() {
+	if len(args) > 2 && args[2].Truthy() && args[1].Type() != js.TypeObject {
 		pageSize, err := render.ParsePageSize(args[2].String())
 		if err != nil {
 			return js.Null()
 		}
 		cfg.PageSize = pageSize
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return js.Null()
 	}
 
 	var nr render.NodeRenderer
@@ -276,6 +315,26 @@ func renderPDF(_ js.Value, args []js.Value) any {
 	var buf bytes.Buffer
 	if err := render.Walk(nr, doc, &buf); err != nil {
 		return js.Null()
+	}
+
+	// Second pass: imposition for non-single layouts.
+	if cfg.Layout != render.LayoutSingle {
+		sheet, err := cfg.PageSize.SheetDimensions()
+		if err != nil {
+			return js.Null()
+		}
+		var imposed bytes.Buffer
+		switch cfg.Layout {
+		case render.Layout2Up:
+			if err := impose.TwoUp(bytes.NewReader(buf.Bytes()), sheet, &imposed); err != nil {
+				return js.Null()
+			}
+		case render.LayoutBooklet:
+			if err := impose.Booklet(bytes.NewReader(buf.Bytes()), sheet, cfg.BookletGutterMM, &imposed); err != nil {
+				return js.Null()
+			}
+		}
+		buf = imposed
 	}
 
 	data := buf.Bytes()

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -257,9 +257,9 @@ func renderPDF(_ js.Value, args []js.Value) any {
 
 	cfg := render.DefaultConfig()
 
-	// Legacy positional args are still accepted for one release, so existing
-	// callers keep working: renderPDF(source, style?, pageSize?). The preferred
-	// shape is renderPDF(source, {style, pageSize, layout, gutter}).
+	// Accept either the structured config object or the legacy positional
+	// (style, pageSize) form for one release so existing callers keep
+	// working during the migration.
 	if len(args) > 1 {
 		if args[1].Type() == js.TypeObject {
 			cfgObj := args[1]
@@ -282,9 +282,8 @@ func renderPDF(_ js.Value, args []js.Value) any {
 				}
 				cfg.Layout = layout
 			}
-			// Gutter only applies to booklet layout. Parsing it for
-			// single/2up exports would let a stale or malformed value
-			// break an export that never uses it.
+			// Only parse gutter for booklet layout; other layouts never use
+			// it, so a stale or malformed value shouldn't fail the export.
 			if cfg.Layout == render.LayoutBooklet {
 				if v := cfgObj.Get("gutter"); v.Truthy() {
 					gutterMM, err := render.ParseMeasurement(v.String())
@@ -322,7 +321,6 @@ func renderPDF(_ js.Value, args []js.Value) any {
 		return js.Null()
 	}
 
-	// Second pass: imposition for non-single layouts.
 	if cfg.Layout != render.LayoutSingle {
 		sheet, err := cfg.PageSize.SheetDimensions()
 		if err != nil {

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -282,12 +282,17 @@ func renderPDF(_ js.Value, args []js.Value) any {
 				}
 				cfg.Layout = layout
 			}
-			if v := cfgObj.Get("gutter"); v.Truthy() {
-				gutterMM, err := render.ParseMeasurement(v.String())
-				if err != nil {
-					return js.Null()
+			// Gutter only applies to booklet layout. Parsing it for
+			// single/2up exports would let a stale or malformed value
+			// break an export that never uses it.
+			if cfg.Layout == render.LayoutBooklet {
+				if v := cfgObj.Get("gutter"); v.Truthy() {
+					gutterMM, err := render.ParseMeasurement(v.String())
+					if err != nil {
+						return js.Null()
+					}
+					cfg.BookletGutterMM = gutterMM
 				}
-				cfg.BookletGutterMM = gutterMM
 			}
 		} else if args[1].String() == "condensed" {
 			cfg.Style = render.StyleCondensed

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -36,8 +36,17 @@ not blocked on file setup.
 
 Export the current script to either a Manuscript PDF or an Acting Edition PDF
 from the command palette. Set `downstage.render.pageSize` to choose `letter`
-or `a4` for export and preview. The generated file opens automatically unless
-you turn that off.
+or `a4` for export and preview.
+
+Acting Edition has three layouts:
+
+- `Export Acting Edition PDF` — one logical page per sheet
+- `Export Acting Edition PDF (2-Up)` — two logical pages per landscape sheet
+- `Export Acting Edition PDF (Booklet)` — duplex booklet order; print
+  double-sided, then fold in half. `downstage.render.bookletGutter` controls
+  the inside gap (default `0.125in`).
+
+The generated file opens automatically unless you turn that off.
 
 ### Writing Help
 
@@ -77,6 +86,8 @@ parentheticals, character cues, aliases, verse, and comments.
 | Downstage: Restart Downstage | Restart the Downstage background services |
 | Downstage: Export Manuscript PDF | Export the current script as a manuscript PDF |
 | Downstage: Export Acting Edition PDF | Export the current script as an acting edition PDF |
+| Downstage: Export Acting Edition PDF (2-Up) | Two logical pages per landscape sheet |
+| Downstage: Export Acting Edition PDF (Booklet) | Duplex booklet order; print double-sided, then fold in half |
 | Downstage: Open Manuscript PDF Preview | Preview the manuscript PDF in VS Code |
 | Downstage: Open Acting Edition PDF Preview | Preview the acting edition PDF in VS Code |
 | Downstage: Open Live Preview | Open the live-updating manuscript preview |
@@ -90,6 +101,7 @@ parentheticals, character cues, aliases, verse, and comments.
 | `downstage.editor.autoSuggestCharacterCues` | boolean | `true` | Auto-trigger cue suggestions on empty lines |
 | `downstage.render.style` | string | `"standard"` | Default export style. `standard` means Manuscript. `condensed` means Acting Edition |
 | `downstage.render.pageSize` | string | `"letter"` | Default PDF page size for manuscript and acting edition export. Supports `letter` and `a4` |
+| `downstage.render.bookletGutter` | string | `"0.125in"` | Inside gutter for booklet-layout Acting Edition export (accepts `in` and `mm` suffixes) |
 | `downstage.render.openAfterRender` | boolean | `true` | Open PDF after rendering |
 | `downstage.preview.debounceMs` | number | `300` | Delay before re-rendering live preview (ms) |
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -69,6 +69,14 @@
         "title": "Downstage: Export Acting Edition PDF"
       },
       {
+        "command": "downstage.renderCondensedScript2Up",
+        "title": "Downstage: Export Acting Edition PDF (2-Up)"
+      },
+      {
+        "command": "downstage.renderCondensedScriptBooklet",
+        "title": "Downstage: Export Acting Edition PDF (Booklet)"
+      },
+      {
         "command": "downstage.previewCurrentScript",
         "title": "Downstage: Open Manuscript PDF Preview"
       },
@@ -121,6 +129,11 @@
           ],
           "default": "letter",
           "markdownDescription": "Default PDF page size for manuscript and acting edition export."
+        },
+        "downstage.render.bookletGutter": {
+          "type": "string",
+          "default": "0.125in",
+          "markdownDescription": "Inside gutter for booklet-layout Acting Edition export (e.g. `0.125in` or `3mm`). Booklet output is duplex: print double-sided, then fold in half."
         },
         "downstage.render.openAfterRender": {
           "type": "boolean",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -17,10 +17,12 @@ import {
 	findTitleValueSelection,
 	getNewPlayTemplate,
 	getPageSizeDisplayName,
+	getPdfLayoutDisplayName,
 	getPreviewHtml,
 	getRenderStyleDisplayName,
 	getSamplePlayTemplate,
 	getValidatedPageSize,
+	getValidatedPdfLayout,
 	getValidatedRenderStyle,
 	isCueSuggestionLine,
 	parseRenderDiagnostics,
@@ -46,6 +48,7 @@ const settingServerTrace = "server.trace";
 const settingAutoSuggestCues = "editor.autoSuggestCharacterCues";
 const settingRenderStyle = "render.style";
 const settingRenderPageSize = "render.pageSize";
+const settingBookletGutter = "render.bookletGutter";
 const settingOpenAfterRender = "render.openAfterRender";
 const settingPreviewDebounce = "preview.debounceMs";
 
@@ -95,25 +98,37 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	const renderCommand = vscode.commands.registerCommand(
 		"downstage.renderCurrentScript",
 		async () => {
-			await renderCurrentScript("standard");
+			await renderCurrentScript({ style: "standard", layout: "single" });
 		},
 	);
 	const renderCondensedCommand = vscode.commands.registerCommand(
 		"downstage.renderCondensedScript",
 		async () => {
-			await renderCurrentScript("condensed");
+			await renderCurrentScript({ style: "condensed", layout: "single" });
+		},
+	);
+	const renderCondensed2UpCommand = vscode.commands.registerCommand(
+		"downstage.renderCondensedScript2Up",
+		async () => {
+			await renderCurrentScript({ style: "condensed", layout: "2up" });
+		},
+	);
+	const renderCondensedBookletCommand = vscode.commands.registerCommand(
+		"downstage.renderCondensedScriptBooklet",
+		async () => {
+			await renderCurrentScript({ style: "condensed", layout: "booklet" });
 		},
 	);
 	const previewCommand = vscode.commands.registerCommand(
 		"downstage.previewCurrentScript",
 		async () => {
-			await previewCurrentScriptPdf("standard");
+			await previewCurrentScriptPdf({ style: "standard", layout: "single" });
 		},
 	);
 	const previewCondensedCommand = vscode.commands.registerCommand(
 		"downstage.previewCondensedScript",
 		async () => {
-			await previewCurrentScriptPdf("condensed");
+			await previewCurrentScriptPdf({ style: "condensed", layout: "single" });
 		},
 	);
 	const livePreviewCommand = vscode.commands.registerCommand(
@@ -158,6 +173,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(restartCommand);
 	context.subscriptions.push(renderCommand);
 	context.subscriptions.push(renderCondensedCommand);
+	context.subscriptions.push(renderCondensed2UpCommand);
+	context.subscriptions.push(renderCondensedBookletCommand);
 	context.subscriptions.push(previewCommand);
 	context.subscriptions.push(previewCondensedCommand);
 	context.subscriptions.push(livePreviewCommand);
@@ -518,6 +535,13 @@ function getRenderPageSizeSetting(): string {
 	);
 }
 
+function getBookletGutterSetting(): string {
+	return vscode.workspace.getConfiguration(configSection).get<string>(
+		settingBookletGutter,
+		"0.125in",
+	);
+}
+
 function getOpenAfterRenderSetting(): boolean {
 	return vscode.workspace.getConfiguration(configSection).get<boolean>(
 		settingOpenAfterRender,
@@ -607,7 +631,12 @@ async function maybeTriggerCueSuggest(editor: vscode.TextEditor): Promise<void> 
 }
 
 
-async function renderCurrentScript(styleOverride?: string): Promise<void> {
+interface RenderOptions {
+	style?: string;
+	layout?: string;
+}
+
+async function renderCurrentScript(override: RenderOptions = {}): Promise<void> {
 	const editor = vscode.window.activeTextEditor;
 	if (!editor || editor.document.languageId !== "downstage") {
 		void vscode.window.showErrorMessage("Open a Downstage script before rendering.");
@@ -629,18 +658,26 @@ async function renderCurrentScript(styleOverride?: string): Promise<void> {
 
 	try {
 		const serverPath = await resolveServerCommand();
-		const style = getValidatedRenderStyle(styleOverride ?? getRenderStyleSetting());
+		const style = getValidatedRenderStyle(override.style ?? getRenderStyleSetting());
 		const pageSize = getValidatedPageSize(getRenderPageSizeSetting());
+		const layout = getValidatedPdfLayout(override.layout ?? "single");
+		const gutter = layout === "booklet" ? getBookletGutterSetting() : undefined;
 		const styleName = getRenderStyleDisplayName(style);
 		const pageSizeName = getPageSizeDisplayName(pageSize);
+		const layoutName = getPdfLayoutDisplayName(layout);
+
+		const renderArgs = buildPDFRenderArgs({ style, pageSize, layout, gutter }, inputPath);
 		outputChannel.appendLine(
-			`Running: ${serverPath.expectedLocation} render --style ${style} --page-size ${pageSize} ${inputPath}`,
+			`Running: ${serverPath.expectedLocation} ${renderArgs.join(" ")}`,
 		);
 		outputChannel.show(true);
 		renderDiagnostics?.delete(editor.document.uri);
 
-		await runDownstageRender(serverPath.command, style, pageSize, inputPath, outputChannel);
-		const message = `Rendered ${styleName} PDF (${pageSizeName}): ${path.basename(outputPath)}`;
+		await runDownstageRender(serverPath.command, renderArgs, path.dirname(inputPath), outputChannel);
+		const detail = layout === "single"
+			? `${styleName} PDF (${pageSizeName})`
+			: `${styleName} PDF (${layoutName}, ${pageSizeName})`;
+		const message = `Rendered ${detail}: ${path.basename(outputPath)}`;
 
 		if (!getOpenAfterRenderSetting()) {
 			void vscode.window.showInformationMessage(message);
@@ -666,7 +703,7 @@ async function renderCurrentScript(styleOverride?: string): Promise<void> {
 	}
 }
 
-async function previewCurrentScriptPdf(styleOverride?: string): Promise<void> {
+async function previewCurrentScriptPdf(override: RenderOptions = {}): Promise<void> {
 	const editor = vscode.window.activeTextEditor;
 	if (!editor || editor.document.languageId !== "downstage") {
 		void vscode.window.showErrorMessage("Open a Downstage script before previewing.");
@@ -684,18 +721,22 @@ async function previewCurrentScriptPdf(styleOverride?: string): Promise<void> {
 
 	try {
 		const serverPath = await resolveServerCommand();
-		const style = getValidatedRenderStyle(styleOverride ?? getRenderStyleSetting());
+		const style = getValidatedRenderStyle(override.style ?? getRenderStyleSetting());
 		const pageSize = getValidatedPageSize(getRenderPageSizeSetting());
+		const layout = getValidatedPdfLayout(override.layout ?? "single");
+		const gutter = layout === "booklet" ? getBookletGutterSetting() : undefined;
 		const styleName = getRenderStyleDisplayName(style);
 		const pageSizeName = getPageSizeDisplayName(pageSize);
+		const layoutName = getPdfLayoutDisplayName(layout);
 		const sourceName = path.basename(inputPath);
 		const tempPath = path.join(
 			os.tmpdir(),
 			`downstage-preview-${path.basename(inputPath, ".ds")}.pdf`,
 		);
 
+		const previewArgs = buildPDFPreviewArgs({ style, pageSize, layout, gutter }, sourceName);
 		outputChannel.appendLine(
-			`Running: ${serverPath.expectedLocation} render --stdin --stdout --format pdf --style ${style} --page-size ${pageSize} --source-name ${sourceName}`,
+			`Running: ${serverPath.expectedLocation} ${previewArgs.join(" ")}`,
 		);
 		outputChannel.show(true);
 		renderDiagnostics?.delete(editor.document.uri);
@@ -704,7 +745,7 @@ async function previewCurrentScriptPdf(styleOverride?: string): Promise<void> {
 			let stderr = "";
 			const chunks: Buffer[] = [];
 
-			const child = spawn(serverPath.command, buildPDFPreviewArgs(style, pageSize, sourceName), {
+			const child = spawn(serverPath.command, previewArgs, {
 				cwd: path.dirname(inputPath),
 			});
 
@@ -748,8 +789,11 @@ async function previewCurrentScriptPdf(styleOverride?: string): Promise<void> {
 		});
 
 		await openRenderedPdf(vscode.Uri.file(tempPath));
+		const detail = layout === "single"
+			? `${styleName} preview (${pageSizeName})`
+			: `${styleName} preview (${layoutName}, ${pageSizeName})`;
 		void vscode.window.showInformationMessage(
-			`${styleName} preview (${pageSizeName}): ${path.basename(inputPath)}`,
+			`${detail}: ${path.basename(inputPath)}`,
 		);
 	} catch (error) {
 		if (error instanceof DownstageRenderError) {
@@ -776,16 +820,13 @@ function getRenderOutputChannel(): vscode.OutputChannel {
 
 async function runDownstageRender(
 	serverPath: string,
-	style: string,
-	pageSize: string,
-	inputPath: string,
+	renderArgs: string[],
+	cwd: string,
 	outputChannel: vscode.OutputChannel,
 ): Promise<void> {
 	await new Promise<void>((resolve, reject) => {
 		let stderr = "";
-		const child = spawn(serverPath, buildPDFRenderArgs(style, pageSize, inputPath), {
-			cwd: path.dirname(inputPath),
-		});
+		const child = spawn(serverPath, renderArgs, { cwd });
 
 		const timeout = setTimeout(() => {
 			child.kill();

--- a/editors/vscode/src/lib.test.ts
+++ b/editors/vscode/src/lib.test.ts
@@ -13,10 +13,12 @@ import {
 	findTitleValueSelection,
 	getNewPlayTemplate,
 	getPageSizeDisplayName,
+	getPdfLayoutDisplayName,
 	getPreviewHtml,
 	getRenderStyleDisplayName,
 	getSamplePlayTemplate,
 	getValidatedPageSize,
+	getValidatedPdfLayout,
 	getValidatedRenderStyle,
 	isCueSuggestionLine,
 	parseRenderDiagnostics,
@@ -221,25 +223,103 @@ describe("getPageSizeDisplayName", () => {
 	});
 });
 
+describe("getValidatedPdfLayout", () => {
+	it("accepts single", () => {
+		expect(getValidatedPdfLayout("single")).toBe("single");
+	});
+
+	it("accepts 2up", () => {
+		expect(getValidatedPdfLayout("2up")).toBe("2up");
+	});
+
+	it("accepts booklet", () => {
+		expect(getValidatedPdfLayout("booklet")).toBe("booklet");
+	});
+
+	it("rejects unknown layouts", () => {
+		expect(() => getValidatedPdfLayout("4up")).toThrow("Unsupported pdf layout");
+	});
+});
+
+describe("getPdfLayoutDisplayName", () => {
+	it("maps single to Single page", () => {
+		expect(getPdfLayoutDisplayName("single")).toBe("Single page");
+	});
+
+	it("maps 2up to 2-up", () => {
+		expect(getPdfLayoutDisplayName("2up")).toBe("2-up");
+	});
+
+	it("maps booklet to Booklet", () => {
+		expect(getPdfLayoutDisplayName("booklet")).toBe("Booklet");
+	});
+});
+
 describe("buildPDFRenderArgs", () => {
-	it("includes page size in render args", () => {
-		expect(buildPDFRenderArgs("condensed", "a4", "/tmp/play.ds")).toEqual([
+	it("includes layout and page size in render args", () => {
+		expect(buildPDFRenderArgs({ style: "condensed", pageSize: "a4", layout: "single" }, "/tmp/play.ds")).toEqual([
 			"render",
 			"--style", "condensed",
 			"--page-size", "a4",
+			"--pdf-layout", "single",
+			"/tmp/play.ds",
+		]);
+	});
+
+	it("defaults layout to single when omitted", () => {
+		expect(buildPDFRenderArgs({ style: "standard", pageSize: "letter" }, "/tmp/play.ds")).toEqual([
+			"render",
+			"--style", "standard",
+			"--page-size", "letter",
+			"--pdf-layout", "single",
+			"/tmp/play.ds",
+		]);
+	});
+
+	it("appends gutter when layout is booklet", () => {
+		expect(buildPDFRenderArgs({ style: "condensed", pageSize: "letter", layout: "booklet", gutter: "3mm" }, "/tmp/play.ds")).toEqual([
+			"render",
+			"--style", "condensed",
+			"--page-size", "letter",
+			"--pdf-layout", "booklet",
+			"--gutter", "3mm",
+			"/tmp/play.ds",
+		]);
+	});
+
+	it("omits gutter when layout is 2up", () => {
+		expect(buildPDFRenderArgs({ style: "condensed", pageSize: "letter", layout: "2up", gutter: "3mm" }, "/tmp/play.ds")).toEqual([
+			"render",
+			"--style", "condensed",
+			"--page-size", "letter",
+			"--pdf-layout", "2up",
 			"/tmp/play.ds",
 		]);
 	});
 });
 
 describe("buildPDFPreviewArgs", () => {
-	it("includes page size in preview args", () => {
-		expect(buildPDFPreviewArgs("standard", "letter", "play.ds")).toEqual([
+	it("includes layout in preview args", () => {
+		expect(buildPDFPreviewArgs({ style: "standard", pageSize: "letter", layout: "single" }, "play.ds")).toEqual([
 			"render",
 			"--stdin", "--stdout",
 			"--format", "pdf",
 			"--style", "standard",
 			"--page-size", "letter",
+			"--pdf-layout", "single",
+			"--source-name", "play.ds",
+		]);
+	});
+
+	it("appends gutter for booklet preview", () => {
+		expect(buildPDFPreviewArgs({ style: "condensed", pageSize: "a4", layout: "booklet", gutter: "0.125in" }, "play.ds")).toEqual([
+			"render",
+			"--stdin", "--stdout",
+			"--format", "pdf",
+			"--style", "condensed",
+			"--page-size", "a4",
+			"--pdf-layout", "booklet",
+			"--gutter", "0.125in",
 			"--source-name", "play.ds",
 		]);
 	});

--- a/editors/vscode/src/lib.ts
+++ b/editors/vscode/src/lib.ts
@@ -144,6 +144,7 @@ export function findTitleValueSelection(documentText: string): SelectionTarget {
 
 const allowedRenderStyles = new Set(["standard", "condensed"]);
 const allowedPageSizes = new Set(["letter", "a4"]);
+const allowedPdfLayouts = new Set(["single", "2up", "booklet"]);
 
 export function getValidatedRenderStyle(style: string): string {
 	if (!allowedRenderStyles.has(style)) {
@@ -169,32 +170,64 @@ export function getPageSizeDisplayName(pageSize: string): string {
 	return getValidatedPageSize(pageSize) === "a4" ? "A4" : "Letter";
 }
 
+export function getValidatedPdfLayout(layout: string): string {
+	if (!allowedPdfLayouts.has(layout)) {
+		throw new Error(`Unsupported pdf layout: ${layout}`);
+	}
+	return layout;
+}
+
+export function getPdfLayoutDisplayName(layout: string): string {
+	switch (getValidatedPdfLayout(layout)) {
+		case "2up": return "2-up";
+		case "booklet": return "Booklet";
+		default: return "Single page";
+	}
+}
+
+export interface PDFRenderArgsInput {
+	style: string;
+	pageSize: string;
+	layout?: string;
+	gutter?: string;
+}
+
 export function buildPDFRenderArgs(
-	style: string,
-	pageSize: string,
+	opts: PDFRenderArgsInput,
 	inputPath: string,
 ): string[] {
-	return [
+	const layout = opts.layout ? getValidatedPdfLayout(opts.layout) : "single";
+	const args = [
 		"render",
-		"--style", getValidatedRenderStyle(style),
-		"--page-size", getValidatedPageSize(pageSize),
-		inputPath,
+		"--style", getValidatedRenderStyle(opts.style),
+		"--page-size", getValidatedPageSize(opts.pageSize),
+		"--pdf-layout", layout,
 	];
+	if (layout === "booklet" && opts.gutter) {
+		args.push("--gutter", opts.gutter);
+	}
+	args.push(inputPath);
+	return args;
 }
 
 export function buildPDFPreviewArgs(
-	style: string,
-	pageSize: string,
+	opts: PDFRenderArgsInput,
 	sourceName: string,
 ): string[] {
-	return [
+	const layout = opts.layout ? getValidatedPdfLayout(opts.layout) : "single";
+	const args = [
 		"render",
 		"--stdin", "--stdout",
 		"--format", "pdf",
-		"--style", getValidatedRenderStyle(style),
-		"--page-size", getValidatedPageSize(pageSize),
-		"--source-name", sourceName,
+		"--style", getValidatedRenderStyle(opts.style),
+		"--page-size", getValidatedPageSize(opts.pageSize),
+		"--pdf-layout", layout,
 	];
+	if (layout === "booklet" && opts.gutter) {
+		args.push("--gutter", opts.gutter);
+	}
+	args.push("--source-name", sourceName);
+	return args;
 }
 
 export function getPreviewHtml(body: string): string {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/jscaltreto/downstage
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/go-pdf/fpdf v0.9.0
+	github.com/phpdave11/gofpdi v1.0.16
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.lsp.dev/jsonrpc2 v0.10.0
@@ -13,6 +14,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.3.4 // indirect
@@ -22,6 +24,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
-	golang.org/x/sys v0.1.0 // indirect
+	golang.org/x/sys v0.37.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/phpdave11/gofpdi v1.0.16 h1:4qi0x31yujXmS4F6L4ZJKtd1DqG/3H/bpQzEZh2dmhY=
+github.com/phpdave11/gofpdi v1.0.16/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -71,8 +73,8 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
+golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -88,8 +90,9 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/render/config.go
+++ b/internal/render/config.go
@@ -3,6 +3,7 @@ package render
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -128,6 +129,9 @@ func ParseMeasurement(s string) (float64, error) {
 	v, err := strconv.ParseFloat(numStr, 64)
 	if err != nil {
 		return 0, fmt.Errorf("invalid number %q in measurement %q", numStr, s)
+	}
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, fmt.Errorf("measurement %q must be a finite number", s)
 	}
 	if v < 0 {
 		return 0, fmt.Errorf("measurement must be non-negative, got %q", s)

--- a/internal/render/config.go
+++ b/internal/render/config.go
@@ -3,6 +3,7 @@ package render
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -77,18 +78,80 @@ func (p PageSize) CondensedPageDimensions() (Dimensions, error) {
 	}
 }
 
+// PDFLayout controls how condensed logical pages are composed onto physical
+// sheets. `single` keeps the current one-logical-page-per-sheet behavior.
+// `2up` and `booklet` impose two logical pages per landscape sheet; booklet
+// additionally pads to a multiple of four and reorders for duplex printing.
+type PDFLayout string
+
+const (
+	LayoutSingle  PDFLayout = "single"
+	Layout2Up     PDFLayout = "2up"
+	LayoutBooklet PDFLayout = "booklet"
+)
+
+// ParsePDFLayout converts a string to a PDFLayout (case-insensitive).
+func ParsePDFLayout(s string) (PDFLayout, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case string(LayoutSingle):
+		return LayoutSingle, nil
+	case string(Layout2Up):
+		return Layout2Up, nil
+	case string(LayoutBooklet):
+		return LayoutBooklet, nil
+	default:
+		return "", fmt.Errorf("unsupported pdf layout: %q", s)
+	}
+}
+
+// ParseMeasurement parses a measurement string like "0.125in" or "3mm" and
+// returns the value in millimeters. Whitespace is tolerated.
+func ParseMeasurement(s string) (float64, error) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return 0, fmt.Errorf("empty measurement")
+	}
+	var (
+		numStr string
+		unit   string
+	)
+	switch {
+	case strings.HasSuffix(trimmed, "mm"):
+		numStr = strings.TrimSpace(strings.TrimSuffix(trimmed, "mm"))
+		unit = "mm"
+	case strings.HasSuffix(trimmed, "in"):
+		numStr = strings.TrimSpace(strings.TrimSuffix(trimmed, "in"))
+		unit = "in"
+	default:
+		return 0, fmt.Errorf("measurement %q must end in 'in' or 'mm'", s)
+	}
+	v, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid number %q in measurement %q", numStr, s)
+	}
+	if v < 0 {
+		return 0, fmt.Errorf("measurement must be non-negative, got %q", s)
+	}
+	if unit == "in" {
+		return v * 25.4, nil
+	}
+	return v, nil
+}
+
 // Config holds rendering configuration.
 type Config struct {
-	PageSize      PageSize
-	Style         Style
-	FontFamily    string
-	FontPath      string // path to a custom TTF font file (optional)
-	FontSize      float64
-	MarginTop     float64 // points (72 points = 1 inch)
-	MarginBottom  float64
-	MarginLeft    float64
-	MarginRight   float64
-	SourceAnchors bool // emit data-source-line attributes on block elements
+	PageSize        PageSize
+	Style           Style
+	Layout          PDFLayout
+	BookletGutterMM float64 // inner gutter for booklet layout, in millimeters
+	FontFamily      string
+	FontPath        string // path to a custom TTF font file (optional)
+	FontSize        float64
+	MarginTop       float64 // points (72 points = 1 inch)
+	MarginBottom    float64
+	MarginLeft      float64
+	MarginRight     float64
+	SourceAnchors   bool // emit data-source-line attributes on block elements
 }
 
 // Validate checks that Config values are within acceptable ranges.
@@ -109,6 +172,9 @@ func (c Config) Validate() error {
 	if c.MarginRight < 0 {
 		errs = append(errs, fmt.Errorf("MarginRight must be >= 0, got %g", c.MarginRight))
 	}
+	if c.BookletGutterMM < 0 {
+		errs = append(errs, fmt.Errorf("BookletGutterMM must be >= 0, got %g", c.BookletGutterMM))
+	}
 	switch c.PageSize {
 	case PageLetter, PageA4:
 	default:
@@ -119,19 +185,29 @@ func (c Config) Validate() error {
 	default:
 		errs = append(errs, fmt.Errorf("unsupported Style: %q", c.Style))
 	}
+	switch c.Layout {
+	case LayoutSingle, Layout2Up, LayoutBooklet:
+	default:
+		errs = append(errs, fmt.Errorf("unsupported Layout: %q", c.Layout))
+	}
+	if c.Style == StyleStandard && (c.Layout == Layout2Up || c.Layout == LayoutBooklet) {
+		errs = append(errs, fmt.Errorf("layout %q is only supported for style %q", c.Layout, StyleCondensed))
+	}
 	return errors.Join(errs...)
 }
 
 // DefaultConfig returns a Config with standard play manuscript settings.
 func DefaultConfig() Config {
 	return Config{
-		PageSize:     PageLetter,
-		Style:        StyleStandard,
-		FontFamily:   "Courier",
-		FontSize:     12,
-		MarginTop:    72,
-		MarginBottom: 72,
-		MarginLeft:   72,
-		MarginRight:  72,
+		PageSize:        PageLetter,
+		Style:           StyleStandard,
+		Layout:          LayoutSingle,
+		BookletGutterMM: 3.175, // 0.125 in
+		FontFamily:      "Courier",
+		FontSize:        12,
+		MarginTop:       72,
+		MarginBottom:    72,
+		MarginLeft:      72,
+		MarginRight:     72,
 	}
 }

--- a/internal/render/config_test.go
+++ b/internal/render/config_test.go
@@ -167,6 +167,11 @@ func TestParseMeasurement(t *testing.T) {
 		{name: "negative", input: "-1in", wantErr: true},
 		{name: "garbage", input: "xin", wantErr: true},
 		{name: "empty", input: "", wantErr: true},
+		{name: "NaN", input: "NaNmm", wantErr: true},
+		{name: "positive infinity", input: "Infin", wantErr: true},
+		{name: "negative infinity", input: "-Infmm", wantErr: true},
+		{name: "trailing garbage", input: "1xin", wantErr: true},
+		{name: "double decimal", input: "3..5mm", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/render/config_test.go
+++ b/internal/render/config_test.go
@@ -120,6 +120,107 @@ func TestPageSizeCondensedDimensionsRejectsUnknown(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported page size")
 }
 
+func TestParsePDFLayout(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    PDFLayout
+		wantErr bool
+	}{
+		{name: "single", input: "single", want: LayoutSingle},
+		{name: "2up", input: "2up", want: Layout2Up},
+		{name: "booklet", input: "booklet", want: LayoutBooklet},
+		{name: "mixed case", input: "Booklet", want: LayoutBooklet},
+		{name: "whitespace", input: "  2up  ", want: Layout2Up},
+		{name: "unknown", input: "4up", wantErr: true},
+		{name: "empty", input: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePDFLayout(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseMeasurement(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantMM  float64
+		wantErr bool
+	}{
+		{name: "inches with decimal", input: "0.125in", wantMM: 3.175},
+		{name: "inches integer", input: "1in", wantMM: 25.4},
+		{name: "millimeters", input: "3mm", wantMM: 3},
+		{name: "mm decimal", input: "3.5mm", wantMM: 3.5},
+		{name: "whitespace", input: "  0.5in  ", wantMM: 12.7},
+		{name: "space before unit", input: "3 mm", wantMM: 3},
+		{name: "zero", input: "0in", wantMM: 0},
+		{name: "missing unit", input: "3", wantErr: true},
+		{name: "unsupported unit", input: "3cm", wantErr: true},
+		{name: "negative", input: "-1in", wantErr: true},
+		{name: "garbage", input: "xin", wantErr: true},
+		{name: "empty", input: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseMeasurement(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.InDelta(t, tt.wantMM, got, 0.001)
+		})
+	}
+}
+
+func TestValidateRejectsStandardImpositions(t *testing.T) {
+	for _, layout := range []PDFLayout{Layout2Up, LayoutBooklet} {
+		t.Run(string(layout), func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Style = StyleStandard
+			cfg.Layout = layout
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "only supported for style")
+		})
+	}
+}
+
+func TestValidateAcceptsCondensedImpositions(t *testing.T) {
+	for _, layout := range []PDFLayout{LayoutSingle, Layout2Up, LayoutBooklet} {
+		t.Run(string(layout), func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Style = StyleCondensed
+			cfg.Layout = layout
+			require.NoError(t, cfg.Validate())
+		})
+	}
+}
+
+func TestValidateRejectsNegativeGutter(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.BookletGutterMM = -1
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "BookletGutterMM")
+}
+
+func TestValidateRejectsUnsupportedLayout(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Layout = "4up"
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Layout")
+}
+
 func TestDefaultConfig(t *testing.T) {
 	got := DefaultConfig()
 

--- a/internal/render/pdf/impose/fit_test.go
+++ b/internal/render/pdf/impose/fit_test.go
@@ -1,0 +1,46 @@
+package impose
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFitUniform_NoScalingWhenCellMatchesSource(t *testing.T) {
+	w, h, dx, dy := fitUniform(139.7, 215.9, 139.7, 215.9)
+	assert.InDelta(t, 139.7, w, 0.001)
+	assert.InDelta(t, 215.9, h, 0.001)
+	assert.InDelta(t, 0, dx, 0.001)
+	assert.InDelta(t, 0, dy, 0.001)
+}
+
+func TestFitUniform_FitsToWidthWhenCellIsNarrower(t *testing.T) {
+	// Half-letter source (139.7 × 215.9) into a cell narrowed by a 10 mm gutter.
+	// Uniform scale factor = 134.7 / 139.7 ≈ 0.964.
+	w, h, dx, dy := fitUniform(139.7, 215.9, 134.7, 215.9)
+	expectedH := 215.9 * (134.7 / 139.7)
+	assert.InDelta(t, 134.7, w, 0.001, "scaled width matches cell width")
+	assert.InDelta(t, expectedH, h, 0.001, "height scales by the same factor as width")
+	assert.InDelta(t, 0, dx, 0.001, "no horizontal offset — full-width fit")
+	assert.InDelta(t, (215.9-expectedH)/2, dy, 0.001, "vertical offset centers the scaled content")
+	// The source aspect (139.7/215.9) must survive scaling.
+	assert.InDelta(t, 139.7/215.9, w/h, 0.0001, "aspect ratio preserved")
+}
+
+func TestFitUniform_FitsToHeightWhenCellIsShorter(t *testing.T) {
+	// Source taller than cell relative to their widths.
+	w, h, dx, dy := fitUniform(100, 200, 120, 150)
+	// source aspect = 100/200 = 0.5; cell aspect = 120/150 = 0.8; cell wider → fit to height.
+	assert.InDelta(t, 150, h, 0.001)
+	assert.InDelta(t, 75, w, 0.001) // 150 * 0.5
+	assert.InDelta(t, (120.0-75.0)/2, dx, 0.001)
+	assert.InDelta(t, 0, dy, 0.001)
+}
+
+func TestFitUniform_DegenerateInputsReturnCell(t *testing.T) {
+	w, h, dx, dy := fitUniform(0, 0, 100, 100)
+	assert.Equal(t, 100.0, w)
+	assert.Equal(t, 100.0, h)
+	assert.Equal(t, 0.0, dx)
+	assert.Equal(t, 0.0, dy)
+}

--- a/internal/render/pdf/impose/impose.go
+++ b/internal/render/pdf/impose/impose.go
@@ -1,10 +1,4 @@
-// Package impose composes condensed PDF logical pages onto landscape sheets
-// by importing the source pages via gofpdi and placing them on new fpdf
-// sheets. See issue #121.
-//
-// This is a second pass: the condensed renderer emits half-letter/A5 logical
-// pages first, then this package imports those pages and arranges two per
-// landscape sheet.
+// Package impose composes condensed PDF logical pages onto landscape sheets.
 //
 // Booklet ordering follows the standard saddle-stitch scheme. For N pages
 // padded to a multiple of 4, physical sheet M (0-indexed) holds:
@@ -14,15 +8,9 @@
 //	back left   = 2*M + 2
 //	back right  = N - 2*M - 1
 //
-// Printing these in order double-sided, then folding the stack in half at
-// the gutter, yields a readable booklet.
-//
-// Padding reserves the back-cover slot (front-left of sheet 0) for a blank
-// page, so the back cover is never a content page when the booklet is
-// unfolded. The padded page count N is the smallest multiple of 4 that is
-// >= pageCount + 1, so N mod 4 == 0 inputs still get a full extra sheet of
-// trailing blanks rather than having their last logical page land opposite
-// the title on the outer sheet.
+// N is padded to the next multiple of 4 that is >= pageCount + 1, so
+// multiple-of-4 inputs still pick up a full extra sheet of trailing blanks
+// and the back-cover slot never carries content.
 package impose
 
 import (
@@ -35,10 +23,7 @@ import (
 	realgofpdi "github.com/phpdave11/gofpdi"
 )
 
-// TwoUp imposes two logical pages per landscape sheet. sheet is the parent
-// sheet size as returned by PageSize.SheetDimensions() (portrait orientation;
-// the imposed output rotates to landscape). The two imposed cells each match
-// the condensed logical page size (half the sheet's longer edge).
+// TwoUp imposes two logical pages per landscape sheet.
 func TwoUp(src io.ReadSeeker, sheet render.Dimensions, dst io.Writer) error {
 	imp, out, rs, pageCount, landscapeW, landscapeH, err := setup(src, sheet)
 	if err != nil {
@@ -58,10 +43,7 @@ func TwoUp(src io.ReadSeeker, sheet render.Dimensions, dst io.Writer) error {
 	return nil
 }
 
-// Booklet imposes logical pages into duplex booklet order. The input is
-// padded to a multiple of 4 and each physical sheet receives four logical
-// pages (two front, two back). gutterMM is the inner gap between the two
-// pages on each output sheet.
+// Booklet imposes logical pages into duplex booklet order.
 func Booklet(src io.ReadSeeker, sheet render.Dimensions, gutterMM float64, dst io.Writer) error {
 	if gutterMM < 0 {
 		return fmt.Errorf("impose.Booklet: negative gutter %.2fmm", gutterMM)
@@ -71,19 +53,14 @@ func Booklet(src io.ReadSeeker, sheet render.Dimensions, gutterMM float64, dst i
 		return fmt.Errorf("impose.Booklet: %w", err)
 	}
 
-	// The gutter sits between two half-sheet cells on a landscape sheet. A
-	// gutter at or above half the landscape width would leave zero-or-
-	// negative-width cells with no room for content.
+	// A gutter at or above the landscape width leaves zero-width cells.
 	maxGutterMM := landscapeW
 	if gutterMM >= maxGutterMM {
 		return fmt.Errorf("impose.Booklet: gutter %.2fmm is too large for sheet (max %.2fmm)", gutterMM, maxGutterMM)
 	}
 
-	// Pad logical page count up to a multiple of 4, reserving the back
-	// cover (last imposed slot) for a blank so it never carries content
-	// when the booklet unfolds beside the title page. Add one virtual
-	// page before rounding so pageCount values that are already a
-	// multiple of 4 pick up a fresh sheet of padding.
+	// +1 before rounding up to a multiple of 4 keeps the back-cover slot
+	// blank even when pageCount is itself a multiple of 4.
 	N := pageCount + 1
 	if rem := N % 4; rem != 0 {
 		N += 4 - rem
@@ -97,12 +74,10 @@ func Booklet(src io.ReadSeeker, sheet render.Dimensions, gutterMM float64, dst i
 
 	sheets := N / 4
 	for m := 0; m < sheets; m++ {
-		// Front
 		out.AddPage()
 		placePage(out, imp, &rs, N-2*m, pageCount, 0, 0, leftW, landscapeH)
 		placePage(out, imp, &rs, 2*m+1, pageCount, rightX, 0, rightW, landscapeH)
 
-		// Back
 		out.AddPage()
 		placePage(out, imp, &rs, 2*m+2, pageCount, 0, 0, leftW, landscapeH)
 		placePage(out, imp, &rs, N-2*m-1, pageCount, rightX, 0, rightW, landscapeH)
@@ -114,10 +89,6 @@ func Booklet(src io.ReadSeeker, sheet render.Dimensions, gutterMM float64, dst i
 	return nil
 }
 
-// setup builds the landscape output PDF, the importer, and reads the source
-// page count. The returned ReadSeeker is rewound and ready for
-// ImportPageFromStream calls. landscapeW and landscapeH are the output
-// sheet dimensions in millimeters (a rotation of the portrait sheet input).
 func setup(src io.ReadSeeker, sheet render.Dimensions) (*gofpdi.Importer, *fpdf.Fpdf, io.ReadSeeker, int, float64, float64, error) {
 	if sheet.WidthMM <= 0 || sheet.HeightMM <= 0 {
 		return nil, nil, nil, 0, 0, 0, fmt.Errorf("invalid sheet %.1fx%.1fmm", sheet.WidthMM, sheet.HeightMM)
@@ -125,8 +96,9 @@ func setup(src io.ReadSeeker, sheet render.Dimensions) (*gofpdi.Importer, *fpdf.
 	if _, err := src.Seek(0, io.SeekStart); err != nil {
 		return nil, nil, nil, 0, 0, 0, fmt.Errorf("rewind source: %w", err)
 	}
-	// Use a raw gofpdi importer to read the page count; the contrib
-	// wrapper doesn't expose GetNumPages.
+	// Raw gofpdi for GetNumPages — the fpdf/contrib wrapper doesn't
+	// re-export it, so we use a throwaway importer for the page count
+	// and a fresh one below for the actual imports.
 	probe := realgofpdi.NewImporter()
 	rs := src
 	probe.SetSourceStream(&rs)
@@ -138,8 +110,9 @@ func setup(src io.ReadSeeker, sheet render.Dimensions) (*gofpdi.Importer, *fpdf.
 		return nil, nil, nil, 0, 0, 0, fmt.Errorf("rewind after count: %w", err)
 	}
 
-	// fpdf's NewCustom interprets Size in portrait and swaps when
-	// OrientationStr is "L"; hand it portrait dims and let it rotate.
+	// fpdf's NewCustom expects Size in portrait and swaps internally when
+	// OrientationStr is "L". The landscapeW/H we return are already swapped
+	// for callers that compute cell geometry.
 	landscapeW := sheet.HeightMM
 	landscapeH := sheet.WidthMM
 	imp := gofpdi.NewImporter()
@@ -151,8 +124,6 @@ func setup(src io.ReadSeeker, sheet render.Dimensions) (*gofpdi.Importer, *fpdf.
 	return imp, out, rs, pageCount, landscapeW, landscapeH, nil
 }
 
-// placePage imports and places logical page `n` on the output sheet, or
-// leaves the cell blank if n is a padding slot (n > realPages).
 func placePage(out *fpdf.Fpdf, imp *gofpdi.Importer, rs *io.ReadSeeker, n, realPages int, x, y, w, h float64) {
 	if n < 1 || n > realPages {
 		return

--- a/internal/render/pdf/impose/impose.go
+++ b/internal/render/pdf/impose/impose.go
@@ -71,6 +71,14 @@ func Booklet(src io.ReadSeeker, sheet render.Dimensions, gutterMM float64, dst i
 		return fmt.Errorf("impose.Booklet: %w", err)
 	}
 
+	// The gutter sits between two half-sheet cells on a landscape sheet. A
+	// gutter at or above half the landscape width would leave zero-or-
+	// negative-width cells with no room for content.
+	maxGutterMM := landscapeW
+	if gutterMM >= maxGutterMM {
+		return fmt.Errorf("impose.Booklet: gutter %.2fmm is too large for sheet (max %.2fmm)", gutterMM, maxGutterMM)
+	}
+
 	// Pad logical page count up to a multiple of 4, reserving the back
 	// cover (last imposed slot) for a blank so it never carries content
 	// when the booklet unfolds beside the title page. Add one virtual

--- a/internal/render/pdf/impose/impose.go
+++ b/internal/render/pdf/impose/impose.go
@@ -1,0 +1,154 @@
+// Package impose composes condensed PDF logical pages onto landscape sheets
+// by importing the source pages via gofpdi and placing them on new fpdf
+// sheets. See issue #121.
+//
+// This is a second pass: the condensed renderer emits half-letter/A5 logical
+// pages first, then this package imports those pages and arranges two per
+// landscape sheet.
+//
+// Booklet ordering follows the standard saddle-stitch scheme. For N pages
+// padded to a multiple of 4, physical sheet M (0-indexed) holds:
+//
+//	front left  = N - 2*M
+//	front right = 2*M + 1
+//	back left   = 2*M + 2
+//	back right  = N - 2*M - 1
+//
+// Printing these in order double-sided, then folding the stack in half at
+// the gutter, yields a readable booklet.
+//
+// Padding reserves the back-cover slot (front-left of sheet 0) for a blank
+// page, so the back cover is never a content page when the booklet is
+// unfolded. The padded page count N is the smallest multiple of 4 that is
+// >= pageCount + 1, so N mod 4 == 0 inputs still get a full extra sheet of
+// trailing blanks rather than having their last logical page land opposite
+// the title on the outer sheet.
+package impose
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/go-pdf/fpdf"
+	"github.com/go-pdf/fpdf/contrib/gofpdi"
+	"github.com/jscaltreto/downstage/internal/render"
+	realgofpdi "github.com/phpdave11/gofpdi"
+)
+
+// TwoUp imposes two logical pages per landscape sheet. sheet is the parent
+// sheet size as returned by PageSize.SheetDimensions() (portrait orientation;
+// the imposed output rotates to landscape). The two imposed cells each match
+// the condensed logical page size (half the sheet's longer edge).
+func TwoUp(src io.ReadSeeker, sheet render.Dimensions, dst io.Writer) error {
+	imp, out, rs, pageCount, landscapeW, landscapeH, err := setup(src, sheet)
+	if err != nil {
+		return fmt.Errorf("impose.TwoUp: %w", err)
+	}
+
+	halfW := landscapeW / 2
+	for i := 0; i < (pageCount+1)/2; i++ {
+		out.AddPage()
+		placePage(out, imp, &rs, 2*i+1, pageCount, 0, 0, halfW, landscapeH)
+		placePage(out, imp, &rs, 2*i+2, pageCount, halfW, 0, halfW, landscapeH)
+	}
+
+	if err := out.Output(dst); err != nil {
+		return fmt.Errorf("impose.TwoUp: write: %w", err)
+	}
+	return nil
+}
+
+// Booklet imposes logical pages into duplex booklet order. The input is
+// padded to a multiple of 4 and each physical sheet receives four logical
+// pages (two front, two back). gutterMM is the inner gap between the two
+// pages on each output sheet.
+func Booklet(src io.ReadSeeker, sheet render.Dimensions, gutterMM float64, dst io.Writer) error {
+	if gutterMM < 0 {
+		return fmt.Errorf("impose.Booklet: negative gutter %.2fmm", gutterMM)
+	}
+	imp, out, rs, pageCount, landscapeW, landscapeH, err := setup(src, sheet)
+	if err != nil {
+		return fmt.Errorf("impose.Booklet: %w", err)
+	}
+
+	// Pad logical page count up to a multiple of 4, reserving the back
+	// cover (last imposed slot) for a blank so it never carries content
+	// when the booklet unfolds beside the title page. Add one virtual
+	// page before rounding so pageCount values that are already a
+	// multiple of 4 pick up a fresh sheet of padding.
+	N := pageCount + 1
+	if rem := N % 4; rem != 0 {
+		N += 4 - rem
+	}
+
+	halfW := landscapeW / 2
+	gutterHalf := gutterMM / 2
+	leftW := halfW - gutterHalf
+	rightX := halfW + gutterHalf
+	rightW := halfW - gutterHalf
+
+	sheets := N / 4
+	for m := 0; m < sheets; m++ {
+		// Front
+		out.AddPage()
+		placePage(out, imp, &rs, N-2*m, pageCount, 0, 0, leftW, landscapeH)
+		placePage(out, imp, &rs, 2*m+1, pageCount, rightX, 0, rightW, landscapeH)
+
+		// Back
+		out.AddPage()
+		placePage(out, imp, &rs, 2*m+2, pageCount, 0, 0, leftW, landscapeH)
+		placePage(out, imp, &rs, N-2*m-1, pageCount, rightX, 0, rightW, landscapeH)
+	}
+
+	if err := out.Output(dst); err != nil {
+		return fmt.Errorf("impose.Booklet: write: %w", err)
+	}
+	return nil
+}
+
+// setup builds the landscape output PDF, the importer, and reads the source
+// page count. The returned ReadSeeker is rewound and ready for
+// ImportPageFromStream calls. landscapeW and landscapeH are the output
+// sheet dimensions in millimeters (a rotation of the portrait sheet input).
+func setup(src io.ReadSeeker, sheet render.Dimensions) (*gofpdi.Importer, *fpdf.Fpdf, io.ReadSeeker, int, float64, float64, error) {
+	if sheet.WidthMM <= 0 || sheet.HeightMM <= 0 {
+		return nil, nil, nil, 0, 0, 0, fmt.Errorf("invalid sheet %.1fx%.1fmm", sheet.WidthMM, sheet.HeightMM)
+	}
+	if _, err := src.Seek(0, io.SeekStart); err != nil {
+		return nil, nil, nil, 0, 0, 0, fmt.Errorf("rewind source: %w", err)
+	}
+	// Use a raw gofpdi importer to read the page count; the contrib
+	// wrapper doesn't expose GetNumPages.
+	probe := realgofpdi.NewImporter()
+	rs := src
+	probe.SetSourceStream(&rs)
+	pageCount := probe.GetNumPages()
+	if pageCount <= 0 {
+		return nil, nil, nil, 0, 0, 0, fmt.Errorf("unable to read source page count")
+	}
+	if _, err := src.Seek(0, io.SeekStart); err != nil {
+		return nil, nil, nil, 0, 0, 0, fmt.Errorf("rewind after count: %w", err)
+	}
+
+	// fpdf's NewCustom interprets Size in portrait and swaps when
+	// OrientationStr is "L"; hand it portrait dims and let it rotate.
+	landscapeW := sheet.HeightMM
+	landscapeH := sheet.WidthMM
+	imp := gofpdi.NewImporter()
+	out := fpdf.NewCustom(&fpdf.InitType{
+		OrientationStr: "L",
+		UnitStr:        "mm",
+		Size:           fpdf.SizeType{Wd: sheet.WidthMM, Ht: sheet.HeightMM},
+	})
+	return imp, out, rs, pageCount, landscapeW, landscapeH, nil
+}
+
+// placePage imports and places logical page `n` on the output sheet, or
+// leaves the cell blank if n is a padding slot (n > realPages).
+func placePage(out *fpdf.Fpdf, imp *gofpdi.Importer, rs *io.ReadSeeker, n, realPages int, x, y, w, h float64) {
+	if n < 1 || n > realPages {
+		return
+	}
+	tpl := imp.ImportPageFromStream(out, rs, n, "/MediaBox")
+	imp.UseImportedTemplate(out, tpl, x, y, w, h)
+}

--- a/internal/render/pdf/impose/impose.go
+++ b/internal/render/pdf/impose/impose.go
@@ -31,10 +31,11 @@ func TwoUp(src io.ReadSeeker, sheet render.Dimensions, dst io.Writer) error {
 	}
 
 	halfW := landscapeW / 2
+	// Source condensed pages are halfW × landscapeH; target cells match.
 	for i := 0; i < (pageCount+1)/2; i++ {
 		out.AddPage()
-		placePage(out, imp, &rs, 2*i+1, pageCount, 0, 0, halfW, landscapeH)
-		placePage(out, imp, &rs, 2*i+2, pageCount, halfW, 0, halfW, landscapeH)
+		placeFitted(out, imp, &rs, 2*i+1, pageCount, 0, 0, halfW, landscapeH, halfW, landscapeH)
+		placeFitted(out, imp, &rs, 2*i+2, pageCount, halfW, 0, halfW, landscapeH, halfW, landscapeH)
 	}
 
 	if err := out.Output(dst); err != nil {
@@ -72,15 +73,20 @@ func Booklet(src io.ReadSeeker, sheet render.Dimensions, gutterMM float64, dst i
 	rightX := halfW + gutterHalf
 	rightW := halfW - gutterHalf
 
+	// Source condensed pages are halfW × landscapeH. Placing them into a
+	// narrower cell without this source size would stretch the content
+	// (gofpdi fills the rectangle in both dimensions).
+	sourceW, sourceH := halfW, landscapeH
+
 	sheets := N / 4
 	for m := 0; m < sheets; m++ {
 		out.AddPage()
-		placePage(out, imp, &rs, N-2*m, pageCount, 0, 0, leftW, landscapeH)
-		placePage(out, imp, &rs, 2*m+1, pageCount, rightX, 0, rightW, landscapeH)
+		placeFitted(out, imp, &rs, N-2*m, pageCount, 0, 0, leftW, landscapeH, sourceW, sourceH)
+		placeFitted(out, imp, &rs, 2*m+1, pageCount, rightX, 0, rightW, landscapeH, sourceW, sourceH)
 
 		out.AddPage()
-		placePage(out, imp, &rs, 2*m+2, pageCount, 0, 0, leftW, landscapeH)
-		placePage(out, imp, &rs, N-2*m-1, pageCount, rightX, 0, rightW, landscapeH)
+		placeFitted(out, imp, &rs, 2*m+2, pageCount, 0, 0, leftW, landscapeH, sourceW, sourceH)
+		placeFitted(out, imp, &rs, N-2*m-1, pageCount, rightX, 0, rightW, landscapeH, sourceW, sourceH)
 	}
 
 	if err := out.Output(dst); err != nil {
@@ -124,10 +130,40 @@ func setup(src io.ReadSeeker, sheet render.Dimensions) (*gofpdi.Importer, *fpdf.
 	return imp, out, rs, pageCount, landscapeW, landscapeH, nil
 }
 
-func placePage(out *fpdf.Fpdf, imp *gofpdi.Importer, rs *io.ReadSeeker, n, realPages int, x, y, w, h float64) {
+// placeFitted imports logical page n and places it into the target cell
+// at (cellX, cellY) with size (cellW, cellH), scaling uniformly to
+// preserve the source aspect ratio (sourceW × sourceH) and centering the
+// result in the cell. This avoids horizontal squish when the gutter makes
+// the cell narrower than the source page, at the cost of some top/bottom
+// white space on the imposed sheet.
+func placeFitted(out *fpdf.Fpdf, imp *gofpdi.Importer, rs *io.ReadSeeker, n, realPages int, cellX, cellY, cellW, cellH, sourceW, sourceH float64) {
 	if n < 1 || n > realPages {
 		return
 	}
+	w, h, dx, dy := fitUniform(sourceW, sourceH, cellW, cellH)
 	tpl := imp.ImportPageFromStream(out, rs, n, "/MediaBox")
-	imp.UseImportedTemplate(out, tpl, x, y, w, h)
+	imp.UseImportedTemplate(out, tpl, cellX+dx, cellY+dy, w, h)
+}
+
+// fitUniform returns the largest w × h that fits inside cellW × cellH while
+// preserving sourceW:sourceH, along with the (dx, dy) offset to center the
+// fitted box within the cell.
+func fitUniform(sourceW, sourceH, cellW, cellH float64) (w, h, dx, dy float64) {
+	if sourceW <= 0 || sourceH <= 0 || cellW <= 0 || cellH <= 0 {
+		return cellW, cellH, 0, 0
+	}
+	sourceAspect := sourceW / sourceH
+	cellAspect := cellW / cellH
+	if cellAspect <= sourceAspect {
+		// Cell is taller relative to source → fit to width, pillar-center vertically.
+		w = cellW
+		h = cellW / sourceAspect
+	} else {
+		// Cell is wider relative to source → fit to height, letter-center horizontally.
+		h = cellH
+		w = cellH * sourceAspect
+	}
+	dx = (cellW - w) / 2
+	dy = (cellH - h) / 2
+	return
 }

--- a/internal/render/pdf/impose/impose_test.go
+++ b/internal/render/pdf/impose/impose_test.go
@@ -159,6 +159,17 @@ func TestBookletRejectsNegativeGutter(t *testing.T) {
 	assert.Contains(t, err.Error(), "negative gutter")
 }
 
+func TestBookletRejectsGutterLargerThanSheet(t *testing.T) {
+	src := renderCondensed(t, buildFixture(2), render.PageLetter)
+	// Landscape Letter width = 279.4mm; a gutter at that value would
+	// leave zero-width cells.
+	sheet := render.Dimensions{WidthMM: 215.9, HeightMM: 279.4}
+	var out bytes.Buffer
+	err := impose.Booklet(bytes.NewReader(src), sheet, 280, &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too large for sheet")
+}
+
 func TestImposeRejectsInvalidSheet(t *testing.T) {
 	src := renderCondensed(t, buildFixture(2), render.PageLetter)
 	badSheet := render.Dimensions{WidthMM: 0, HeightMM: 0}

--- a/internal/render/pdf/impose/impose_test.go
+++ b/internal/render/pdf/impose/impose_test.go
@@ -1,0 +1,170 @@
+package impose_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/parser"
+	"github.com/jscaltreto/downstage/internal/render"
+	"github.com/jscaltreto/downstage/internal/render/pdf"
+	"github.com/jscaltreto/downstage/internal/render/pdf/impose"
+	realgofpdi "github.com/phpdave11/gofpdi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func renderCondensed(t *testing.T, body string, pageSize render.PageSize) []byte {
+	t.Helper()
+	doc, errs := parser.Parse([]byte(body))
+	require.Empty(t, errs)
+
+	cfg := render.DefaultConfig()
+	cfg.Style = render.StyleCondensed
+	cfg.PageSize = pageSize
+
+	nr := pdf.NewCondensedRenderer(cfg)
+	var buf bytes.Buffer
+	require.NoError(t, render.Walk(nr, doc, &buf))
+	return buf.Bytes()
+}
+
+func pdfPageCount(t *testing.T, data []byte) int {
+	t.Helper()
+	imp := realgofpdi.NewImporter()
+	var rs io.ReadSeeker = bytes.NewReader(data)
+	imp.SetSourceStream(&rs)
+	n := imp.GetNumPages()
+	require.Greater(t, n, 0)
+	return n
+}
+
+// buildFixture synthesizes a .ds source that produces approximately the
+// requested number of condensed logical pages. Each cue takes roughly
+// half a logical page given the default condensed layout, so we scale
+// accordingly.
+func buildFixture(pages int) string {
+	var b strings.Builder
+	b.WriteString("# Test Play\n\n## ACT I\n\n### SCENE 1\n\n")
+	for i := 0; i < pages*20; i++ {
+		fmt.Fprintf(&b, "ALICE\nLine number %d of dialogue that takes up some vertical space.\n\n", i)
+	}
+	return b.String()
+}
+
+func TestTwoUpPageCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		pages    int
+		pageSize render.PageSize
+		sheet    render.Dimensions
+	}{
+		{"letter 3 pages", 3, render.PageLetter, render.Dimensions{WidthMM: 215.9, HeightMM: 279.4}},
+		{"letter 5 pages", 5, render.PageLetter, render.Dimensions{WidthMM: 215.9, HeightMM: 279.4}},
+		{"letter 8 pages", 8, render.PageLetter, render.Dimensions{WidthMM: 215.9, HeightMM: 279.4}},
+		{"a4 5 pages", 5, render.PageA4, render.Dimensions{WidthMM: 210, HeightMM: 297}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := renderCondensed(t, buildFixture(tt.pages), tt.pageSize)
+			n := pdfPageCount(t, src)
+
+			var out bytes.Buffer
+			require.NoError(t, impose.TwoUp(bytes.NewReader(src), tt.sheet, &out))
+			assert.Equal(t, "%PDF-", string(out.Bytes()[:5]))
+
+			expected := (n + 1) / 2
+			assert.Equal(t, expected, pdfPageCount(t, out.Bytes()),
+				"2-up should produce ceil(%d/2)=%d output PDF pages", n, expected)
+		})
+	}
+}
+
+func TestBookletPageCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		pages    int
+		pageSize render.PageSize
+		sheet    render.Dimensions
+	}{
+		{"letter 3 pages", 3, render.PageLetter, render.Dimensions{WidthMM: 215.9, HeightMM: 279.4}},
+		{"letter 5 pages", 5, render.PageLetter, render.Dimensions{WidthMM: 215.9, HeightMM: 279.4}},
+		{"letter 8 pages", 8, render.PageLetter, render.Dimensions{WidthMM: 215.9, HeightMM: 279.4}},
+		{"a4 5 pages", 5, render.PageA4, render.Dimensions{WidthMM: 210, HeightMM: 297}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := renderCondensed(t, buildFixture(tt.pages), tt.pageSize)
+			n := pdfPageCount(t, src)
+
+			var out bytes.Buffer
+			require.NoError(t, impose.Booklet(bytes.NewReader(src), tt.sheet, 3.175, &out))
+			assert.Equal(t, "%PDF-", string(out.Bytes()[:5]))
+
+			// Padded page count reserves the back cover as blank, so we
+			// round up n+1 (not n) to the next multiple of 4.
+			expected := 2 * ((n + 4) / 4)
+			assert.Equal(t, expected, pdfPageCount(t, out.Bytes()),
+				"booklet should produce 2*ceil((%d+1)/4)=%d output PDF pages", n, expected)
+		})
+	}
+}
+
+// TestBookletReservesBlankBackCover checks the invariant that the
+// back-cover slot (logical page N_padded, which lands on the front-left
+// of sheet 0) is always a padding slot, so the back cover never carries
+// content when the booklet is unfolded.
+func TestBookletReservesBlankBackCover(t *testing.T) {
+	sheet := render.Dimensions{WidthMM: 215.9, HeightMM: 279.4}
+
+	// Each fixture produces a different logical page count; across the
+	// set we cover n % 4 ∈ {0, 1, 2, 3} so the multiple-of-4 case is
+	// exercised even without knowing the exact page count up front.
+	for _, pages := range []int{3, 5, 7, 8, 10} {
+		t.Run(fmt.Sprintf("%d_pages", pages), func(t *testing.T) {
+			src := renderCondensed(t, buildFixture(pages), render.PageLetter)
+			n := pdfPageCount(t, src)
+
+			var out bytes.Buffer
+			require.NoError(t, impose.Booklet(bytes.NewReader(src), sheet, 3.175, &out))
+			outputPages := pdfPageCount(t, out.Bytes())
+
+			// Each physical sheet contributes 2 output PDF pages and
+			// holds 4 logical pages. So the padded logical count is
+			// 2 * outputPages.
+			nPadded := 2 * outputPages
+			assert.Greater(t, nPadded, n,
+				"padded page count %d must exceed logical page count %d so the back cover is blank",
+				nPadded, n)
+			assert.Equal(t, 0, nPadded%4,
+				"padded page count %d must be a multiple of 4", nPadded)
+		})
+	}
+}
+
+func TestBookletNoGutter(t *testing.T) {
+	src := renderCondensed(t, buildFixture(5), render.PageLetter)
+	var out bytes.Buffer
+	require.NoError(t, impose.Booklet(bytes.NewReader(src), render.Dimensions{WidthMM: 215.9, HeightMM: 279.4}, 0, &out))
+	assert.Equal(t, "%PDF-", string(out.Bytes()[:5]))
+}
+
+func TestBookletRejectsNegativeGutter(t *testing.T) {
+	src := renderCondensed(t, buildFixture(2), render.PageLetter)
+	var out bytes.Buffer
+	err := impose.Booklet(bytes.NewReader(src), render.Dimensions{WidthMM: 215.9, HeightMM: 279.4}, -1, &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "negative gutter")
+}
+
+func TestImposeRejectsInvalidSheet(t *testing.T) {
+	src := renderCondensed(t, buildFixture(2), render.PageLetter)
+	badSheet := render.Dimensions{WidthMM: 0, HeightMM: 0}
+
+	var out bytes.Buffer
+	err := impose.TwoUp(bytes.NewReader(src), badSheet, &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid sheet")
+}

--- a/web/README.md
+++ b/web/README.md
@@ -126,7 +126,7 @@ The WASM module exposes a global `downstage` object:
 | `completion(source, line, col)` | Source + 0-based LSP position | LSP `CompletionList` (`{isIncomplete, items[]}`) |
 | `codeActions(source, line, col, codes?)` | Source + 0-based LSP position + optional diagnostic-code filter | `{uri, actions: LSPCodeAction[]}` |
 | `renderHTML(source, style?)` | Source + optional style (`"standard"`/Manuscript or `"condensed"`/Acting Edition) | HTML string |
-| `renderPDF(source, style?, pageSize?)` | Source + optional style and page size (`"letter"`/`"a4"`) | `Uint8Array` (PDF bytes) |
+| `renderPDF(source, options?)` | Source + `{ style?, pageSize?, layout?, gutter? }`. `layout` is `"single"`/`"2up"`/`"booklet"` (2up and booklet are condensed-only); `gutter` accepts `in`/`mm` suffixes and only applies for booklet | `Uint8Array` (PDF bytes) |
 | `semanticTokens(source)` | Source string | `Uint32Array` (delta-encoded LSP tokens) |
 | `tokenTypeNames` | — | `string[]` (token type legend) |
 

--- a/web/e2e/export.spec.ts
+++ b/web/e2e/export.spec.ts
@@ -157,4 +157,36 @@ test.describe("export", () => {
     expect(storedLayout).toBe("booklet");
     expect(storedGutter).toBe("5mm");
   });
+
+  test("Manuscript export preserves a previously chosen condensed layout", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.setEditorContent(body);
+    await expect(editor.exportPdfButton).toBeEnabled();
+
+    // 1. Export once as Acting Edition / booklet so the layout is stored.
+    const firstDownload = await editor.downloadPdf({
+      style: "condensed",
+      layout: "booklet",
+    });
+    await firstDownload.path();
+    expect(await page.evaluate(() =>
+      window.localStorage.getItem("downstage-editor-export-layout"),
+    )).toBe("booklet");
+
+    // 2. Export as Manuscript. Layout should not be clobbered.
+    const secondDownload = await editor.downloadPdf({ style: "standard" });
+    await secondDownload.path();
+    expect(await page.evaluate(() =>
+      window.localStorage.getItem("downstage-editor-export-layout"),
+    )).toBe("booklet");
+
+    // 3. Reopen the dialog and flip back to Acting Edition; the stored
+    //    booklet layout should be preselected.
+    await editor.exportPdfButton.click();
+    await expect(editor.exportDialog).toBeVisible();
+    await editor.exportStyleOption("condensed").click();
+    await expect(editor.layoutOption("booklet")).toHaveAttribute("aria-checked", "true");
+  });
 });

--- a/web/e2e/export.spec.ts
+++ b/web/e2e/export.spec.ts
@@ -186,6 +186,36 @@ test.describe("export", () => {
     await expect(editor.exportConfirmButton).toBeEnabled();
   });
 
+  test("Switching to Manuscript ignores a stale invalid gutter", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.setEditorContent(body);
+    await expect(editor.exportPdfButton).toBeEnabled();
+
+    await editor.exportPdfButton.click();
+    await expect(editor.exportDialog).toBeVisible();
+
+    // Enter an invalid gutter in the Acting Edition / Booklet path.
+    await editor.exportStyleOption("condensed").click();
+    await editor.layoutOption("booklet").click();
+    await editor.gutterValueInput.fill("50");
+    await editor.gutterUnitSelect.selectOption("in");
+    await expect(editor.exportConfirmButton).toBeDisabled();
+
+    // Switching to Manuscript: the gutter field is hidden and the stale
+    // invalid value must not keep the Export button disabled.
+    await editor.exportStyleOption("standard").click();
+    await expect(editor.layoutGroup).toBeHidden();
+    await expect(editor.gutterRow).toBeHidden();
+    await expect(editor.exportConfirmButton).toBeEnabled();
+
+    // Switching back to Acting Edition re-applies the validation.
+    await editor.exportStyleOption("condensed").click();
+    await expect(editor.gutterRow).toBeVisible();
+    await expect(editor.exportConfirmButton).toBeDisabled();
+  });
+
   test("Manuscript export preserves a previously chosen condensed layout", async ({ page }) => {
     const editor = new EditorPage(page);
     await editor.gotoReady();

--- a/web/e2e/export.spec.ts
+++ b/web/e2e/export.spec.ts
@@ -82,7 +82,7 @@ test.describe("export", () => {
     await editor.setEditorContent(body);
     await expect(editor.exportPdfButton).toBeEnabled();
 
-    const download = await editor.downloadPdf("a4");
+    const download = await editor.downloadPdf({ pageSize: "a4" });
     const pdfPath = await download.path();
     const buf = await readFile(pdfPath!);
     expect(buf.slice(0, 5).toString("utf8")).toBe("%PDF-");
@@ -97,5 +97,64 @@ test.describe("export", () => {
     await editor.exportPdfButton.click();
     await expect(editor.exportDialog).toBeVisible();
     await expect(editor.pageSizeOption("a4")).toHaveAttribute("aria-checked", "true");
+  });
+
+  test("Manuscript hides Layout controls; Acting Edition shows them", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.setEditorContent(body);
+    await expect(editor.exportPdfButton).toBeEnabled();
+
+    await editor.exportPdfButton.click();
+    await expect(editor.exportDialog).toBeVisible();
+
+    // Default style is Manuscript → layout section hidden.
+    await expect(editor.exportStyleOption("standard")).toHaveAttribute("aria-checked", "true");
+    await expect(editor.layoutGroup).toBeHidden();
+
+    // Switch to Acting Edition → layout appears.
+    await editor.exportStyleOption("condensed").click();
+    await expect(editor.layoutGroup).toBeVisible();
+    await expect(editor.gutterRow).toBeHidden();
+
+    // Booklet reveals the gutter control.
+    await editor.layoutOption("booklet").click();
+    await expect(editor.gutterRow).toBeVisible();
+
+    // Switching back to Manuscript hides both again and snaps layout back.
+    await editor.exportStyleOption("standard").click();
+    await expect(editor.layoutGroup).toBeHidden();
+    await expect(editor.gutterRow).toBeHidden();
+  });
+
+  test("Export PDF booklet with custom gutter produces a valid PDF and persists", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.setEditorContent(body);
+    await expect(editor.exportPdfButton).toBeEnabled();
+
+    const download = await editor.downloadPdf({
+      style: "condensed",
+      layout: "booklet",
+      gutterValue: 5,
+      gutterUnit: "mm",
+    });
+    expect(download.suggestedFilename()).toMatch(/acting-edition-booklet\.pdf$/);
+
+    const pdfPath = await download.path();
+    const buf = await readFile(pdfPath!);
+    expect(buf.slice(0, 5).toString("utf8")).toBe("%PDF-");
+    expect(buf.byteLength).toBeGreaterThan(1000);
+
+    const storedLayout = await page.evaluate(() =>
+      window.localStorage.getItem("downstage-editor-export-layout"),
+    );
+    const storedGutter = await page.evaluate(() =>
+      window.localStorage.getItem("downstage-editor-export-booklet-gutter"),
+    );
+    expect(storedLayout).toBe("booklet");
+    expect(storedGutter).toBe("5mm");
   });
 });

--- a/web/e2e/export.spec.ts
+++ b/web/e2e/export.spec.ts
@@ -158,6 +158,34 @@ test.describe("export", () => {
     expect(storedGutter).toBe("5mm");
   });
 
+  test("Oversized gutter shows an error and disables Export", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.setEditorContent(body);
+    await expect(editor.exportPdfButton).toBeEnabled();
+
+    await editor.exportPdfButton.click();
+    await expect(editor.exportDialog).toBeVisible();
+    await editor.exportStyleOption("condensed").click();
+    await editor.layoutOption("booklet").click();
+    await expect(editor.gutterRow).toBeVisible();
+
+    // 50 inches is wildly over any sheet's landscape width.
+    await editor.gutterValueInput.fill("50");
+    await editor.gutterUnitSelect.selectOption("in");
+
+    const gutterError = editor.exportDialog.locator('[data-testid="gutter-error"]');
+    await expect(gutterError).toBeVisible();
+    await expect(gutterError).toContainText(/Gutter must be under/i);
+    await expect(editor.exportConfirmButton).toBeDisabled();
+
+    // Bringing the value back under the max re-enables Export.
+    await editor.gutterValueInput.fill("0.125");
+    await expect(gutterError).toBeHidden();
+    await expect(editor.exportConfirmButton).toBeEnabled();
+  });
+
   test("Manuscript export preserves a previously chosen condensed layout", async ({ page }) => {
     const editor = new EditorPage(page);
     await editor.gotoReady();

--- a/web/e2e/export.spec.ts
+++ b/web/e2e/export.spec.ts
@@ -186,6 +186,44 @@ test.describe("export", () => {
     await expect(editor.exportConfirmButton).toBeEnabled();
   });
 
+  test("Non-booklet exports ignore the stored gutter", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+
+    // Seed a nonsense gutter value before the editor boots. If the export
+    // path still forwards this to WASM for non-booklet layouts, ParseMeasurement
+    // will reject it and renderPDF returns null bytes → error toast.
+    await page.addInitScript(() => {
+      window.localStorage.setItem("downstage-editor-export-booklet-gutter", "not-a-measurement");
+    });
+    await page.reload();
+    await editor.welcomeStartButton.click();
+    await editor.setEditorContent(body);
+    await expect(editor.exportPdfButton).toBeEnabled();
+
+    // 2-up export: gutter is stored but should never be sent to WASM.
+    const twoUpDownload = await editor.downloadPdf({
+      style: "condensed",
+      layout: "2up",
+    });
+    const twoUpPath = await twoUpDownload.path();
+    const twoUpBuf = await readFile(twoUpPath!);
+    expect(twoUpBuf.slice(0, 5).toString("utf8")).toBe("%PDF-");
+
+    // The poisoned gutter should remain untouched — 2-up exports must not
+    // overwrite the stored gutter value either.
+    const storedAfter2Up = await page.evaluate(() =>
+      window.localStorage.getItem("downstage-editor-export-booklet-gutter"),
+    );
+    expect(storedAfter2Up).toBe("not-a-measurement");
+
+    // Manuscript export: same invariant.
+    const manuscriptDownload = await editor.downloadPdf({ style: "standard" });
+    const manuscriptPath = await manuscriptDownload.path();
+    const manuscriptBuf = await readFile(manuscriptPath!);
+    expect(manuscriptBuf.slice(0, 5).toString("utf8")).toBe("%PDF-");
+  });
+
   test("Gutter value converts when the unit toggles", async ({ page }) => {
     const editor = new EditorPage(page);
     await editor.gotoReady();

--- a/web/e2e/export.spec.ts
+++ b/web/e2e/export.spec.ts
@@ -186,6 +186,31 @@ test.describe("export", () => {
     await expect(editor.exportConfirmButton).toBeEnabled();
   });
 
+  test("Gutter value converts when the unit toggles", async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.gotoReady();
+    await editor.welcomeStartButton.click();
+    await editor.setEditorContent(body);
+    await expect(editor.exportPdfButton).toBeEnabled();
+
+    await editor.exportPdfButton.click();
+    await expect(editor.exportDialog).toBeVisible();
+    await editor.exportStyleOption("condensed").click();
+    await editor.layoutOption("booklet").click();
+
+    // Start from a known value and unit.
+    await editor.gutterUnitSelect.selectOption("in");
+    await editor.gutterValueInput.fill("0.125");
+
+    // Swap to mm: 0.125 in × 25.4 = 3.175 mm.
+    await editor.gutterUnitSelect.selectOption("mm");
+    await expect(editor.gutterValueInput).toHaveValue("3.18");
+
+    // Swap back to in: 3.18 mm ÷ 25.4 = 0.1252 in (rounded).
+    await editor.gutterUnitSelect.selectOption("in");
+    await expect(editor.gutterValueInput).toHaveValue("0.1252");
+  });
+
   test("Switching to Manuscript ignores a stale invalid gutter", async ({ page }) => {
     const editor = new EditorPage(page);
     await editor.gotoReady();

--- a/web/e2e/pages/EditorPage.ts
+++ b/web/e2e/pages/EditorPage.ts
@@ -49,6 +49,30 @@ export class EditorPage {
     return this.exportDialog.locator(`button[data-page-size="${value}"]`);
   }
 
+  exportStyleOption(value: "standard" | "condensed"): Locator {
+    return this.exportDialog.locator(`button[data-export-style="${value}"]`);
+  }
+
+  layoutOption(value: "single" | "2up" | "booklet"): Locator {
+    return this.exportDialog.locator(`button[data-pdf-layout="${value}"]`);
+  }
+
+  get layoutGroup(): Locator {
+    return this.exportDialog.locator('[data-testid="layout-group"]');
+  }
+
+  get gutterRow(): Locator {
+    return this.exportDialog.locator('[data-testid="gutter-row"]');
+  }
+
+  get gutterValueInput(): Locator {
+    return this.exportDialog.locator('[data-testid="gutter-value"]');
+  }
+
+  get gutterUnitSelect(): Locator {
+    return this.exportDialog.locator('[data-testid="gutter-unit"]');
+  }
+
   // --- Workbench drawer ---
 
   get drawer(): Locator {
@@ -159,13 +183,35 @@ export class EditorPage {
     await expect(this.drawerTab(tab)).toHaveAttribute("aria-selected", "true");
   }
 
-  async downloadPdf(pageSize?: "letter" | "a4"): Promise<Download> {
+  async downloadPdf(options?: {
+    pageSize?: "letter" | "a4";
+    style?: "standard" | "condensed";
+    layout?: "single" | "2up" | "booklet";
+    gutterValue?: number;
+    gutterUnit?: "in" | "mm";
+  }): Promise<Download> {
     await this.exportPdfButton.click();
     await expect(this.exportDialog).toBeVisible();
-    if (pageSize) {
-      await this.pageSizeOption(pageSize).click();
-      await expect(this.pageSizeOption(pageSize)).toHaveAttribute("aria-checked", "true");
+
+    if (options?.pageSize) {
+      await this.pageSizeOption(options.pageSize).click();
+      await expect(this.pageSizeOption(options.pageSize)).toHaveAttribute("aria-checked", "true");
     }
+    if (options?.style) {
+      await this.exportStyleOption(options.style).click();
+      await expect(this.exportStyleOption(options.style)).toHaveAttribute("aria-checked", "true");
+    }
+    if (options?.layout) {
+      await this.layoutOption(options.layout).click();
+      await expect(this.layoutOption(options.layout)).toHaveAttribute("aria-checked", "true");
+    }
+    if (options?.gutterValue !== undefined) {
+      await this.gutterValueInput.fill(String(options.gutterValue));
+    }
+    if (options?.gutterUnit) {
+      await this.gutterUnitSelect.selectOption(options.gutterUnit);
+    }
+
     const downloadPromise = this.page.waitForEvent("download");
     await this.exportConfirmButton.click();
     return downloadPromise;

--- a/web/e2e/pages/EditorPage.ts
+++ b/web/e2e/pages/EditorPage.ts
@@ -205,11 +205,14 @@ export class EditorPage {
       await this.layoutOption(options.layout).click();
       await expect(this.layoutOption(options.layout)).toHaveAttribute("aria-checked", "true");
     }
-    if (options?.gutterValue !== undefined) {
-      await this.gutterValueInput.fill(String(options.gutterValue));
-    }
+    // Pick the unit first; changing the unit converts whatever value is
+    // already in the field. Filling after the unit change gives the test
+    // the literal value it requested, independent of the modal's default.
     if (options?.gutterUnit) {
       await this.gutterUnitSelect.selectOption(options.gutterUnit);
+    }
+    if (options?.gutterValue !== undefined) {
+      await this.gutterValueInput.fill(String(options.gutterValue));
     }
 
     const downloadPromise = this.page.waitForEvent("download");

--- a/web/src/AppWeb.vue
+++ b/web/src/AppWeb.vue
@@ -364,6 +364,18 @@ async function handleExportConfirmed(opts: ExportPdfOptions) {
     const filename = `${title.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}-${styleSlug}${layoutSuffix}.pdf`;
 
     const pdfBytes = await props.env.renderPDF(activeContent.value, opts);
+    // renderPDF returns an empty (or falsy) Uint8Array when the WASM side
+    // rejects the request (e.g. invalid config, imposition failure).
+    // Saving an empty file would quietly produce a broken PDF; surface the
+    // failure as a toast instead.
+    if (!pdfBytes || pdfBytes.byteLength === 0) {
+        toastManager.value?.addToast(
+            "PDF export failed. Check the export settings and try again.",
+            "error",
+            5000,
+        );
+        return;
+    }
     await props.env.saveFile(filename, pdfBytes, [
         { displayName: "PDF Files (*.pdf)", pattern: "*.pdf" }
     ]);

--- a/web/src/AppWeb.vue
+++ b/web/src/AppWeb.vue
@@ -343,10 +343,9 @@ async function handleExportConfirmed(opts: ExportPdfOptions) {
         // ignore storage errors
     }
 
-    // Layout is only meaningful for condensed exports. A Manuscript export
-    // always comes through as single; persisting it back would clobber a
-    // previously chosen condensed layout (2up/booklet), so only update the
-    // stored layout on condensed exports.
+    // Only persist the layout on condensed exports. Manuscript always
+    // comes through as layout=single and would clobber a previously chosen
+    // 2up/booklet preference otherwise.
     if (opts.style === "condensed") {
         exportLayout.value = opts.layout;
         try {
@@ -374,10 +373,9 @@ async function handleExportConfirmed(opts: ExportPdfOptions) {
     const filename = `${title.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}-${styleSlug}${layoutSuffix}.pdf`;
 
     const pdfBytes = await props.env.renderPDF(activeContent.value, opts);
-    // renderPDF returns an empty (or falsy) Uint8Array when the WASM side
-    // rejects the request (e.g. invalid config, imposition failure).
-    // Saving an empty file would quietly produce a broken PDF; surface the
-    // failure as a toast instead.
+    // An empty Uint8Array means the WASM side rejected the request (bad
+    // config, imposition failure, etc.). Saving it would produce a broken
+    // file; surface the failure as a toast instead.
     if (!pdfBytes || pdfBytes.byteLength === 0) {
         toastManager.value?.addToast(
             "PDF export failed. Check the export settings and try again.",

--- a/web/src/AppWeb.vue
+++ b/web/src/AppWeb.vue
@@ -337,14 +337,25 @@ function handleExport() {
 async function handleExportConfirmed(opts: ExportPdfOptions) {
     showExportDialog.value = false;
     exportPageSize.value = opts.pageSize;
-    exportLayout.value = opts.layout;
     exportGutter.value = opts.bookletGutter;
     try {
         localStorage.setItem(pageSizeStorageKey, opts.pageSize);
-        localStorage.setItem(layoutStorageKey, opts.layout);
         localStorage.setItem(gutterStorageKey, opts.bookletGutter);
     } catch {
         // ignore storage errors
+    }
+
+    // Layout is only meaningful for condensed exports. A Manuscript export
+    // always comes through as single; persisting it back would clobber a
+    // previously chosen condensed layout (2up/booklet), so only update the
+    // stored layout on condensed exports.
+    if (opts.style === "condensed") {
+        exportLayout.value = opts.layout;
+        try {
+            localStorage.setItem(layoutStorageKey, opts.layout);
+        } catch {
+            // ignore storage errors
+        }
     }
 
     const title = extractDocumentTitle(activeContent.value) || "untitled";
@@ -566,7 +577,7 @@ watch(activeContent, (newContent) => {
         :initial-options="{
           pageSize: exportPageSize,
           style: pageStyle === 'condensed' ? 'condensed' : 'standard',
-          layout: pageStyle === 'condensed' ? exportLayout : 'single',
+          layout: exportLayout,
           bookletGutter: exportGutter,
         }"
         @close="showExportDialog = false"

--- a/web/src/AppWeb.vue
+++ b/web/src/AppWeb.vue
@@ -337,10 +337,8 @@ function handleExport() {
 async function handleExportConfirmed(opts: ExportPdfOptions) {
     showExportDialog.value = false;
     exportPageSize.value = opts.pageSize;
-    exportGutter.value = opts.bookletGutter;
     try {
         localStorage.setItem(pageSizeStorageKey, opts.pageSize);
-        localStorage.setItem(gutterStorageKey, opts.bookletGutter);
     } catch {
         // ignore storage errors
     }
@@ -353,6 +351,18 @@ async function handleExportConfirmed(opts: ExportPdfOptions) {
         exportLayout.value = opts.layout;
         try {
             localStorage.setItem(layoutStorageKey, opts.layout);
+        } catch {
+            // ignore storage errors
+        }
+    }
+
+    // Gutter only applies to booklet exports. Persisting it on single/2up
+    // exports would overwrite the user's last booklet preference (and
+    // could store a value they never intended for a booklet).
+    if (opts.layout === "booklet") {
+        exportGutter.value = opts.bookletGutter;
+        try {
+            localStorage.setItem(gutterStorageKey, opts.bookletGutter);
         } catch {
             // ignore storage errors
         }

--- a/web/src/AppWeb.vue
+++ b/web/src/AppWeb.vue
@@ -4,7 +4,7 @@ import {
     Plus, FolderOpen, FileText, Download, Copy, ExternalLink, Trash2, FileOutput, Upload, AlertTriangle
 } from 'lucide-vue-next';
 import { Store } from './core/store';
-import type { EditorEnv, ExportPdfOptions, PdfPageSize, SavedDraft } from './core/types';
+import type { EditorEnv, ExportPdfOptions, PdfLayout, PdfPageSize, SavedDraft } from './core/types';
 import ToolbarButton from './components/shared/ToolbarButton.vue';
 import BaseModal from './components/shared/BaseModal.vue';
 import DeleteConfirmationModal from './components/shared/DeleteConfirmationModal.vue';
@@ -22,6 +22,8 @@ provide('store', store);
 
 const welcomeStorageKey = "downstage-editor-welcome-dismissed";
 const pageSizeStorageKey = "downstage-editor-export-page-size";
+const layoutStorageKey = "downstage-editor-export-layout";
+const gutterStorageKey = "downstage-editor-export-booklet-gutter";
 const letterRegions = new Set(["CA", "MX", "PH", "US"]);
 
 function guessDefaultPageSize(): PdfPageSize {
@@ -50,12 +52,38 @@ function readStoredPageSize(): PdfPageSize {
   return guessDefaultPageSize();
 }
 
+function readStoredLayout(): PdfLayout {
+  try {
+    const stored = localStorage.getItem(layoutStorageKey);
+    if (stored === "single" || stored === "2up" || stored === "booklet") {
+      return stored;
+    }
+  } catch {
+    // ignore storage errors
+  }
+  return "single";
+}
+
+function readStoredGutter(): string {
+  try {
+    const stored = localStorage.getItem(gutterStorageKey);
+    if (stored && /^-?[\d.]+\s*(in|mm)$/i.test(stored)) {
+      return stored;
+    }
+  } catch {
+    // ignore storage errors
+  }
+  return "0.125in";
+}
+
 const isLoaded = ref(false);
 const showDrafts = ref(false);
 const showWelcome = ref(false);
 const showNewPlayConfirm = ref(false);
 const showExportDialog = ref(false);
 const exportPageSize = ref<PdfPageSize>(readStoredPageSize());
+const exportLayout = ref<PdfLayout>(readStoredLayout());
+const exportGutter = ref<string>(readStoredGutter());
 const activeContent = ref("");
 const pageStyle = ref("standard");
 const isV1Document = ref(false);
@@ -309,17 +337,22 @@ function handleExport() {
 async function handleExportConfirmed(opts: ExportPdfOptions) {
     showExportDialog.value = false;
     exportPageSize.value = opts.pageSize;
+    exportLayout.value = opts.layout;
+    exportGutter.value = opts.bookletGutter;
     try {
         localStorage.setItem(pageSizeStorageKey, opts.pageSize);
+        localStorage.setItem(layoutStorageKey, opts.layout);
+        localStorage.setItem(gutterStorageKey, opts.bookletGutter);
     } catch {
         // ignore storage errors
     }
 
     const title = extractDocumentTitle(activeContent.value) || "untitled";
     const styleSlug = opts.style === "condensed" ? "acting-edition" : "manuscript";
-    const filename = `${title.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}-${styleSlug}.pdf`;
+    const layoutSuffix = opts.layout === "single" ? "" : `-${opts.layout}`;
+    const filename = `${title.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}-${styleSlug}${layoutSuffix}.pdf`;
 
-    const pdfBytes = await props.env.renderPDF(activeContent.value, opts.style, opts.pageSize);
+    const pdfBytes = await props.env.renderPDF(activeContent.value, opts);
     await props.env.saveFile(filename, pdfBytes, [
         { displayName: "PDF Files (*.pdf)", pattern: "*.pdf" }
     ]);
@@ -530,7 +563,12 @@ watch(activeContent, (newContent) => {
 
     <ExportPdfModal
         :open="showExportDialog"
-        :initial-options="{ pageSize: exportPageSize, style: pageStyle === 'condensed' ? 'condensed' : 'standard' }"
+        :initial-options="{
+          pageSize: exportPageSize,
+          style: pageStyle === 'condensed' ? 'condensed' : 'standard',
+          layout: pageStyle === 'condensed' ? exportLayout : 'single',
+          bookletGutter: exportGutter,
+        }"
         @close="showExportDialog = false"
         @confirm="handleExportConfirmed"
     />

--- a/web/src/components/shared/ExportPdfModal.vue
+++ b/web/src/components/shared/ExportPdfModal.vue
@@ -43,11 +43,9 @@ watch(
   { deep: true },
 );
 
-// Preserve the last condensed layout when the user toggles style so a
-// booklet/2-up choice isn't erased by a quick detour to Manuscript. The
-// Layout and Gutter controls are hidden when style !== 'condensed', and
-// handleConfirm emits layout='single' for manuscript exports regardless
-// of the stored value, so manuscript validation still sees a valid combo.
+// Remembers the user's 2up/booklet pick so a quick detour to Manuscript
+// (which hides the layout row) doesn't erase their choice. Restored when
+// style flips back to condensed.
 const lastCondensedLayout = ref<PdfLayout>(
   props.initialOptions.layout === 'single' ? 'single' : props.initialOptions.layout,
 );
@@ -77,9 +75,6 @@ const condensedDerivedSize = computed(() =>
   pageSize.value === 'a4' ? 'A5 (148 × 210 mm)' : 'half-letter (5.5 × 8.5 in)',
 );
 
-// Landscape sheet width in millimeters, which is the hard upper bound on
-// gutter: a gutter at or above this value would leave zero-width cells.
-// For Letter the landscape width is 11in (279.4mm); for A4 it is 297mm.
 const maxGutterMM = computed(() => (pageSize.value === 'a4' ? 297 : 279.4));
 
 function gutterInMM(): number {
@@ -117,9 +112,9 @@ const canConfirm = computed(() => {
   return true;
 });
 
-// Switching the unit preserves the physical gutter by converting the
-// displayed value. Rounded to 4 decimal places for inches and 2 for
-// millimeters, which is well below the step the user can dial in.
+// Preserve the physical gutter when the user flips the unit: 0.125in
+// becomes 3.18mm, not 0.125mm. Round to 2 dp for mm and 4 dp for inches
+// so round-trip drift stays below the input's step.
 function changeGutterUnit(next: 'in' | 'mm') {
   const prev = gutterUnit.value;
   if (next === prev) return;
@@ -148,9 +143,9 @@ function selectLayout(value: PdfLayout) {
 
 function handleConfirm() {
   if (!canConfirm.value) return;
-  // Manuscript exports force layout=single so downstream validation
-  // (standard + 2up/booklet is rejected) always sees a valid combo.
-  // lastCondensedLayout is preserved for the next Acting Edition export.
+  // Force layout=single for Manuscript so config.Validate still sees a
+  // valid combo (standard + 2up/booklet is rejected). lastCondensedLayout
+  // keeps the user's actual pick around for the next condensed export.
   const emittedLayout = style.value === 'condensed' ? layout.value : 'single';
   emit('confirm', {
     pageSize: pageSize.value,

--- a/web/src/components/shared/ExportPdfModal.vue
+++ b/web/src/components/shared/ExportPdfModal.vue
@@ -117,6 +117,23 @@ const canConfirm = computed(() => {
   return true;
 });
 
+// Switching the unit preserves the physical gutter by converting the
+// displayed value. Rounded to 4 decimal places for inches and 2 for
+// millimeters, which is well below the step the user can dial in.
+function changeGutterUnit(next: 'in' | 'mm') {
+  const prev = gutterUnit.value;
+  if (next === prev) return;
+  const v = gutterValue.value;
+  if (Number.isFinite(v)) {
+    if (prev === 'in' && next === 'mm') {
+      gutterValue.value = Math.round(v * 25.4 * 100) / 100;
+    } else if (prev === 'mm' && next === 'in') {
+      gutterValue.value = Math.round((v / 25.4) * 10000) / 10000;
+    }
+  }
+  gutterUnit.value = next;
+}
+
 function selectPageSize(value: PdfPageSize) {
   pageSize.value = value;
 }
@@ -301,7 +318,8 @@ function handleConfirm() {
               :class="gutterError ? 'border-red-500/60' : 'border-border'"
             />
             <select
-              v-model="gutterUnit"
+              :value="gutterUnit"
+              @change="changeGutterUnit(($event.target as HTMLSelectElement).value as 'in' | 'mm')"
               data-testid="gutter-unit"
               class="px-3 py-2 rounded-md text-sm font-bold bg-black/5 dark:bg-white/5 border border-border text-text-main focus:outline-none focus:ring-2 focus:ring-brass-500/40"
             >

--- a/web/src/components/shared/ExportPdfModal.vue
+++ b/web/src/components/shared/ExportPdfModal.vue
@@ -43,12 +43,33 @@ watch(
   { deep: true },
 );
 
-// Snap layout back to single when switching to Manuscript so a stray
-// 2-up/booklet selection never leaks into a manuscript export (validation
-// would reject it anyway).
+// Preserve the last condensed layout when the user toggles style so a
+// booklet/2-up choice isn't erased by a quick detour to Manuscript. The
+// Layout and Gutter controls are hidden when style !== 'condensed', and
+// handleConfirm emits layout='single' for manuscript exports regardless
+// of the stored value, so manuscript validation still sees a valid combo.
+const lastCondensedLayout = ref<PdfLayout>(
+  props.initialOptions.layout === 'single' ? 'single' : props.initialOptions.layout,
+);
+
+watch(
+  () => [props.open, props.initialOptions.layout] as const,
+  ([isOpen, initial]) => {
+    if (isOpen) {
+      lastCondensedLayout.value = initial;
+    }
+  },
+);
+
+watch(layout, (next) => {
+  if (style.value === 'condensed') {
+    lastCondensedLayout.value = next;
+  }
+});
+
 watch(style, (next) => {
-  if (next !== 'condensed') {
-    layout.value = 'single';
+  if (next === 'condensed') {
+    layout.value = lastCondensedLayout.value;
   }
 });
 
@@ -79,10 +100,14 @@ function selectLayout(value: PdfLayout) {
 
 function handleConfirm() {
   if (!canConfirm.value) return;
+  // Manuscript exports force layout=single so downstream validation
+  // (standard + 2up/booklet is rejected) always sees a valid combo.
+  // lastCondensedLayout is preserved for the next Acting Edition export.
+  const emittedLayout = style.value === 'condensed' ? layout.value : 'single';
   emit('confirm', {
     pageSize: pageSize.value,
     style: style.value,
-    layout: layout.value,
+    layout: emittedLayout,
     bookletGutter: gutterString.value,
   });
 }

--- a/web/src/components/shared/ExportPdfModal.vue
+++ b/web/src/components/shared/ExportPdfModal.vue
@@ -77,9 +77,36 @@ const condensedDerivedSize = computed(() =>
   pageSize.value === 'a4' ? 'A5 (148 × 210 mm)' : 'half-letter (5.5 × 8.5 in)',
 );
 
+// Landscape sheet width in millimeters, which is the hard upper bound on
+// gutter: a gutter at or above this value would leave zero-width cells.
+// For Letter the landscape width is 11in (279.4mm); for A4 it is 297mm.
+const maxGutterMM = computed(() => (pageSize.value === 'a4' ? 297 : 279.4));
+
+function gutterInMM(): number {
+  const v = gutterValue.value;
+  if (!Number.isFinite(v)) return NaN;
+  return gutterUnit.value === 'in' ? v * 25.4 : v;
+}
+
+const maxGutterDisplay = computed(() => {
+  const mm = maxGutterMM.value;
+  if (gutterUnit.value === 'in') return `${(mm / 25.4).toFixed(2)}in`;
+  return `${mm.toFixed(1)}mm`;
+});
+
 const gutterString = computed(() => `${gutterValue.value}${gutterUnit.value}`);
 
-const gutterIsValid = computed(() => gutterValue.value >= 0 && Number.isFinite(gutterValue.value));
+const gutterError = computed<string | null>(() => {
+  const v = gutterValue.value;
+  if (!Number.isFinite(v)) return 'Gutter must be a number';
+  if (v < 0) return 'Gutter must be non-negative';
+  if (gutterInMM() >= maxGutterMM.value) {
+    return `Gutter must be under ${maxGutterDisplay.value} for the selected page size`;
+  }
+  return null;
+});
+
+const gutterIsValid = computed(() => gutterError.value === null);
 
 const canConfirm = computed(() => {
   if (layout.value === 'booklet') return gutterIsValid.value;
@@ -264,7 +291,10 @@ function handleConfirm() {
               min="0"
               v-model.number="gutterValue"
               data-testid="gutter-value"
-              class="flex-1 px-3 py-2 rounded-md text-sm font-bold bg-black/5 dark:bg-white/5 border border-border text-text-main focus:outline-none focus:ring-2 focus:ring-brass-500/40"
+              aria-describedby="gutter-help"
+              :aria-invalid="!gutterIsValid"
+              class="flex-1 px-3 py-2 rounded-md text-sm font-bold bg-black/5 dark:bg-white/5 border text-text-main focus:outline-none focus:ring-2 focus:ring-brass-500/40"
+              :class="gutterError ? 'border-red-500/60' : 'border-border'"
             />
             <select
               v-model="gutterUnit"
@@ -275,7 +305,18 @@ function handleConfirm() {
               <option value="mm">mm</option>
             </select>
           </div>
-          <p class="mt-2 text-xs text-text-muted leading-relaxed">
+          <p
+            v-if="gutterError"
+            data-testid="gutter-error"
+            class="mt-2 text-xs text-red-500 leading-relaxed"
+          >
+            {{ gutterError }}
+          </p>
+          <p
+            v-else
+            id="gutter-help"
+            class="mt-2 text-xs text-text-muted leading-relaxed"
+          >
             Inside spacing between the two pages on each sheet. Booklet output
             is duplex: print double-sided, then fold in half.
           </p>

--- a/web/src/components/shared/ExportPdfModal.vue
+++ b/web/src/components/shared/ExportPdfModal.vue
@@ -109,6 +109,10 @@ const gutterError = computed<string | null>(() => {
 const gutterIsValid = computed(() => gutterError.value === null);
 
 const canConfirm = computed(() => {
+  // Gutter only matters for Acting Edition booklet exports. Manuscript
+  // exports force layout=single downstream (see handleConfirm), so a
+  // stale invalid gutter value should not block them.
+  if (style.value !== 'condensed') return true;
   if (layout.value === 'booklet') return gutterIsValid.value;
   return true;
 });

--- a/web/src/components/shared/ExportPdfModal.vue
+++ b/web/src/components/shared/ExportPdfModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import BaseModal from './BaseModal.vue';
-import type { ExportPdfOptions, PdfExportStyle, PdfPageSize } from '../../core/types';
+import type { ExportPdfOptions, PdfExportStyle, PdfLayout, PdfPageSize } from '../../core/types';
 
 const props = defineProps<{
   open: boolean;
@@ -15,20 +15,55 @@ const emit = defineEmits<{
 
 const pageSize = ref<PdfPageSize>(props.initialOptions.pageSize);
 const style = ref<PdfExportStyle>(props.initialOptions.style);
+const layout = ref<PdfLayout>(props.initialOptions.layout);
+const gutterValue = ref<number>(parseGutterValue(props.initialOptions.bookletGutter));
+const gutterUnit = ref<'in' | 'mm'>(parseGutterUnit(props.initialOptions.bookletGutter));
+
+function parseGutterValue(s: string): number {
+  const m = s.match(/^\s*(-?[\d.]+)\s*(in|mm)\s*$/i);
+  return m ? Number(m[1]) : 0.125;
+}
+
+function parseGutterUnit(s: string): 'in' | 'mm' {
+  const m = s.match(/^\s*(-?[\d.]+)\s*(in|mm)\s*$/i);
+  return m ? (m[2].toLowerCase() as 'in' | 'mm') : 'in';
+}
 
 watch(
-  () => [props.open, props.initialOptions.pageSize, props.initialOptions.style] as const,
-  ([isOpen, initialSize, initialStyle]) => {
+  () => [props.open, props.initialOptions] as const,
+  ([isOpen, initial]) => {
     if (isOpen) {
-      pageSize.value = initialSize;
-      style.value = initialStyle;
+      pageSize.value = initial.pageSize;
+      style.value = initial.style;
+      layout.value = initial.layout;
+      gutterValue.value = parseGutterValue(initial.bookletGutter);
+      gutterUnit.value = parseGutterUnit(initial.bookletGutter);
     }
   },
+  { deep: true },
 );
+
+// Snap layout back to single when switching to Manuscript so a stray
+// 2-up/booklet selection never leaks into a manuscript export (validation
+// would reject it anyway).
+watch(style, (next) => {
+  if (next !== 'condensed') {
+    layout.value = 'single';
+  }
+});
 
 const condensedDerivedSize = computed(() =>
   pageSize.value === 'a4' ? 'A5 (148 × 210 mm)' : 'half-letter (5.5 × 8.5 in)',
 );
+
+const gutterString = computed(() => `${gutterValue.value}${gutterUnit.value}`);
+
+const gutterIsValid = computed(() => gutterValue.value >= 0 && Number.isFinite(gutterValue.value));
+
+const canConfirm = computed(() => {
+  if (layout.value === 'booklet') return gutterIsValid.value;
+  return true;
+});
 
 function selectPageSize(value: PdfPageSize) {
   pageSize.value = value;
@@ -38,8 +73,18 @@ function selectStyle(value: PdfExportStyle) {
   style.value = value;
 }
 
+function selectLayout(value: PdfLayout) {
+  layout.value = value;
+}
+
 function handleConfirm() {
-  emit('confirm', { pageSize: pageSize.value, style: style.value });
+  if (!canConfirm.value) return;
+  emit('confirm', {
+    pageSize: pageSize.value,
+    style: style.value,
+    layout: layout.value,
+    bookletGutter: gutterString.value,
+  });
 }
 </script>
 
@@ -126,12 +171,95 @@ function handleConfirm() {
       <div
         v-if="style === 'condensed'"
         data-testid="condensed-sheet-note"
-        class="mt-3 mb-6 px-3 py-2 rounded-lg border border-brass-500/30 bg-brass-500/5 text-xs text-text-muted leading-relaxed"
+        class="mt-3 mb-5 px-3 py-2 rounded-lg border border-brass-500/30 bg-brass-500/5 text-xs text-text-muted leading-relaxed"
       >
         Acting edition renders on <strong class="font-semibold text-text-main">{{ condensedDerivedSize }}</strong> —
         the half-sheet derived from the selected page size.
       </div>
-      <div v-else class="mb-6" />
+
+      <template v-if="style === 'condensed'">
+        <label class="text-xs font-bold uppercase tracking-[0.15em] text-text-muted mb-2">
+          Layout
+        </label>
+        <div
+          role="radiogroup"
+          aria-label="PDF layout"
+          data-testid="layout-group"
+          class="grid grid-cols-3 gap-2 mb-5 p-1 rounded-lg bg-black/5 dark:bg-white/5 border border-border"
+        >
+          <button
+            type="button"
+            role="radio"
+            :aria-checked="layout === 'single'"
+            data-pdf-layout="single"
+            class="px-3 py-2 rounded-md text-xs font-bold transition-colors"
+            :class="layout === 'single'
+              ? 'bg-brass-500 text-ember-850 shadow-sm'
+              : 'text-text-muted hover:text-text-main hover:bg-black/5 dark:hover:bg-white/10'"
+            @click="selectLayout('single')"
+          >
+            Single page
+          </button>
+          <button
+            type="button"
+            role="radio"
+            :aria-checked="layout === '2up'"
+            data-pdf-layout="2up"
+            class="px-3 py-2 rounded-md text-xs font-bold transition-colors"
+            :class="layout === '2up'
+              ? 'bg-brass-500 text-ember-850 shadow-sm'
+              : 'text-text-muted hover:text-text-main hover:bg-black/5 dark:hover:bg-white/10'"
+            @click="selectLayout('2up')"
+          >
+            2-up
+          </button>
+          <button
+            type="button"
+            role="radio"
+            :aria-checked="layout === 'booklet'"
+            data-pdf-layout="booklet"
+            class="px-3 py-2 rounded-md text-xs font-bold transition-colors"
+            :class="layout === 'booklet'
+              ? 'bg-brass-500 text-ember-850 shadow-sm'
+              : 'text-text-muted hover:text-text-main hover:bg-black/5 dark:hover:bg-white/10'"
+            @click="selectLayout('booklet')"
+          >
+            Booklet
+          </button>
+        </div>
+
+        <div v-if="layout === 'booklet'" data-testid="gutter-row" class="mb-5">
+          <label class="text-xs font-bold uppercase tracking-[0.15em] text-text-muted mb-2 block">
+            Booklet gutter
+          </label>
+          <div class="flex gap-2 items-center">
+            <input
+              type="number"
+              step="0.025"
+              min="0"
+              v-model.number="gutterValue"
+              data-testid="gutter-value"
+              class="flex-1 px-3 py-2 rounded-md text-sm font-bold bg-black/5 dark:bg-white/5 border border-border text-text-main focus:outline-none focus:ring-2 focus:ring-brass-500/40"
+            />
+            <select
+              v-model="gutterUnit"
+              data-testid="gutter-unit"
+              class="px-3 py-2 rounded-md text-sm font-bold bg-black/5 dark:bg-white/5 border border-border text-text-main focus:outline-none focus:ring-2 focus:ring-brass-500/40"
+            >
+              <option value="in">in</option>
+              <option value="mm">mm</option>
+            </select>
+          </div>
+          <p class="mt-2 text-xs text-text-muted leading-relaxed">
+            Inside spacing between the two pages on each sheet. Booklet output
+            is duplex: print double-sided, then fold in half.
+          </p>
+        </div>
+      </template>
+
+      <div v-else class="mt-3 mb-5 text-xs text-text-muted italic">
+        2-up and booklet layouts are available for Acting Edition only.
+      </div>
 
       <div class="flex gap-3 w-full">
         <button
@@ -144,7 +272,8 @@ function handleConfirm() {
         <button
           type="button"
           data-testid="export-confirm"
-          class="flex-1 px-4 py-2.5 rounded-lg bg-brass-500 text-ember-850 text-sm font-bold hover:brightness-110 transition-all shadow-lg"
+          :disabled="!canConfirm"
+          class="flex-1 px-4 py-2.5 rounded-lg bg-brass-500 text-ember-850 text-sm font-bold hover:brightness-110 transition-all shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
           @click="handleConfirm"
         >
           Export PDF

--- a/web/src/core/types.ts
+++ b/web/src/core/types.ts
@@ -134,10 +134,13 @@ export interface EditorDiagnostic {
 
 export type PdfPageSize = "letter" | "a4";
 export type PdfExportStyle = "standard" | "condensed";
+export type PdfLayout = "single" | "2up" | "booklet";
 
 export interface ExportPdfOptions {
   pageSize: PdfPageSize;
   style: PdfExportStyle;
+  layout: PdfLayout;
+  bookletGutter: string; // e.g. "0.125in" or "3mm"
 }
 
 export interface SavedDraft {
@@ -163,7 +166,7 @@ export interface EditorEnv {
 
   // Rendering
   renderHTML(source: string, style?: string): Promise<string>;
-  renderPDF(source: string, style?: string, pageSize?: PdfPageSize): Promise<Uint8Array>;
+  renderPDF(source: string, options: ExportPdfOptions): Promise<Uint8Array>;
 
   // Persistence (Drafts)
   loadDrafts(): Promise<SavedDraft[]>;

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -27,7 +27,12 @@ declare global {
       codeActions(source: string, line: number, col: number, codes?: string[]): LSPCodeActionsResult;
       documentSymbols(source: string): DocumentSymbolsResult;
       renderHTML(source: string, style?: string): string;
-      renderPDF(source: string, style?: string, pageSize?: string): Uint8Array;
+      renderPDF(source: string, options?: {
+        style?: string;
+        pageSize?: string;
+        layout?: string;
+        gutter?: string;
+      }): Uint8Array;
       semanticTokens(source: string): Uint32Array;
       stats(source: string): ManuscriptStats;
       tokenTypeNames: string[];
@@ -136,8 +141,15 @@ export function renderHTML(source: string, style?: string): string {
   return window.downstage.renderHTML(source, style);
 }
 
-export function renderPDF(source: string, style?: string, pageSize?: string): Uint8Array {
-  return window.downstage.renderPDF(source, style, pageSize);
+export interface WasmRenderPdfOptions {
+  style?: string;
+  pageSize?: string;
+  layout?: string;
+  gutter?: string;
+}
+
+export function renderPDF(source: string, options?: WasmRenderPdfOptions): Uint8Array {
+  return window.downstage.renderPDF(source, options);
 }
 
 export function stats(source: string): ManuscriptStats {

--- a/web/src/web-app.ts
+++ b/web/src/web-app.ts
@@ -94,12 +94,22 @@ class WebEnv implements EditorEnv {
   }
 
   async renderPDF(source: string, options: ExportPdfOptions): Promise<Uint8Array> {
-    return window.downstage.renderPDF(source, {
+    const wasmOpts: {
+      style: string;
+      pageSize: string;
+      layout: string;
+      gutter?: string;
+    } = {
       style: options.style,
       pageSize: options.pageSize,
       layout: options.layout,
-      gutter: options.bookletGutter,
-    });
+    };
+    // Gutter only applies to booklet layout. Omitting it for single/2up
+    // exports keeps a stale or malformed value from reaching WASM.
+    if (options.layout === "booklet") {
+      wasmOpts.gutter = options.bookletGutter;
+    }
+    return window.downstage.renderPDF(source, wasmOpts);
   }
 
   async loadDrafts(): Promise<SavedDraft[]> {

--- a/web/src/web-app.ts
+++ b/web/src/web-app.ts
@@ -104,8 +104,8 @@ class WebEnv implements EditorEnv {
       pageSize: options.pageSize,
       layout: options.layout,
     };
-    // Gutter only applies to booklet layout. Omitting it for single/2up
-    // exports keeps a stale or malformed value from reaching WASM.
+    // Only send gutter for booklet exports; other layouts never use it,
+    // so a stale or malformed stored value shouldn't reach WASM.
     if (options.layout === "booklet") {
       wasmOpts.gutter = options.bookletGutter;
     }

--- a/web/src/web-app.ts
+++ b/web/src/web-app.ts
@@ -4,6 +4,7 @@ import AppWeb from "./AppWeb.vue";
 import { initWasm, upgradeV1 as upgradeV1Wasm } from "./wasm";
 import type {
   EditorEnv,
+  ExportPdfOptions,
   SavedDraft,
   ParseError,
   WasmDiagnostic,
@@ -92,8 +93,13 @@ class WebEnv implements EditorEnv {
     return window.downstage.renderHTML(source, style);
   }
 
-  async renderPDF(source: string, style?: string, pageSize?: string): Promise<Uint8Array> {
-    return window.downstage.renderPDF(source, style, pageSize);
+  async renderPDF(source: string, options: ExportPdfOptions): Promise<Uint8Array> {
+    return window.downstage.renderPDF(source, {
+      style: options.style,
+      pageSize: options.pageSize,
+      layout: options.layout,
+      gutter: options.bookletGutter,
+    });
   }
 
   async loadDrafts(): Promise<SavedDraft[]> {


### PR DESCRIPTION
Closes #121.

Builds on #122 / PR #170 (page-size model). Adds PDF imposition as a second-pass composition step on top of the existing condensed renderer — fpdf still renders the source PDF, then [gofpdi](https://github.com/phpdave11/gofpdi) (via fpdf's `contrib/gofpdi` bridge) imports those pages and places them on new landscape sheets.

## Summary

- **Core renderer**: `render.Config` gains `Layout` (`single`/`2up`/`booklet`) and `BookletGutterMM`. Validation rejects `standard + 2up/booklet` with a direct error. `render.ParseMeasurement` accepts `in`/`mm` suffixes.
- **Imposition package** (new, `internal/render/pdf/impose/`): thin wrapper around gofpdi. Supports `TwoUp` and `Booklet`. Booklet pads to multiples of 4 and computes duplex page ordering in-package following the standard saddle-stitch scheme.
- **CLI**: new `--pdf-layout` and `--gutter` flags. Invalid combos rejected before render; layout + gutter rejected for HTML output.
- **WASM bridge**: `renderPDF` accepts a structured config object `{ style, pageSize, layout, gutter }`. Legacy positional args still accepted for one release.
- **Web editor**: `ExportPdfModal` gains a Layout section (only shown for Acting Edition) and a conditional Gutter input (only for Booklet). Layout and gutter persist in localStorage under `downstage-editor-export-layout` / `downstage-editor-export-booklet-gutter`. Filenames gain a layout suffix (`-2up`, `-booklet`).
- **VS Code**: two new commands — *Export Acting Edition PDF (2-Up)* and *Export Acting Edition PDF (Booklet)* — plus a `downstage.render.bookletGutter` setting (default `0.125in`).
- **E2E**: three new Playwright specs cover Manuscript-hides-Layout, Booklet-reveals-Gutter, and booklet download-with-persistence.
- **Docs**: `README.md`, `SPEC.md` (new `### PDF Layout` section), `editors/vscode/README.md`, `web/README.md`.

## Size impact

gofpdi was picked over pdfcpu after a quick comparison; this branch initially shipped with pdfcpu but its transitive deps (x/image, x/crypto, x/text, yaml.v2, PKCS7, TIFF codec) bloated the binaries far beyond what a page-imposition feature earns:

| Artifact | main | pdfcpu (rejected) | **gofpdi (this PR)** |
|---|---:|---:|---:|
| Go binary | 10.8 MB | +14.5 MB | **+312 KB** |
| WASM uncompressed | 9.6 MB | +18.4 MB | **+836 KB** |
| WASM gzipped (wire) | 2.8 MB | +6.1 MB | **+210 KB** |

gofpdi also preserves all four Libre Baskerville variants end-to-end; pdfcpu dropped the BoldItalic variant during imposition.

## Breaking change

The preferred WASM `renderPDF` shape is now `renderPDF(source, { style, pageSize, layout, gutter })`. The old positional `renderPDF(source, style?, pageSize?)` form is still accepted internally for one release but is deprecated; external callers should migrate. All in-repo consumers are updated in this PR.

## Test plan

- [x] `go test ./...` — all packages green, including the new `impose` package (page-count assertions for 2-up and booklet across Letter + A4 fixtures).
- [x] `gofmt -l .` clean, `go vet ./...` clean.
- [x] `make wasm` succeeds; see size table above for WASM growth.
- [x] `make web` builds cleanly.
- [x] `npm --prefix editors/vscode test` — 62 passed. `npm run compile` clean.
- [x] `npm --prefix web test` — 54 passed (includes `tsc --noEmit`).
- [x] `npm --prefix web run test:e2e` — 27 passed (24 existing + 3 new).
- [x] Manual CLI smoke (Letter + A4 × single/2up/booklet + invalid combos):
  - `--style condensed --pdf-layout 2up` → 792×612 landscape, 34 output PDF pages (68 logical → `ceil(68/2)=34`)
  - `--style condensed --pdf-layout booklet --page-size a4` → 842×595 landscape, 34 output PDF pages (68 → `2*ceil(68/4)=34`)
  - `--style standard --pdf-layout booklet` → rejected with `layout "booklet" is only supported for style "condensed"`