### PR TITLE
fix(render): drop blank page between title page and generic section in condensed

### DIFF
--- a/internal/render/pdf/condensed.go
+++ b/internal/render/pdf/condensed.go
@@ -212,7 +212,7 @@ func (r *condensedRenderer) BeginSection(s *ast.Section) error {
 			r.pdf.Ln(r.lineHeight)
 			return nil
 		}
-		if !r.consumePendingDramatisBodyPage() && !r.consumePendingInlinePlayFirstBodyPage() {
+		if !r.consumePendingTitlePageBodyPage() && !r.consumePendingDramatisBodyPage() && !r.consumePendingInlinePlayFirstBodyPage() {
 			r.pdf.AddPage()
 		}
 		if s.Title != "" {

--- a/internal/render/pdf/pdf_test.go
+++ b/internal/render/pdf/pdf_test.go
@@ -250,6 +250,37 @@ func TestRender_CondensedDramatisPersonaeGetsOwnPageBeforeAct(t *testing.T) {
 	assert.Equal(t, 3, r.pdf.PageNo())
 }
 
+// TestRender_CondensedGenericSectionAfterTitlePageNoBlankPage ensures a
+// generic section immediately following the title page lands on page 2
+// and does not leave a blank page between the title page and the section
+// body.
+func TestRender_CondensedGenericSectionAfterTitlePageNoBlankPage(t *testing.T) {
+	r := NewCondensedRenderer(render.DefaultConfig()).(*condensedRenderer)
+	doc := &ast.Document{
+		TitlePage: &ast.TitlePage{
+			Entries: []ast.KeyValue{
+				{Key: "Title", Value: "Test"},
+				{Key: "Author", Value: "Test Author"},
+			},
+		},
+		Body: []ast.Node{
+			&ast.Section{
+				Kind:  ast.SectionGeneric,
+				Level: 2,
+				Title: "Preface",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := render.Walk(r, doc, &buf)
+	require.NoError(t, err)
+	assert.True(t, buf.Len() > 0)
+	// Title page (page 1) + generic section body (page 2) = 2 pages total.
+	// Before this fix, the renderer added an extra blank page 2, producing 3.
+	assert.Equal(t, 2, r.pdf.PageNo())
+}
+
 func TestRender_CompilationSubplayStaysInlineAfterHeader(t *testing.T) {
 	r := NewRenderer(render.DefaultConfig()).(*pdfRenderer)
 	doc := &ast.Document{


### PR DESCRIPTION
## Problem

When a condensed (Acting Edition) document has a generic section at level 2 immediately after the title page, the renderer inserts an extra blank page between the two.

Minimal repro structure:

```
# My Play
Author: Someone

## Preface

(some preface content)

# Another Top-Level Section
...body...
```

Observed layout before fix:

| Page | Contents |
|---|---|
| 1 | Title page |
| 2 | (blank) |
| 3 | Preface heading + body, then next top-level section runs onto the same page |
| 4 | Remaining body |

Expected:

| Page | Contents |
|---|---|
| 1 | Title page |
| 2 | Preface heading + body |
| 3 | Next top-level section + its front matter |
| 4 | Remaining body |

## Cause

`finishTitlePage` in `pdfBase` adds a new blank page and sets `pendingTitlePageBodyPage = true`; the next real body element is expected to consume that page instead of calling `AddPage()` again.

The condensed renderer's generic-section fallback at `internal/render/pdf/condensed.go:215` was checking `consumePendingDramatisBodyPage` and `consumePendingInlinePlayFirstBodyPage` but **not** `consumePendingTitlePageBodyPage`. So the section's entry point fell through to `AddPage()`, leaving the pending title-page body page unconsumed — which then got claimed by the later inline-play section header, which stopped adding its own page break, pushing that header onto the same page as the preceding section.

The standard renderer's corresponding fallback already consumes all three pending markers; the condensed path is now aligned.

Regression introduced in #131 (V2 document model) when the generic-section branch was refactored.

## Fix

One-line change:

```go
-if !r.consumePendingDramatisBodyPage() && !r.consumePendingInlinePlayFirstBodyPage() {
+if !r.consumePendingTitlePageBodyPage() && !r.consumePendingDramatisBodyPage() && !r.consumePendingInlinePlayFirstBodyPage() {
    r.pdf.AddPage()
}
```

## Test plan

- [x] New regression test `TestRender_CondensedGenericSectionAfterTitlePageNoBlankPage` passes (fails without the fix).
- [x] `go test ./internal/render/... ./cmd/...` — all green.
- [x] `gofmt -l .` clean.
- [x] Manual: a document with title page + generic section + inline-play section renders 4 pages with no blank page 2 (verified via `pdfinfo` + `pdftotext`).