### PR TITLE
ci: trigger CI on merge_group events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Add `merge_group:` to the CI workflow triggers so the two required status checks (\`Build and Check\`, \`Web E2E (Playwright)\`) fire on GitHub merge-queue refs (\`gh-readonly-queue/*\`).
- This must land **before** the branch ruleset is switched to use a merge queue. Without it, queued PRs reach the queue ref but no required check ever runs, and entries hang until timeout.

## Test plan

- [ ] Merge normally (manual rebase, no queue yet).
- [ ] After merge, update the "Protect main" ruleset to add a \`merge_queue\` rule and disable \`strict_required_status_checks_policy\`.
- [ ] Re-enable Dependabot PRs with \`gh pr merge --auto --squash\` and confirm the first one sequences through the queue.