### PR TITLE
fix(deps): bump liquidjs to 10.27.0 to clear security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2129,9 +2129,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.25.2",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.2.tgz",
-      "integrity": "sha512-ZbgcjEjGNlAIjqhuMzymO3lCpHgmVMftKfrq4/YLLxmKaFFeQMXRGrJTqKX7OXX1hKVPUDpTIrvL7lxt3X/hmw==",
+      "version": "10.27.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
+      "integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Lockfile-only update: \`liquidjs@10.25.2 → 10.27.0\`.
- \`liquidjs\` is a transitive devDependency of \`@11ty/eleventy\`. Eleventy declares \`liquidjs: ^10.25.0\` so this update fits inside its existing semver range — no \`overrides\` entry needed.
- Clears three open Dependabot alerts:
  - **high** — Root restriction bypass for partial and layout loading through symlinked templates (fixed in 10.25.3)
  - **medium** — \`ownPropertyOnly\` bypass via \`sort_natural\` filter (fixed in 10.25.4)
  - **medium** — \`renderFile()\` / \`parseFile()\` bypass configured \`root\` (fixed in 10.25.5)

Our \`.eleventy.js\` uses Nunjucks for both \`markdownTemplateEngine\` and \`htmlTemplateEngine\`, so the vulnerable liquidjs code paths weren't being exercised at render time. Patching anyway: the alerts are real, the fix is free, and a future config change shouldn't reopen the surface.

## Test plan

- [x] \`npm update liquidjs\` resolves cleanly within Eleventy's existing \`^10.25.0\` range.
- [x] \`npx @11ty/eleventy --dryrun\` succeeds with no errors or warnings.
- [ ] CI green.