### PR TITLE
feat(revisions): add revision-pages workflow (`downstage revisions`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,15 @@ brew install downstage
 ## CLI Usage
 
 ```
-downstage parse play.ds       # Output AST as JSON
-downstage validate play.ds    # Check for errors
-downstage stats play.ds       # Report word/dialogue/runtime stats
-downstage render play.ds      # Render to PDF (default)
-downstage render -f html play.ds  # Render to HTML
-downstage lsp                 # Start LSP server (stdio)
-downstage version             # Print version info
+downstage parse play.ds            # Output AST as JSON
+downstage validate play.ds         # Check for errors
+downstage stats play.ds            # Report word/dialogue/runtime stats
+downstage render play.ds           # Render to PDF (default)
+downstage render -f html play.ds   # Render to HTML
+downstage revisions play_v2.ds --against play_v1.ds   # Render revision pages
+downstage revisions play.ds --from HEAD~1             # ...against a git ref
+downstage lsp                      # Start LSP server (stdio)
+downstage version                  # Print version info
 ```
 
 Use `-v` or `--verbose` to enable debug logging on any command.
@@ -190,6 +192,36 @@ Acting edition can be imposed for print via `--pdf-layout`:
 
 HTML produces a self-contained document with embedded CSS using semantic
 `.downstage-*` class names for custom styling.
+
+### Revision Pages
+
+`downstage revisions` produces a small PDF containing only the pages that changed
+between two drafts of a play — the Hollywood "revision pages" workflow. Print
+the result and slot the pages into a v1 binder by their A/B/C-suffixed numbers;
+changed blocks get a right-margin asterisk and each page has a top-margin note
+indicating where it inserts or replaces in the v1 print.
+
+```
+downstage revisions v2.ds --against v1.ds            # explicit prior version
+downstage revisions v2.ds --from HEAD~1              # prior version from git
+downstage revisions v2.ds --against v1.ds -o rev.pdf # custom output path
+```
+
+Useful flags:
+
+- `--page-numbers v1-labels|natural|none` — default `v1-labels` (A/B/C suffix
+  off v1 page numbers). `natural` numbers from 1, `none` suppresses the footer.
+- `--mark-changes / --no-mark-changes` — right-margin asterisks (default on).
+- `--anchor-window N` — merge change hunks separated by ≤ N equal blocks into a
+  single region (default 4). Lower for tighter regions, higher for fewer.
+- `--removed-marker / --no-removed-marker` — emit a REMOVED placeholder page
+  when a revision shortens v1's pagination (default on).
+
+Exit codes: 0 success, 1 parse/render error, 2 no differences detected,
+3 git-ref resolution failed.
+
+Block-level granularity: when one word changes inside a long dialogue cue, the
+whole cue is marked. Per-visual-line marking is a planned follow-up.
 
 ### Statistics
 

--- a/cmd/revisions.go
+++ b/cmd/revisions.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jscaltreto/downstage/internal/render"
+	"github.com/jscaltreto/downstage/internal/revisions"
+	"github.com/spf13/cobra"
+)
+
+var (
+	revisionsAgainst       string
+	revisionsFromRef       string
+	revisionsOutput        string
+	revisionsPageSize      string
+	revisionsStyle         string
+	revisionsFont          string
+	revisionsMarkChanges   bool
+	revisionsPageNumbering string
+	revisionsAnchorWindow  int
+	revisionsRemovedMarker bool
+)
+
+var revisionsCmd = &cobra.Command{
+	Use:   "revisions <v2.ds>",
+	Short: "Render a revision-pages PDF that highlights what changed since v1",
+	Long: `Render a Hollywood-style revision-pages PDF.
+
+Given a current ("v2") .ds file and a prior version, downstage revisions emits
+a small PDF containing only the pages that changed, with right-margin
+asterisks marking changed blocks and a top-margin note describing where each
+page slots into the v1 print. Pages keep v1 numbering with A/B/C suffixes
+where inserts overflow.
+
+The v1 source can be supplied either as a separate file (--against) or by
+reference to a git revision in the same repo (--from). v1 is rendered once
+internally to compute its pagination; the resulting PDF is discarded.
+
+Block-level granularity in v1: when a single word changes inside a long
+dialogue cue, the whole cue is marked changed. Per-visual-line marking is a
+planned follow-up.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRevisions,
+}
+
+func init() {
+	revisionsCmd.Flags().StringVar(&revisionsAgainst, "against", "", "path to the v1 (prior) .ds file")
+	revisionsCmd.Flags().StringVar(&revisionsFromRef, "from", "", "git ref (commit, tag, branch) to read v1 from in the v2 file's repo")
+	revisionsCmd.Flags().StringVarP(&revisionsOutput, "output", "o", "", "output PDF (default: <v2-stem>.revisions.pdf)")
+	revisionsCmd.Flags().StringVar(&revisionsPageSize, "page-size", "letter", "page size: letter, a4")
+	revisionsCmd.Flags().StringVar(&revisionsStyle, "style", "standard", "rendering style: standard (Manuscript). Condensed is reserved for a follow-up.")
+	revisionsCmd.Flags().StringVar(&revisionsFont, "font", "", "path to a custom TTF font file")
+	revisionsCmd.Flags().BoolVar(&revisionsMarkChanges, "mark-changes", true, "draw a right-margin asterisk on each changed block")
+	revisionsCmd.Flags().StringVar(&revisionsPageNumbering, "page-numbers", "v1-labels", "page-number style: v1-labels, natural, none")
+	revisionsCmd.Flags().IntVar(&revisionsAnchorWindow, "anchor-window", 4, "merge adjacent change hunks separated by ≤ N equal blocks into one region")
+	revisionsCmd.Flags().BoolVar(&revisionsRemovedMarker, "removed-marker", true, "emit a REMOVED placeholder page when a revision shortens v1's pagination")
+	rootCmd.AddCommand(revisionsCmd)
+}
+
+func runRevisions(cmd *cobra.Command, args []string) error {
+	v2Path := args[0]
+	if (revisionsAgainst == "") == (revisionsFromRef == "") {
+		return errors.New("specify exactly one of --against or --from")
+	}
+
+	v2Source, err := os.ReadFile(v2Path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", v2Path, err)
+	}
+
+	var v1Source []byte
+	var v1Name string
+	switch {
+	case revisionsAgainst != "":
+		v1Source, err = os.ReadFile(revisionsAgainst)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", revisionsAgainst, err)
+		}
+		v1Name = revisionsAgainst
+	case revisionsFromRef != "":
+		v1Source, err = revisions.ReadFromGit(v2Path, revisionsFromRef)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(3)
+		}
+		v1Name = fmt.Sprintf("%s@%s", filepath.Base(v2Path), revisionsFromRef)
+	}
+
+	cfg := render.DefaultConfig()
+	pageSize, err := render.ParsePageSize(revisionsPageSize)
+	if err != nil {
+		return err
+	}
+	cfg.PageSize = pageSize
+
+	style, err := render.ParseStyle(revisionsStyle)
+	if err != nil {
+		return err
+	}
+	if style != render.StyleStandard {
+		return fmt.Errorf("--style %q is not supported by `revisions` in v1; use --style standard", revisionsStyle)
+	}
+	cfg.Style = style
+	cfg.FontPath = revisionsFont
+
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("invalid render config: %w", err)
+	}
+
+	pageNumbering, err := parsePageNumbering(revisionsPageNumbering)
+	if err != nil {
+		return err
+	}
+
+	out := revisionsOutput
+	if out == "" {
+		stem := strings.TrimSuffix(v2Path, filepath.Ext(v2Path))
+		out = stem + ".revisions.pdf"
+	}
+
+	outDir := filepath.Dir(out)
+	tmp, err := os.CreateTemp(outDir, ".revisions-*.pdf")
+	if err != nil {
+		return fmt.Errorf("creating temp file in %s: %w", outDir, err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}
+
+	if err := revisions.Render(tmp, revisions.Options{
+		V1Source:              v1Source,
+		V2Source:              v2Source,
+		V1Name:                v1Name,
+		V2Name:                v2Path,
+		Config:                cfg,
+		AnchorWindow:          revisionsAnchorWindow,
+		MarkChanges:           revisionsMarkChanges,
+		IncludeRemovedMarkers: revisionsRemovedMarker,
+		PageNumbering:         pageNumbering,
+	}); err != nil {
+		cleanup()
+		if errors.Is(err, revisions.ErrNoDifferences) {
+			fmt.Fprintln(os.Stderr, "no differences detected between v1 and v2; nothing to render")
+			os.Exit(2)
+		}
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, out); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("renaming %s to %s: %w", tmpPath, out, err)
+	}
+	slog.Info("revisions written", "output", out)
+	return nil
+}
+
+func parsePageNumbering(s string) (revisions.PageNumberingMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "v1-labels", "":
+		return revisions.PageNumberingV1Labels, nil
+	case "natural":
+		return revisions.PageNumberingNatural, nil
+	case "none":
+		return revisions.PageNumberingNone, nil
+	}
+	return 0, fmt.Errorf("unsupported --page-numbers: %q (want v1-labels, natural, or none)", s)
+}

--- a/cmd/revisions_test.go
+++ b/cmd/revisions_test.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunRevisions_GeneratesPDF(t *testing.T) {
+	dir := t.TempDir()
+	v1Path := filepath.Join(dir, "v1.ds")
+	v2Path := filepath.Join(dir, "v2.ds")
+	outPath := filepath.Join(dir, "rev.pdf")
+
+	require.NoError(t, os.WriteFile(v1Path, []byte("# Play\n\n## ACT I\n\nHAMLET\nA.\n"), 0o644))
+	require.NoError(t, os.WriteFile(v2Path, []byte("# Play\n\n## ACT I\n\nHAMLET\nA.\n\nHAMLET\nB.\n"), 0o644))
+
+	resetRevisionFlags()
+	revisionsAgainst = v1Path
+	revisionsOutput = outPath
+	revisionsPageSize = "letter"
+	revisionsStyle = "standard"
+	revisionsPageNumbering = "v1-labels"
+	revisionsMarkChanges = true
+	revisionsRemovedMarker = true
+	revisionsAnchorWindow = 4
+
+	err := runRevisions(revisionsCmd, []string{v2Path})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(data), "%PDF-"))
+}
+
+func TestRunRevisions_RejectsBothInputModes(t *testing.T) {
+	dir := t.TempDir()
+	v1 := filepath.Join(dir, "v1.ds")
+	v2 := filepath.Join(dir, "v2.ds")
+	require.NoError(t, os.WriteFile(v1, []byte("# P\n"), 0o644))
+	require.NoError(t, os.WriteFile(v2, []byte("# P\n"), 0o644))
+
+	resetRevisionFlags()
+	revisionsAgainst = v1
+	revisionsFromRef = "HEAD"
+
+	err := runRevisions(revisionsCmd, []string{v2})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one")
+}
+
+func TestRunRevisions_RejectsNeitherInputMode(t *testing.T) {
+	dir := t.TempDir()
+	v2 := filepath.Join(dir, "v2.ds")
+	require.NoError(t, os.WriteFile(v2, []byte("# P\n"), 0o644))
+
+	resetRevisionFlags()
+
+	err := runRevisions(revisionsCmd, []string{v2})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one")
+}
+
+func TestRunRevisions_CondensedRejected(t *testing.T) {
+	dir := t.TempDir()
+	v1 := filepath.Join(dir, "v1.ds")
+	v2 := filepath.Join(dir, "v2.ds")
+	require.NoError(t, os.WriteFile(v1, []byte("# P\n"), 0o644))
+	require.NoError(t, os.WriteFile(v2, []byte("# P\n\nHAMLET\nLine.\n"), 0o644))
+
+	resetRevisionFlags()
+	revisionsAgainst = v1
+	revisionsOutput = filepath.Join(dir, "out.pdf")
+	revisionsStyle = "condensed"
+
+	err := runRevisions(revisionsCmd, []string{v2})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "condensed")
+}
+
+func TestParsePageNumbering(t *testing.T) {
+	cases := map[string]bool{
+		"v1-labels": true,
+		"natural":   true,
+		"none":      true,
+		"":          true,
+		"weird":     false,
+	}
+	for in, ok := range cases {
+		_, err := parsePageNumbering(in)
+		if ok {
+			assert.NoError(t, err, in)
+		} else {
+			assert.Error(t, err, in)
+		}
+	}
+}
+
+func resetRevisionFlags() {
+	revisionsAgainst = ""
+	revisionsFromRef = ""
+	revisionsOutput = ""
+	revisionsPageSize = "letter"
+	revisionsStyle = "standard"
+	revisionsFont = ""
+	revisionsMarkChanges = true
+	revisionsPageNumbering = "v1-labels"
+	revisionsAnchorWindow = 4
+	revisionsRemovedMarker = true
+}
+
+func TestRunRevisions_RenderFailureLeavesNoOutputFile(t *testing.T) {
+	dir := t.TempDir()
+	v1 := filepath.Join(dir, "v1.ds")
+	v2 := filepath.Join(dir, "v2.ds")
+	require.NoError(t, os.WriteFile(v1, []byte("# Play\n\n## ACT I\n\nHAMLET\nFirst.\n"), 0o644))
+	require.NoError(t, os.WriteFile(v2, []byte("# Play\n\n## ACT I\n\nSONG 1: Test\n\nHAMLET\nNo SONG END.\n"), 0o644))
+
+	out := filepath.Join(dir, "rev.pdf")
+	resetRevisionFlags()
+	revisionsAgainst = v1
+	revisionsOutput = out
+
+	err := runRevisions(revisionsCmd, []string{v2})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SONG")
+
+	_, statErr := os.Stat(out)
+	assert.True(t, os.IsNotExist(statErr),
+		"no PDF should remain at the destination path on render failure (got: %v)", statErr)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.HasPrefix(e.Name(), ".revisions-"))
+	}
+}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,0 +1,363 @@
+package diff
+
+// HunkKind describes the relationship between an aligned pair of block runs.
+type HunkKind int
+
+const (
+	HunkEqual HunkKind = iota
+	HunkInsert
+	HunkDelete
+	HunkModify
+)
+
+// Hunk is a contiguous alignment between v1 and v2 block streams.
+//
+//   - HunkEqual:  V1Start..V1End == V2Start..V2End (semantically equal)
+//   - HunkInsert: V1Start == V1End (no v1 blocks), V2 blocks added
+//   - HunkDelete: V2Start == V2End (no v2 blocks), V1 blocks removed
+//   - HunkModify: both spans non-empty and not equal
+//
+// All indices are half-open: [Start, End).
+type Hunk struct {
+	Kind    HunkKind
+	V1Start int
+	V1End   int
+	V2Start int
+	V2End   int
+}
+
+// Diff aligns two flattened block streams and returns the resulting hunks in
+// document order. The result always covers every block in both streams; the
+// concatenation of v1 indices equals [0, len(v1)) and likewise for v2.
+//
+// The algorithm is a Patience-style diff over block fingerprints, falling
+// back to a Myers LCS within sub-spans where Patience finds no anchors
+// (e.g. long stretches of repeated dialogue).
+func Diff(v1, v2 []Block) []Hunk {
+	var hunks []Hunk
+	emitDiff(v1, v2, 0, 0, &hunks)
+	return mergeAdjacent(hunks)
+}
+
+type anchorPair struct {
+	v1, v2 int
+}
+
+type diffStep struct {
+	op   byte // 'E' equal, 'D' delete (v1), 'I' insert (v2)
+	i, j int
+}
+
+// emitDiff recursively diffs v1[0:] vs v2[0:] (the slices are already shifted)
+// and appends hunks to out, using the supplied (v1Base, v2Base) offsets so
+// emitted indices are in the caller's coordinate system.
+func emitDiff(v1, v2 []Block, v1Base, v2Base int, out *[]Hunk) {
+	// Strip a common prefix.
+	prefix := 0
+	for prefix < len(v1) && prefix < len(v2) && v1[prefix].Fingerprint == v2[prefix].Fingerprint {
+		prefix++
+	}
+	if prefix > 0 {
+		appendHunk(out, Hunk{
+			Kind:    HunkEqual,
+			V1Start: v1Base, V1End: v1Base + prefix,
+			V2Start: v2Base, V2End: v2Base + prefix,
+		})
+		emitDiff(v1[prefix:], v2[prefix:], v1Base+prefix, v2Base+prefix, out)
+		return
+	}
+
+	// Strip a common suffix.
+	suffix := 0
+	for suffix < len(v1) && suffix < len(v2) &&
+		v1[len(v1)-1-suffix].Fingerprint == v2[len(v2)-1-suffix].Fingerprint {
+		suffix++
+	}
+	if suffix > 0 {
+		mid1 := v1[:len(v1)-suffix]
+		mid2 := v2[:len(v2)-suffix]
+		emitDiff(mid1, mid2, v1Base, v2Base, out)
+		appendHunk(out, Hunk{
+			Kind:    HunkEqual,
+			V1Start: v1Base + len(mid1), V1End: v1Base + len(v1),
+			V2Start: v2Base + len(mid2), V2End: v2Base + len(v2),
+		})
+		return
+	}
+
+	if len(v1) == 0 && len(v2) == 0 {
+		return
+	}
+	if len(v1) == 0 {
+		appendHunk(out, Hunk{Kind: HunkInsert, V1Start: v1Base, V1End: v1Base, V2Start: v2Base, V2End: v2Base + len(v2)})
+		return
+	}
+	if len(v2) == 0 {
+		appendHunk(out, Hunk{Kind: HunkDelete, V1Start: v1Base, V1End: v1Base + len(v1), V2Start: v2Base, V2End: v2Base})
+		return
+	}
+
+	// Try Patience anchors over this slice.
+	if anchors := patienceAnchors(v1, v2); len(anchors) > 0 {
+		prevV1, prevV2 := 0, 0
+		for _, a := range anchors {
+			emitDiff(v1[prevV1:a.v1], v2[prevV2:a.v2], v1Base+prevV1, v2Base+prevV2, out)
+			appendHunk(out, Hunk{
+				Kind:    HunkEqual,
+				V1Start: v1Base + a.v1, V1End: v1Base + a.v1 + 1,
+				V2Start: v2Base + a.v2, V2End: v2Base + a.v2 + 1,
+			})
+			prevV1, prevV2 = a.v1+1, a.v2+1
+		}
+		emitDiff(v1[prevV1:], v2[prevV2:], v1Base+prevV1, v2Base+prevV2, out)
+		return
+	}
+
+	// No Patience anchors — fall back to Myers LCS.
+	myersDiff(v1, v2, v1Base, v2Base, out)
+}
+
+// patienceAnchors returns a longest-increasing-subsequence of fingerprints
+// that appear exactly once in each of v1 and v2, in v1 order.
+func patienceAnchors(v1, v2 []Block) []anchorPair {
+	v1Counts := map[string]int{}
+	v1Index := map[string]int{}
+	for i, b := range v1 {
+		v1Counts[b.Fingerprint]++
+		v1Index[b.Fingerprint] = i
+	}
+	v2Counts := map[string]int{}
+	v2Index := map[string]int{}
+	for i, b := range v2 {
+		v2Counts[b.Fingerprint]++
+		v2Index[b.Fingerprint] = i
+	}
+
+	var pairs []anchorPair
+	for fp, c1 := range v1Counts {
+		if c1 != 1 {
+			continue
+		}
+		if v2Counts[fp] != 1 {
+			continue
+		}
+		pairs = append(pairs, anchorPair{v1: v1Index[fp], v2: v2Index[fp]})
+	}
+	if len(pairs) == 0 {
+		return nil
+	}
+
+	// Sort by v1 index ascending (insertion sort; pairs is small in practice).
+	for i := 1; i < len(pairs); i++ {
+		for j := i; j > 0 && pairs[j-1].v1 > pairs[j].v1; j-- {
+			pairs[j-1], pairs[j] = pairs[j], pairs[j-1]
+		}
+	}
+
+	// LIS on v2 indices.
+	return longestIncreasingSubsequence(pairs)
+}
+
+// longestIncreasingSubsequence returns the LIS of pairs by .v2, preserving
+// the v1 ordering that the input is assumed to already have.
+func longestIncreasingSubsequence(pairs []anchorPair) []anchorPair {
+	if len(pairs) == 0 {
+		return nil
+	}
+	n := len(pairs)
+	tails := make([]int, 0, n)
+	prev := make([]int, n)
+	for i := range prev {
+		prev[i] = -1
+	}
+	for i, p := range pairs {
+		lo, hi := 0, len(tails)
+		for lo < hi {
+			mid := (lo + hi) / 2
+			if pairs[tails[mid]].v2 < p.v2 {
+				lo = mid + 1
+			} else {
+				hi = mid
+			}
+		}
+		if lo > 0 {
+			prev[i] = tails[lo-1]
+		}
+		if lo == len(tails) {
+			tails = append(tails, i)
+		} else {
+			tails[lo] = i
+		}
+	}
+
+	k := tails[len(tails)-1]
+	out := make([]anchorPair, 0, len(tails))
+	for k != -1 {
+		out = append(out, pairs[k])
+		k = prev[k]
+	}
+	// Reverse.
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out
+}
+
+// myersDiff implements a standard LCS-based diff for sub-spans where Patience
+// found no anchors. The textbook DP is acceptable here because Patience
+// catches the long-script case; only short, anchor-free sub-spans hit this
+// fallback.
+func myersDiff(v1, v2 []Block, v1Base, v2Base int, out *[]Hunk) {
+	n, m := len(v1), len(v2)
+	if n == 0 && m == 0 {
+		return
+	}
+
+	dp := make([][]int, n+1)
+	for i := range dp {
+		dp[i] = make([]int, m+1)
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			if v1[i-1].Fingerprint == v2[j-1].Fingerprint {
+				dp[i][j] = dp[i-1][j-1] + 1
+			} else if dp[i-1][j] >= dp[i][j-1] {
+				dp[i][j] = dp[i-1][j]
+			} else {
+				dp[i][j] = dp[i][j-1]
+			}
+		}
+	}
+
+	var steps []diffStep
+	i, j := n, m
+	for i > 0 || j > 0 {
+		switch {
+		case i > 0 && j > 0 && v1[i-1].Fingerprint == v2[j-1].Fingerprint:
+			steps = append(steps, diffStep{op: 'E', i: i - 1, j: j - 1})
+			i--
+			j--
+		case j > 0 && (i == 0 || dp[i][j-1] >= dp[i-1][j]):
+			steps = append(steps, diffStep{op: 'I', i: i, j: j - 1})
+			j--
+		default:
+			steps = append(steps, diffStep{op: 'D', i: i - 1, j: j})
+			i--
+		}
+	}
+	for k, l := 0, len(steps)-1; k < l; k, l = k+1, l-1 {
+		steps[k], steps[l] = steps[l], steps[k]
+	}
+
+	*out = append(*out, buildHunksFromSteps(steps, v1Base, v2Base)...)
+}
+
+type stepSpan struct {
+	i1, j1 int // inclusive lo (i for v1, j for v2)
+	i2, j2 int // exclusive hi
+}
+
+// buildHunksFromSteps walks a forward-ordered step sequence (E/D/I) and
+// produces the merged hunk list, coalescing adjacent D+I into HunkModify.
+func buildHunksFromSteps(steps []diffStep, v1Base, v2Base int) []Hunk {
+	var hunks []Hunk
+	var (
+		eq, del, ins          stepSpan
+		hasEq, hasDel, hasIns bool
+	)
+	reset := func() { hasEq, hasDel, hasIns = false, false, false }
+	flush := func() {
+		if hasDel && hasIns {
+			hunks = append(hunks, Hunk{
+				Kind:    HunkModify,
+				V1Start: v1Base + del.i1, V1End: v1Base + del.i2,
+				V2Start: v2Base + ins.j1, V2End: v2Base + ins.j2,
+			})
+		} else if hasDel {
+			hunks = append(hunks, Hunk{
+				Kind:    HunkDelete,
+				V1Start: v1Base + del.i1, V1End: v1Base + del.i2,
+				V2Start: v2Base + del.j1, V2End: v2Base + del.j1,
+			})
+		} else if hasIns {
+			hunks = append(hunks, Hunk{
+				Kind:    HunkInsert,
+				V1Start: v1Base + ins.i1, V1End: v1Base + ins.i1,
+				V2Start: v2Base + ins.j1, V2End: v2Base + ins.j2,
+			})
+		}
+		if hasEq {
+			hunks = append(hunks, Hunk{
+				Kind:    HunkEqual,
+				V1Start: v1Base + eq.i1, V1End: v1Base + eq.i2,
+				V2Start: v2Base + eq.j1, V2End: v2Base + eq.j2,
+			})
+		}
+		reset()
+	}
+
+	for _, s := range steps {
+		switch s.op {
+		case 'E':
+			if hasDel || hasIns {
+				flush()
+			}
+			if !hasEq {
+				eq = stepSpan{i1: s.i, j1: s.j, i2: s.i + 1, j2: s.j + 1}
+				hasEq = true
+			} else {
+				eq.i2 = s.i + 1
+				eq.j2 = s.j + 1
+			}
+		case 'D':
+			if hasEq {
+				flush()
+			}
+			if !hasDel {
+				del = stepSpan{i1: s.i, j1: s.j, i2: s.i + 1, j2: s.j}
+				hasDel = true
+			} else {
+				del.i2 = s.i + 1
+			}
+		case 'I':
+			if hasEq {
+				flush()
+			}
+			if !hasIns {
+				ins = stepSpan{i1: s.i, j1: s.j, i2: s.i, j2: s.j + 1}
+				hasIns = true
+			} else {
+				ins.j2 = s.j + 1
+			}
+		}
+	}
+	flush()
+	return hunks
+}
+
+// mergeAdjacent collapses consecutive same-kind hunks that abut perfectly,
+// which can arise from recursive emitDiff calls split at Patience anchors.
+func mergeAdjacent(hunks []Hunk) []Hunk {
+	if len(hunks) <= 1 {
+		return hunks
+	}
+	out := hunks[:0]
+	out = append(out, hunks[0])
+	for _, h := range hunks[1:] {
+		last := &out[len(out)-1]
+		if last.Kind == h.Kind && last.V1End == h.V1Start && last.V2End == h.V2Start {
+			last.V1End = h.V1End
+			last.V2End = h.V2End
+			continue
+		}
+		out = append(out, h)
+	}
+	return out
+}
+
+func appendHunk(out *[]Hunk, h Hunk) {
+	if h.V1Start == h.V1End && h.V2Start == h.V2End {
+		return
+	}
+	*out = append(*out, h)
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,0 +1,220 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseOrFail is a small helper to keep test fixtures readable.
+func parseOrFail(t *testing.T, src string) []Block {
+	t.Helper()
+	doc, errs := parser.Parse([]byte(src))
+	require.Empty(t, errs, "parse errors: %v", errs)
+	return FlattenedBlocks(doc, CanonicalNameMap(doc))
+}
+
+func TestFlattenedBlocks_OrderedKindsMatchRendererWalk(t *testing.T) {
+	src := "# Test\n\n" +
+		"## ACT I\n\n" +
+		"### SCENE 1\n\n" +
+		"> Lights up.\n\n" +
+		"HAMLET\nTo be or not to be.\n\n" +
+		">> Important note.\n\n" +
+		"===\n\n" +
+		"### SCENE 2\n\n" +
+		"HAMLET\nThat is the question.\n"
+
+	blocks := parseOrFail(t, src)
+	require.NotEmpty(t, blocks)
+
+	// We expect at least: title-section header, act header, scene-1 header,
+	// stage direction, dialogue, callout, page break, scene-2 header,
+	// dialogue. Allow flex on exact count to tolerate parser nuances.
+	var kinds []BlockKind
+	for _, b := range blocks {
+		kinds = append(kinds, b.Kind)
+	}
+
+	// Section headers always come first within their nesting.
+	assert.Equal(t, BlockSectionHeader, kinds[0], "first block should be the play title section header")
+
+	// Find expected kinds appear in order.
+	mustContain := []BlockKind{
+		BlockSectionHeader, // play title
+		BlockSectionHeader, // act
+		BlockSectionHeader, // scene 1
+		BlockStageDirection,
+		BlockDialogue,
+		BlockCallout,
+		BlockPageBreak,
+		BlockSectionHeader, // scene 2
+		BlockDialogue,
+	}
+	pos := 0
+	for _, want := range mustContain {
+		found := false
+		for ; pos < len(kinds); pos++ {
+			if kinds[pos] == want {
+				found = true
+				pos++
+				break
+			}
+		}
+		assert.True(t, found, "expected to find %v at or after current position", want)
+	}
+}
+
+func TestDiff_EmptyEqual(t *testing.T) {
+	hunks := Diff(nil, nil)
+	assert.Empty(t, hunks)
+}
+
+func TestDiff_AllEqual(t *testing.T) {
+	src := "# Same\n\nHAMLET\nLine.\n"
+	v1 := parseOrFail(t, src)
+	v2 := parseOrFail(t, src)
+	hunks := Diff(v1, v2)
+	require.Len(t, hunks, 1)
+	assert.Equal(t, HunkEqual, hunks[0].Kind)
+	assert.Equal(t, len(v1), hunks[0].V1End)
+	assert.Equal(t, len(v2), hunks[0].V2End)
+}
+
+func TestDiff_PureInsert(t *testing.T) {
+	v1 := parseOrFail(t, "# Play\n\n## ACT I\n\nHAMLET\nLine A.\n")
+	v2 := parseOrFail(t, "# Play\n\n## ACT I\n\nHAMLET\nLine A.\n\nHAMLET\nLine B.\n")
+	hunks := Diff(v1, v2)
+
+	var insert *Hunk
+	for i := range hunks {
+		if hunks[i].Kind == HunkInsert {
+			insert = &hunks[i]
+		}
+	}
+	require.NotNil(t, insert, "expected an Insert hunk: %+v", hunks)
+	assert.Equal(t, insert.V1Start, insert.V1End, "insert v1 span must be empty")
+	assert.Greater(t, insert.V2End, insert.V2Start, "insert v2 span must be non-empty")
+}
+
+func TestDiff_PureDelete(t *testing.T) {
+	v1 := parseOrFail(t, "# Play\n\n## ACT I\n\nHAMLET\nLine A.\n\nHAMLET\nLine B.\n")
+	v2 := parseOrFail(t, "# Play\n\n## ACT I\n\nHAMLET\nLine A.\n")
+	hunks := Diff(v1, v2)
+
+	var del *Hunk
+	for i := range hunks {
+		if hunks[i].Kind == HunkDelete {
+			del = &hunks[i]
+		}
+	}
+	require.NotNil(t, del, "expected a Delete hunk: %+v", hunks)
+	assert.Greater(t, del.V1End, del.V1Start)
+	assert.Equal(t, del.V2Start, del.V2End)
+}
+
+func TestDiff_ModifyOneDialogue(t *testing.T) {
+	v1 := parseOrFail(t, "# Play\n\n## ACT I\n\nHAMLET\nOriginal line.\n")
+	v2 := parseOrFail(t, "# Play\n\n## ACT I\n\nHAMLET\nUpdated line.\n")
+	hunks := Diff(v1, v2)
+
+	var modify *Hunk
+	for i := range hunks {
+		if hunks[i].Kind == HunkModify {
+			modify = &hunks[i]
+		}
+	}
+	require.NotNil(t, modify, "expected a Modify hunk: %+v", hunks)
+	assert.Equal(t, 1, modify.V1End-modify.V1Start)
+	assert.Equal(t, 1, modify.V2End-modify.V2Start)
+}
+
+func TestDiff_CharacterAliasIsNotAChange(t *testing.T) {
+	v1 := parseOrFail(t, "# Play\n\n## Dramatis Personae\n\nHAMLET/HAM - Prince of Denmark\n\n## ACT I\n\nHAMLET\nTo be or not to be.\n")
+	v2 := parseOrFail(t, "# Play\n\n## Dramatis Personae\n\nHAMLET/HAM - Prince of Denmark\n\n## ACT I\n\nHAM\nTo be or not to be.\n")
+
+	hunks := Diff(v1, v2)
+
+	// Verify no Modify or Insert/Delete hunks; only Equal.
+	for _, h := range hunks {
+		assert.Equal(t, HunkEqual, h.Kind, "alias change should not produce non-Equal hunks: %+v", hunks)
+	}
+}
+
+func TestDiff_CommentOnlyEditIsNoOp(t *testing.T) {
+	v1 := parseOrFail(t, "# Play\n\n## ACT I\n\nHAMLET\nLine.\n")
+	v2 := parseOrFail(t, "# Play\n\n// note\n\n## ACT I\n\n// another\n\nHAMLET\nLine.\n")
+	hunks := Diff(v1, v2)
+	for _, h := range hunks {
+		assert.Equal(t, HunkEqual, h.Kind, "comment-only edit should not produce non-Equal hunks: %+v", hunks)
+	}
+}
+
+func TestDiff_WhitespaceOnlyEditIsNoOp(t *testing.T) {
+	v1 := parseOrFail(t, "# Play\n\n## ACT I\n\nHAMLET\nLine of dialogue.\n")
+	v2 := parseOrFail(t, "# Play\n\n## ACT I\n\nHAMLET\nLine of    dialogue.\n")
+	hunks := Diff(v1, v2)
+	for _, h := range hunks {
+		assert.Equal(t, HunkEqual, h.Kind, "whitespace-only edit should not produce non-Equal hunks: %+v", hunks)
+	}
+}
+
+func TestDiff_Reorder_DetectedAsModification(t *testing.T) {
+	v1 := parseOrFail(t, "# Play\n\n## ACT I\n\nHAMLET\nFirst.\n\nHAMLET\nSecond.\n")
+	v2 := parseOrFail(t, "# Play\n\n## ACT I\n\nHAMLET\nSecond.\n\nHAMLET\nFirst.\n")
+	hunks := Diff(v1, v2)
+
+	hasNonEqual := false
+	for _, h := range hunks {
+		if h.Kind != HunkEqual {
+			hasNonEqual = true
+		}
+	}
+	assert.True(t, hasNonEqual, "reorder should surface as a non-Equal hunk: %+v", hunks)
+}
+
+func TestDiff_MyersFallback_NoUniqueFingerprints(t *testing.T) {
+	// Build streams where every fingerprint repeats — Patience finds no
+	// anchors and the algorithm must fall through to Myers.
+	v1 := parseOrFail(t, "# Play\n\nHAMLET\nA.\n\nHAMLET\nA.\n\nHAMLET\nA.\n")
+	v2 := parseOrFail(t, "# Play\n\nHAMLET\nA.\n\nHAMLET\nA.\n\nHAMLET\nA.\n\nHAMLET\nA.\n")
+	hunks := Diff(v1, v2)
+
+	// Expect the diff still terminates and produces an Insert covering the
+	// extra dialogue in v2.
+	totalV2 := 0
+	for _, h := range hunks {
+		totalV2 += h.V2End - h.V2Start
+	}
+	assert.Equal(t, len(v2), totalV2, "diff must cover every v2 block: %+v", hunks)
+}
+
+func TestDiff_FullRewrite_AllChanged(t *testing.T) {
+	v1 := parseOrFail(t, "# Play\n\n## ACT I\n\nHAMLET\nOld line.\n")
+	v2 := parseOrFail(t, "# Play 2\n\n## ACT I\n\nOPHELIA\nBrand new line.\n")
+	hunks := Diff(v1, v2)
+
+	totalV1, totalV2 := 0, 0
+	for _, h := range hunks {
+		totalV1 += h.V1End - h.V1Start
+		totalV2 += h.V2End - h.V2Start
+	}
+	assert.Equal(t, len(v1), totalV1)
+	assert.Equal(t, len(v2), totalV2)
+}
+
+func TestCanonicalNameMap_KnownAndUnknown(t *testing.T) {
+	doc, errs := parser.Parse([]byte("# P\n\n## Dramatis Personae\n\nHAMLET/HAM - Prince\n"))
+	require.Empty(t, errs)
+	canon := CanonicalNameMap(doc)
+	assert.Equal(t, "HAMLET", canon("hamlet"))
+	assert.Equal(t, "HAMLET", canon("HAM"))
+	assert.Equal(t, "OPHELIA", canon("ophelia"), "unknown name should round-trip uppercased")
+}
+
+func TestCanonText_NormalizesWhitespace(t *testing.T) {
+	assert.Equal(t, "to be or not to be", canonText("   to be   or  not\tto\nbe   "))
+	assert.Equal(t, "", canonText("   \t\n"))
+}

--- a/internal/diff/fingerprint.go
+++ b/internal/diff/fingerprint.go
@@ -1,0 +1,169 @@
+package diff
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/jscaltreto/downstage/internal/ast"
+	"github.com/jscaltreto/downstage/internal/render"
+)
+
+// CanonicalNameMap builds a name-canonicalization function from a document's
+// dramatis personae. Aliases collapse to their primary name; unknown names are
+// returned uppercased verbatim. The function is safe to call concurrently.
+func CanonicalNameMap(doc *ast.Document) func(string) string {
+	if doc == nil {
+		return strings.ToUpper
+	}
+	m := map[string]string{}
+	for _, node := range doc.Body {
+		collectCharactersInto(node, m)
+	}
+	return func(name string) string {
+		key := strings.ToUpper(strings.TrimSpace(name))
+		if v, ok := m[key]; ok {
+			return v
+		}
+		return key
+	}
+}
+
+func collectCharactersInto(node ast.Node, m map[string]string) {
+	switch n := node.(type) {
+	case *ast.Section:
+		if n.Kind == ast.SectionDramatisPersonae {
+			for _, c := range n.AllCharacters() {
+				canonical := strings.ToUpper(strings.TrimSpace(c.Name))
+				m[canonical] = canonical
+				for _, alias := range c.Aliases {
+					m[strings.ToUpper(strings.TrimSpace(alias))] = canonical
+				}
+			}
+			return
+		}
+		for _, child := range n.Children {
+			collectCharactersInto(child, m)
+		}
+	}
+}
+
+func fingerprintSectionHeader(s *ast.Section) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "section|%d|%d|%s|%s\n", int(s.Kind), s.Level, canonText(s.Title), strings.TrimSpace(s.Number))
+	if s.Metadata != nil {
+		for _, kv := range s.Metadata.Entries {
+			fmt.Fprintf(h, "meta|%s=%s\n", canonText(kv.Key), canonText(kv.Value))
+		}
+	}
+	return hexSum(h)
+}
+
+func fingerprintSectionLine(line *ast.SectionLine) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "sectionline|%s", canonText(render.PlainText(line.Content)))
+	return hexSum(h)
+}
+
+func fingerprintDialogue(d *ast.Dialogue, canonName func(string) string) string {
+	h := sha256.New()
+	name := d.Character
+	if canonName != nil {
+		name = canonName(d.Character)
+	}
+	fmt.Fprintf(h, "dialogue|%s|%s\n", name, canonText(d.Parenthetical))
+	for _, line := range d.Lines {
+		text := canonText(render.PlainText(line.Content))
+		fmt.Fprintf(h, "line|%t|%s\n", line.IsVerse, text)
+	}
+	return hexSum(h)
+}
+
+func fingerprintDualDialogue(d *ast.DualDialogue, canonName func(string) string) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "dual|%s|%s",
+		fingerprintDialogue(d.Left, canonName),
+		fingerprintDialogue(d.Right, canonName),
+	)
+	return hexSum(h)
+}
+
+func fingerprintStageDirection(sd *ast.StageDirection) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "sd|%s", canonText(render.PlainText(sd.Content)))
+	return hexSum(h)
+}
+
+func fingerprintCallout(c *ast.Callout) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "callout|%s", canonText(render.PlainText(c.Content)))
+	return hexSum(h)
+}
+
+func fingerprintSong(s *ast.Song, canonName func(string) string) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "song|%s|%s\n", canonText(s.Number), canonText(s.Title))
+	for _, child := range s.Content {
+		fmt.Fprintf(h, "child|%s\n", childFingerprint(child, canonName))
+	}
+	return hexSum(h)
+}
+
+func fingerprintVerseBlock(vb *ast.VerseBlock) string {
+	h := sha256.New()
+	h.Write([]byte("verseblock"))
+	for _, line := range vb.Lines {
+		fmt.Fprintf(h, "|%s", canonText(render.PlainText(line.Content)))
+	}
+	return hexSum(h)
+}
+
+// childFingerprint computes a stable fingerprint for any block node, used
+// when folding a parent's children into the parent's fingerprint (Song).
+func childFingerprint(node ast.Node, canonName func(string) string) string {
+	switch n := node.(type) {
+	case *ast.Dialogue:
+		return fingerprintDialogue(n, canonName)
+	case *ast.DualDialogue:
+		return fingerprintDualDialogue(n, canonName)
+	case *ast.StageDirection:
+		return fingerprintStageDirection(n)
+	case *ast.Callout:
+		return fingerprintCallout(n)
+	case *ast.VerseBlock:
+		return fingerprintVerseBlock(n)
+	case *ast.PageBreak:
+		return "pagebreak"
+	case *ast.Comment:
+		return ""
+	}
+	return ""
+}
+
+// canonText normalizes whitespace for fingerprinting: trim, collapse internal
+// runs of whitespace to single spaces. Case is preserved.
+func canonText(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	prevSpace := false
+	for _, r := range s {
+		if r == ' ' || r == '\t' || r == '\r' || r == '\n' {
+			if !prevSpace {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+			continue
+		}
+		b.WriteRune(r)
+		prevSpace = false
+	}
+	return b.String()
+}
+
+func hexSum(h interface{ Sum([]byte) []byte }) string {
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/diff/walk.go
+++ b/internal/diff/walk.go
@@ -1,0 +1,229 @@
+// Package diff implements a structural diff between two parsed Downstage
+// documents. It produces a sequence of hunks (Equal, Insert, Delete, Modify)
+// aligned to the renderer's block-level walk order, which lets downstream
+// callers (internal/revisions) compute revision regions that the PDF renderer
+// can emit.
+//
+// The flattened block stream produced by FlattenedBlocks is the unit of
+// comparison: a Section is split into a SectionHeader block followed by the
+// blocks for its ordered children. Songs and verse blocks are atoms — their
+// inner content is folded into the parent fingerprint so that any edit inside
+// shows up as a single change.
+package diff
+
+import (
+	"strings"
+
+	"github.com/jscaltreto/downstage/internal/ast"
+	"github.com/jscaltreto/downstage/internal/token"
+)
+
+// BlockKind enumerates the diffable block kinds. Each kind corresponds to a
+// node the PDF renderer emits as a top-level visual block.
+type BlockKind int
+
+const (
+	BlockSectionHeader BlockKind = iota
+	BlockSectionLine
+	BlockDialogue
+	BlockDualDialogue
+	BlockStageDirection
+	BlockCallout
+	BlockSong
+	BlockVerseBlock
+	BlockPageBreak
+)
+
+// Block is one element in the flattened diffable stream.
+type Block struct {
+	Kind BlockKind
+	// Fingerprint is the content-derived hash used by the diff algorithm.
+	// Two blocks with the same fingerprint are considered semantically equal
+	// for revision-page purposes.
+	Fingerprint string
+	// Path is the block's location in the source document, expressed as a
+	// chain of indices: doc.Body[Path[0]] → Section.OrderedItems[Path[1]] →
+	// (and so on). The first element of Path identifies the body slot.
+	Path []int
+	// SectionPath records the titles of the enclosing sections in
+	// outermost-first order, so that callers can build a "ACT II — SCENE 3"
+	// style context heading without re-walking the AST.
+	SectionPath []string
+	// Source is the original source range of the block, useful for
+	// diagnostics and asterisk-targeting at the line level.
+	Source token.Range
+	// Node points back to the original AST node for the block. For
+	// BlockSectionLine it is nil and Line is populated instead.
+	Node ast.Node
+	// Line is the source line for BlockSectionLine blocks.
+	Line *ast.SectionLine
+}
+
+// FlattenedBlocks returns the document's diffable block stream in the order
+// the PDF renderer walks the AST. It mirrors the structure of
+// internal/render.walkNode at the block level.
+//
+// The character canonicalizer is consulted when fingerprinting dialogue cues
+// so that an alias rename does not show up as a content change. Pass nil to
+// fingerprint character names literally.
+func FlattenedBlocks(doc *ast.Document, canonName func(string) string) []Block {
+	if doc == nil {
+		return nil
+	}
+	w := &flattener{canonName: canonName}
+	for i, node := range doc.Body {
+		w.walk(node, []int{i}, nil)
+	}
+	return w.blocks
+}
+
+type flattener struct {
+	blocks    []Block
+	canonName func(string) string
+}
+
+func (f *flattener) walk(node ast.Node, path []int, sectionPath []string) {
+	switch n := node.(type) {
+	case *ast.Section:
+		f.emitSection(n, path, sectionPath)
+	case *ast.DualDialogue:
+		f.emit(Block{
+			Kind:        BlockDualDialogue,
+			Fingerprint: fingerprintDualDialogue(n, f.canonName),
+			Path:        copyPath(path),
+			SectionPath: copyStrings(sectionPath),
+			Source:      n.Range,
+			Node:        n,
+		})
+	case *ast.Dialogue:
+		f.emit(Block{
+			Kind:        BlockDialogue,
+			Fingerprint: fingerprintDialogue(n, f.canonName),
+			Path:        copyPath(path),
+			SectionPath: copyStrings(sectionPath),
+			Source:      n.Range,
+			Node:        n,
+		})
+	case *ast.StageDirection:
+		f.emit(Block{
+			Kind:        BlockStageDirection,
+			Fingerprint: fingerprintStageDirection(n),
+			Path:        copyPath(path),
+			SectionPath: copyStrings(sectionPath),
+			Source:      n.Range,
+			Node:        n,
+		})
+	case *ast.Callout:
+		f.emit(Block{
+			Kind:        BlockCallout,
+			Fingerprint: fingerprintCallout(n),
+			Path:        copyPath(path),
+			SectionPath: copyStrings(sectionPath),
+			Source:      n.Range,
+			Node:        n,
+		})
+	case *ast.Song:
+		f.emit(Block{
+			Kind:        BlockSong,
+			Fingerprint: fingerprintSong(n, f.canonName),
+			Path:        copyPath(path),
+			SectionPath: copyStrings(sectionPath),
+			Source:      n.Range,
+			Node:        n,
+		})
+	case *ast.VerseBlock:
+		f.emit(Block{
+			Kind:        BlockVerseBlock,
+			Fingerprint: fingerprintVerseBlock(n),
+			Path:        copyPath(path),
+			SectionPath: copyStrings(sectionPath),
+			Source:      n.Range,
+			Node:        n,
+		})
+	case *ast.PageBreak:
+		f.emit(Block{
+			Kind:        BlockPageBreak,
+			Fingerprint: "pagebreak",
+			Path:        copyPath(path),
+			SectionPath: copyStrings(sectionPath),
+			Source:      n.Range,
+			Node:        n,
+		})
+	case *ast.Comment:
+		// Comments do not render and do not participate in diffing.
+	}
+}
+
+func (f *flattener) emitSection(s *ast.Section, path []int, sectionPath []string) {
+	f.emit(Block{
+		Kind:        BlockSectionHeader,
+		Fingerprint: fingerprintSectionHeader(s),
+		Path:        copyPath(path),
+		SectionPath: copyStrings(sectionPath),
+		Source:      s.HeadingRange(),
+		Node:        s,
+	})
+
+	childSectionPath := append(copyStrings(sectionPath), sectionDisplayLabel(s))
+	for i, item := range s.OrderedItems() {
+		childPath := append(copyPath(path), i)
+		switch {
+		case item.Node != nil:
+			f.walk(item.Node, childPath, childSectionPath)
+		case item.Line != nil:
+			f.emit(Block{
+				Kind:        BlockSectionLine,
+				Fingerprint: fingerprintSectionLine(item.Line),
+				Path:        childPath,
+				SectionPath: copyStrings(childSectionPath),
+				Source:      item.Line.Range,
+				Line:        item.Line,
+			})
+		}
+	}
+}
+
+func (f *flattener) emit(b Block) {
+	f.blocks = append(f.blocks, b)
+}
+
+// sectionDisplayLabel constructs a human-readable label for a section,
+// preferring the title and falling back to "<KIND> <NUMBER>" when titles are
+// empty (which is common for "## ACT II" headings where the parser stores
+// the literal as (Number="II", Title="")).
+func sectionDisplayLabel(s *ast.Section) string {
+	title := strings.TrimSpace(s.Title)
+	number := strings.TrimSpace(s.Number)
+	switch s.Kind {
+	case ast.SectionAct:
+		if number != "" && title != "" {
+			return "ACT " + number + ": " + title
+		}
+		if number != "" {
+			return "ACT " + number
+		}
+	case ast.SectionScene:
+		if number != "" && title != "" {
+			return "SCENE " + number + ": " + title
+		}
+		if number != "" {
+			return "SCENE " + number
+		}
+	}
+	return title
+}
+
+func copyPath(p []int) []int {
+	out := make([]int, len(p))
+	copy(out, p)
+	return out
+}
+
+func copyStrings(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
+}

--- a/internal/render/config.go
+++ b/internal/render/config.go
@@ -156,6 +156,37 @@ type Config struct {
 	MarginLeft      float64
 	MarginRight     float64
 	SourceAnchors   bool // emit data-source-line attributes on block elements
+
+	// Revision-pages hooks. Each is independent and inert by default.
+
+	// PageLabelFormatter overrides the page-number text in the footer. When
+	// nil the renderer prints the natural fpdf page number. The argument is
+	// the internal fpdf page number (1-indexed).
+	PageLabelFormatter func(internalPage int) string
+	// PageHeaderFn returns the top-of-page annotation for the given internal
+	// fpdf page (1-indexed). When nil no header is drawn.
+	PageHeaderFn func(internalPage int) string
+	// SkipOutline disables PDF outline / bookmark emission. Used for
+	// revision-pages output, which has no canonical structure to bookmark.
+	SkipOutline bool
+	// MarkChangedBlocks is the set of block AST nodes whose visual lines
+	// should be marked with a right-margin asterisk. Set membership is
+	// keyed by AST node pointer (e.g. *ast.Dialogue, *ast.StageDirection,
+	// *ast.SectionLine). When nil or empty no asterisks are drawn.
+	MarkChangedBlocks map[any]bool
+	// RecordPageMap, when non-nil, receives per-block (startPage, endPage)
+	// records as the renderer walks the document.
+	RecordPageMap PageSpanRecorder
+}
+
+// PageSpanRecorder is the minimal interface the renderer needs from
+// pdf/pagemap.Recorder to record block page spans. It is declared in the
+// render package to avoid a render → pdf/pagemap import cycle; pagemap's
+// concrete Recorder satisfies this interface implicitly.
+type PageSpanRecorder interface {
+	Begin(key any, page int)
+	End(key any, page int)
+	Record(key any, page int)
 }
 
 // Validate checks that Config values are within acceptable ranges.

--- a/internal/render/pdf/base.go
+++ b/internal/render/pdf/base.go
@@ -62,6 +62,18 @@ type pdfBase struct {
 	captureStyleStack   []string
 	captureDirDepth     int
 	capturedRuns        []dialogueTextRun
+
+	// changeBegins tracks the (page, y) at which each currently-rendering
+	// changed block started laying out content. Populated by
+	// markChangeBegin* and consumed by markChangeEnd, which iterates from
+	// begin to end stamping a right-margin asterisk on every visual line
+	// of the changed block.
+	changeBegins map[any]changeBegin
+}
+
+type changeBegin struct {
+	page int
+	y    float64
 }
 
 type dialogueTextRun struct {
@@ -106,6 +118,7 @@ func (b *pdfBase) initPDF(fontLoader func(*fpdf.Fpdf), defaultFamily string) err
 	b.pdf.AliasNbPages("")
 	b.titlePagePages = make(map[int]bool)
 	b.installPageNumberFooter(5, 10)
+	b.installRevisionHeaderIfConfigured()
 
 	b.pdf.AddPage()
 	b.fontStyle = ""
@@ -126,9 +139,192 @@ func (b *pdfBase) installPageNumberFooter(offset, height float64) {
 		}
 		b.pdf.SetY(-b.marginB + offset)
 		b.pdf.SetFont(b.cfg.FontFamily, "", b.cfg.FontSize-2)
-		b.renderPageNumberFooter(fmt.Sprintf("%d", b.pdf.PageNo()), height)
+		label := b.pageLabel(b.pdf.PageNo())
+		if label != "" {
+			b.renderPageNumberFooter(label, height)
+		}
 		b.pdf.SetFont(b.cfg.FontFamily, "", b.cfg.FontSize)
 	})
+}
+
+// pageLabel returns the rendered page-number text for the given internal
+// fpdf page. When Config.PageLabelFormatter is set, the caller supplies the
+// formatting (including the option to return an empty string to suppress the
+// footer entirely). Otherwise the natural integer page number is used.
+func (b *pdfBase) pageLabel(internalPage int) string {
+	if b.cfg.PageLabelFormatter != nil {
+		return b.cfg.PageLabelFormatter(internalPage)
+	}
+	return fmt.Sprintf("%d", internalPage)
+}
+
+// installRevisionHeaderIfConfigured installs a top-margin header function
+// when Config.PageHeaderFn is set. Non-revision renders skip this path
+// entirely so layout for normal PDFs is unchanged.
+func (b *pdfBase) installRevisionHeaderIfConfigured() {
+	if b.cfg.PageHeaderFn == nil {
+		return
+	}
+	b.pdf.SetHeaderFunc(func() {
+		if b.titlePagePages[b.pdf.PageNo()] {
+			return
+		}
+		header := b.cfg.PageHeaderFn(b.pdf.PageNo())
+		if header == "" {
+			return
+		}
+		// Draw the header text at the top of the page, above the body
+		// margin. The header sits inside marginT/2 to keep it clear of body
+		// content.
+		savedY := b.pdf.GetY()
+		b.pdf.SetY(b.marginT / 2)
+		b.pdf.SetFont(b.cfg.FontFamily, "I", b.cfg.FontSize-2)
+		b.centeredText(header)
+		b.pdf.SetFont(b.cfg.FontFamily, "", b.cfg.FontSize)
+		b.pdf.SetY(savedY)
+	})
+}
+
+// recordBlockBegin records the entry page for a block keyed by node pointer.
+// No-op when the page-map recorder is not installed.
+func (b *pdfBase) recordBlockBegin(node any) {
+	if b.cfg.RecordPageMap == nil || node == nil {
+		return
+	}
+	b.cfg.RecordPageMap.Begin(node, b.pdf.PageNo())
+}
+
+// recordBlockEnd records the exit page for a block keyed by node pointer.
+// Captured at End hooks, after fpdf has had a chance to auto-page-break from
+// any flowing Write/MultiCell/Ln calls inside the block.
+func (b *pdfBase) recordBlockEnd(node any) {
+	if b.cfg.RecordPageMap == nil || node == nil {
+		return
+	}
+	b.cfg.RecordPageMap.End(node, b.pdf.PageNo())
+}
+
+// recordLeaf records a single page for a self-contained block (PageBreak).
+func (b *pdfBase) recordLeaf(node any) {
+	if b.cfg.RecordPageMap == nil || node == nil {
+		return
+	}
+	b.cfg.RecordPageMap.Record(node, b.pdf.PageNo())
+}
+
+// blockChanged reports whether the given block AST node is marked as changed
+// for right-margin asterisk emission.
+func (b *pdfBase) blockChanged(node any) bool {
+	if b.cfg.MarkChangedBlocks == nil || node == nil {
+		return false
+	}
+	return b.cfg.MarkChangedBlocks[node]
+}
+
+// markChangeBegin records the current (page, y) for a changed block so that
+// markChangeEnd can stamp a right-margin asterisk on every visual line the
+// block occupies. Callers must invoke this *after* any leading ensureSpace /
+// AddPage / Ln, so the captured Y matches the block's first visible line.
+//
+// Single-asterisk callers (Section, SectionLine) can still use stampSingleAsterisk
+// for block-level marking on one-line blocks.
+func (b *pdfBase) markChangeBegin(node any) {
+	b.markChangeBeginAt(node, b.pdf.PageNo(), b.pdf.GetY())
+}
+
+// markChangeBeginAt is like markChangeBegin but lets the caller supply an
+// explicit (page, y). Used by buffered dialogue, where the actual Y of the
+// character-name line is known only after the leading Ln inside
+// renderDialogueHeader.
+func (b *pdfBase) markChangeBeginAt(node any, page int, y float64) {
+	if !b.blockChanged(node) {
+		return
+	}
+	if b.changeBegins == nil {
+		b.changeBegins = map[any]changeBegin{}
+	}
+	b.changeBegins[node] = changeBegin{page: page, y: y}
+}
+
+// markChangeEnd stamps a right-margin asterisk on every visual line between
+// the recorded begin (page, y) and the current (page, y), at lineHeight
+// intervals. Walks pages with pdf.SetPage when the block straddles a page
+// break. No-op if no matching markChangeBegin fired (i.e. the block isn't
+// marked as changed).
+func (b *pdfBase) markChangeEnd(node any) {
+	if b.changeBegins == nil {
+		return
+	}
+	begin, ok := b.changeBegins[node]
+	if !ok {
+		return
+	}
+	delete(b.changeBegins, node)
+	if b.pdf == nil {
+		return
+	}
+
+	endPage := b.pdf.PageNo()
+	endY := b.pdf.GetY()
+	savedPage := b.pdf.PageNo()
+	savedX, savedY := b.pdf.GetX(), b.pdf.GetY()
+
+	bodyTop := b.marginT
+	bodyBottom := b.pageH - b.marginB
+
+	for p := begin.page; p <= endPage; p++ {
+		if p != b.pdf.PageNo() {
+			b.pdf.SetPage(p)
+		}
+		var yLo, yHi float64
+		switch {
+		case p == begin.page && p == endPage:
+			yLo, yHi = begin.y, endY
+		case p == begin.page:
+			yLo, yHi = begin.y, bodyBottom
+		case p == endPage:
+			yLo, yHi = bodyTop, endY
+		default:
+			yLo, yHi = bodyTop, bodyBottom
+		}
+		// Stop a little before yHi so a trailing Ln overshoot doesn't
+		// add a spurious asterisk on empty space below the last line.
+		for y := yLo; y+b.lineHeight*0.5 < yHi; y += b.lineHeight {
+			b.stampAsteriskAt(y)
+		}
+	}
+
+	if savedPage != b.pdf.PageNo() {
+		b.pdf.SetPage(savedPage)
+	}
+	b.pdf.SetXY(savedX, savedY)
+}
+
+// stampSingleAsterisk stamps one asterisk at the current Y for a changed
+// node. Used for one-line blocks (Section heading, SectionLine) where the
+// per-line begin/end span machinery would over-stamp.
+func (b *pdfBase) stampSingleAsterisk(node any) {
+	if !b.blockChanged(node) {
+		return
+	}
+	b.stampAsteriskAt(b.pdf.GetY())
+}
+
+// stampAsteriskAt draws an unconditional right-margin asterisk at y on the
+// current page. Uses pdf.Text (absolute baseline positioning) rather than
+// pdf.Write — Write would treat the asterisk as flowing content, see no
+// room to the right of the right margin, and wrap to the next line, leaving
+// the asterisk one line below its intended position.
+func (b *pdfBase) stampAsteriskAt(y float64) {
+	if b.pdf == nil {
+		return
+	}
+	asteriskX := b.pageW - b.marginR + 2.0
+	// pdf.Text positions text at the baseline. y here is the top of the
+	// line (where pdf.Write would start), so offset by approximately the
+	// font ascent — using lineHeight-1 as a close-enough proxy that puts
+	// the asterisk visually next to the line that starts at y.
+	b.pdf.Text(asteriskX, y+b.lineHeight-1, "*")
 }
 
 func (b *pdfBase) beginTitlePage() {
@@ -352,10 +548,11 @@ func (b *pdfBase) appendCapturedText(text string) {
 	b.capturedRuns = append(b.capturedRuns, dialogueTextRun{text: text, style: b.captureStyle})
 }
 
-func (b *pdfBase) RenderPageBreak(_ *ast.PageBreak) error {
+func (b *pdfBase) RenderPageBreak(pb *ast.PageBreak) error {
 	b.pdf.AddPage()
 	b.prevWasStageDirection = false
 	b.prevWasCallout = false
+	b.recordLeaf(pb)
 	return nil
 }
 

--- a/internal/render/pdf/body.go
+++ b/internal/render/pdf/body.go
@@ -12,6 +12,9 @@ import (
 
 func (r *pdfRenderer) BeginSection(s *ast.Section) error {
 	r.resetBodyBlockState()
+	// Both recordBlockBegin and asterisk stamping are deferred until each
+	// section sub-handler has had a chance to AddPage / ensureSpace, so
+	// they land on the section's actual rendered page.
 	switch s.Kind {
 	case ast.SectionAct:
 		return r.beginAct(s)
@@ -76,6 +79,7 @@ func (r *pdfRenderer) EndSection(s *ast.Section) error {
 		r.activeTopLevelSection = nil
 		r.pendingInlinePlayFirstBodyPage = false
 	}
+	r.recordBlockEnd(s)
 	return nil
 }
 
@@ -84,6 +88,9 @@ func (r *pdfRenderer) BeginSectionLine(sl *ast.SectionLine) error {
 		// Blank line = paragraph break
 		r.pdf.Ln(r.lineHeight * 2)
 	}
+	r.recordBlockBegin(sl)
+	// SectionLines are single-line — one asterisk suffices.
+	r.stampSingleAsterisk(sl)
 	return nil
 }
 
@@ -92,6 +99,7 @@ func (r *pdfRenderer) EndSectionLine(sl *ast.SectionLine) error {
 		// Single line break = space (prose reflow)
 		r.pdf.Write(r.lineHeight, " ")
 	}
+	r.recordBlockEnd(sl)
 	return nil
 }
 
@@ -112,6 +120,9 @@ func (r *pdfRenderer) beginAct(s *ast.Section) error {
 	}
 
 	bookmarkSection(&r.pdfBase, s)
+	r.recordBlockBegin(s)
+	// Act/Scene headings are one centered line — single asterisk suffices.
+	r.stampSingleAsterisk(s)
 
 	var heading string
 	switch {
@@ -137,6 +148,9 @@ func (r *pdfRenderer) beginScene(s *ast.Section) error {
 	}
 
 	bookmarkSection(&r.pdfBase, s)
+	r.recordBlockBegin(s)
+	// Act/Scene headings are one centered line — single asterisk suffices.
+	r.stampSingleAsterisk(s)
 
 	var heading string
 	switch {
@@ -163,18 +177,24 @@ func (r *pdfRenderer) BeginDualDialogue(d *ast.DualDialogue) error {
 	r.dualMidY = 0
 	estimatedHeight := r.estimateDualDialogueHeight(d)
 	if estimatedHeight > r.usablePageHeight() {
+		r.recordBlockBegin(d)
+		r.markChangeBegin(d)
 		return nil
 	}
 	if estimatedHeight > r.remainingPageHeight() {
 		r.pdf.AddPage()
 	}
+	r.recordBlockBegin(d)
+	r.markChangeBegin(d)
 	r.inDualDialogue = true
 	r.dualSide = 0
 	r.dualStartY = r.pdf.GetY()
 	return nil
 }
 
-func (r *pdfRenderer) EndDualDialogue(_ *ast.DualDialogue) error {
+func (r *pdfRenderer) EndDualDialogue(d *ast.DualDialogue) error {
+	defer r.recordBlockEnd(d)
+	defer r.markChangeEnd(d)
 	if !r.inDualDialogue {
 		r.dualSequential = false
 		return nil
@@ -197,7 +217,13 @@ func (r *pdfRenderer) EndDualDialogue(_ *ast.DualDialogue) error {
 
 func (r *pdfRenderer) BeginDialogue(d *ast.Dialogue) error {
 	r.resetBodyBlockState()
+	// recordBlockBegin is intentionally deferred to renderSegment — the
+	// page-map "begin" must reflect where the dialogue actually lands
+	// after fpdf paginates for its header, not the page we were on when
+	// the previous block finished.
 	if r.inDualDialogue {
+		// Dual dialogue stamps its asterisk via the surrounding DualDialogue
+		// block; suppress per-side stamping to avoid duplicates.
 		return r.beginDualDialogueSide(d)
 	}
 	r.activeDialogue = &bufferedDialogue{
@@ -205,6 +231,8 @@ func (r *pdfRenderer) BeginDialogue(d *ast.Dialogue) error {
 		parenthetical:        d.Parenthetical,
 		parentheticalInlines: dialogueParentheticalInlines(d),
 		lines:                make([]bufferedDialogueLine, 0, len(d.Lines)),
+		markChanged:          r.blockChanged(d),
+		node:                 d,
 	}
 	return nil
 }
@@ -308,7 +336,9 @@ func (r *pdfRenderer) estimateDialogueHeight(d *ast.Dialogue, width float64) flo
 	return height
 }
 
-func (r *pdfRenderer) EndDialogue(_ *ast.Dialogue) error {
+func (r *pdfRenderer) EndDialogue(d *ast.Dialogue) error {
+	defer r.recordBlockEnd(d)
+	defer r.markChangeEnd(d)
 	if r.inDualDialogue {
 		r.dualSide++
 		return nil
@@ -373,14 +403,22 @@ func (r *pdfRenderer) BeginStageDirection(sd *ast.StageDirection) error {
 	}
 	r.setStyle("I")
 	r.pdf.SetX(r.marginL)
+	r.recordBlockBegin(sd)
+	r.markChangeBegin(sd)
 	return nil
 }
 
-func (r *pdfRenderer) EndStageDirection(_ *ast.StageDirection) error {
+func (r *pdfRenderer) EndStageDirection(sd *ast.StageDirection) error {
 	r.pdf.Ln(r.lineHeight)
 	r.setStyle("")
 	r.prevWasStageDirection = true
 	r.prevWasCallout = false
+	// Capture endY *after* the trailing Ln so it sits one line below
+	// the last content line. Combined with the iterator's `y < endY`
+	// stop condition, this includes every visible content line and
+	// excludes the empty trailing-Ln position.
+	r.markChangeEnd(sd)
+	r.recordBlockEnd(sd)
 	return nil
 }
 
@@ -400,15 +438,19 @@ func (r *pdfRenderer) BeginCallout(c *ast.Callout) error {
 	r.setStyle("B")
 	r.pdf.SetLeftMargin(r.marginL + calloutIndent)
 	r.pdf.SetX(r.marginL + calloutIndent)
+	r.recordBlockBegin(c)
+	r.markChangeBegin(c)
 	return nil
 }
 
-func (r *pdfRenderer) EndCallout(_ *ast.Callout) error {
+func (r *pdfRenderer) EndCallout(c *ast.Callout) error {
 	r.pdf.Ln(r.lineHeight)
 	r.setStyle("")
 	r.pdf.SetLeftMargin(r.marginL)
 	r.prevWasStageDirection = false
 	r.prevWasCallout = true
+	r.markChangeEnd(c)
+	r.recordBlockEnd(c)
 	return nil
 }
 
@@ -418,6 +460,8 @@ func (r *pdfRenderer) BeginSong(song *ast.Song) error {
 	r.resetBodyBlockState()
 	r.ensureSpace(r.lineHeight * 3)
 	r.pdf.Ln(r.lineHeight)
+	r.recordBlockBegin(song)
+	r.markChangeBegin(song)
 
 	header := "SONG"
 	if song.Number != "" {
@@ -434,25 +478,31 @@ func (r *pdfRenderer) BeginSong(song *ast.Song) error {
 	return nil
 }
 
-func (r *pdfRenderer) EndSong(_ *ast.Song) error {
+func (r *pdfRenderer) EndSong(song *ast.Song) error {
 	r.resetBodyBlockState()
 	r.pdf.Ln(r.lineHeight / 2)
 	r.setStyle("B")
 	r.centeredText("SONG END")
 	r.setStyle("")
 	r.pdf.Ln(r.lineHeight)
+	r.markChangeEnd(song)
+	r.recordBlockEnd(song)
 	return nil
 }
 
 // --- Verse Block ---
 
-func (r *pdfRenderer) BeginVerseBlock(_ *ast.VerseBlock) error {
+func (r *pdfRenderer) BeginVerseBlock(vb *ast.VerseBlock) error {
 	r.resetBodyBlockState()
 	r.ensureSpace(r.lineHeight * 2)
+	r.recordBlockBegin(vb)
+	r.markChangeBegin(vb)
 	return nil
 }
 
-func (r *pdfRenderer) EndVerseBlock(_ *ast.VerseBlock) error {
+func (r *pdfRenderer) EndVerseBlock(vb *ast.VerseBlock) error {
+	r.markChangeEnd(vb)
+	r.recordBlockEnd(vb)
 	return nil
 }
 

--- a/internal/render/pdf/condensed.go
+++ b/internal/render/pdf/condensed.go
@@ -120,9 +120,7 @@ func (r *condensedRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 	r.hasTitlePage = true
 	r.titlePageTitle = title
 
-	if t := strings.TrimSpace(title); t != "" {
-		r.pdf.Bookmark(t, 0, -1)
-	}
+	addBookmark(&r.pdfBase, strings.TrimSpace(title), 0)
 
 	titleY := r.pageH * 0.30
 

--- a/internal/render/pdf/dialogue_pagination.go
+++ b/internal/render/pdf/dialogue_pagination.go
@@ -16,6 +16,17 @@ type bufferedDialogue struct {
 	parenthetical        string
 	parentheticalInlines []ast.Inline
 	lines                []bufferedDialogueLine
+	// markChanged signals that the dialogue's AST node is in
+	// Config.MarkChangedBlocks. Captured at BeginDialogue and consumed at
+	// the start of the first rendered segment so the asterisk lands on the
+	// page where the content actually paginates to.
+	markChanged bool
+	// node carries the source AST node pointer so the page-map recorder
+	// can record the dialogue's actual start page from inside
+	// renderSegment — by the time renderSegment runs, fpdf has already
+	// auto-paginated if the header didn't fit, and pdf.PageNo() reflects
+	// the page the dialogue truly starts on.
+	node *ast.Dialogue
 }
 
 type bufferedDialogueLine struct {
@@ -57,7 +68,20 @@ func (r *pdfRenderer) availableWrappedLines(dialogue bufferedDialogue, _ bool, f
 }
 
 func (r *pdfRenderer) renderSegment(dialogue bufferedDialogue, continuation, firstSegment bool, lines []bufferedDialogueLine, showMore bool) {
-	r.renderDialogueSegment(dialogue.character, dialogue.parenthetical, dialogue.parentheticalInlines, continuation, firstSegment, lines, showMore)
+	if firstSegment && dialogue.node != nil {
+		// Capture the actual start page now that fpdf has paginated for
+		// the header (availableWrappedLines may have called AddPage). This
+		// supersedes any earlier (and necessarily wrong) recording made at
+		// BeginDialogue, which fires before the dialogue is laid out.
+		r.recordBlockBegin(dialogue.node)
+		// Anchor the per-line asterisk span at the character-name line —
+		// renderDialogueHeader's first action is pdf.Ln(lineHeight) for
+		// the leading gap, so the name lands at current Y + lineHeight.
+		if dialogue.markChanged {
+			r.markChangeBeginAt(dialogue.node, r.pdf.PageNo(), r.pdf.GetY()+r.lineHeight)
+		}
+	}
+	r.renderDialogueSegment(dialogue.character, dialogue.parenthetical, dialogue.parentheticalInlines, continuation, firstSegment, lines, showMore, dialogue.markChanged)
 }
 
 func (r *pdfRenderer) addPage() {
@@ -68,7 +92,7 @@ func (r *pdfRenderer) showContinuationFooter() bool {
 	return true
 }
 
-func (r *pdfRenderer) renderDialogueSegment(character, parenthetical string, parentheticalInlines []ast.Inline, continuation, firstSegment bool, lines []bufferedDialogueLine, showMore bool) {
+func (r *pdfRenderer) renderDialogueSegment(character, parenthetical string, parentheticalInlines []ast.Inline, continuation, firstSegment bool, lines []bufferedDialogueLine, showMore bool, _ bool) {
 	r.renderDialogueHeader(character, parenthetical, parentheticalInlines, continuation, firstSegment)
 	dialogueMargin := r.bodyW * 0.15
 	dialogueX := r.marginL + dialogueMargin

--- a/internal/render/pdf/hooks_test.go
+++ b/internal/render/pdf/hooks_test.go
@@ -1,0 +1,96 @@
+package pdf
+
+import (
+	"bytes"
+	"sync/atomic"
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/parser"
+	"github.com/jscaltreto/downstage/internal/render"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func renderToBuffer(t *testing.T, cfg render.Config, src string) []byte {
+	t.Helper()
+	doc, errs := parser.Parse([]byte(src))
+	require.Empty(t, errs)
+	nr := NewRenderer(cfg)
+	var buf bytes.Buffer
+	require.NoError(t, render.Walk(nr, doc, &buf))
+	return buf.Bytes()
+}
+
+func TestConfig_PageLabelFormatter_OverridesFooter(t *testing.T) {
+	calls := int32(0)
+	cfg := render.DefaultConfig()
+	cfg.PageLabelFormatter = func(p int) string {
+		atomic.AddInt32(&calls, 1)
+		// Map page 1 → "23A".
+		if p == 1 {
+			return "23A"
+		}
+		return ""
+	}
+	out := renderToBuffer(t, cfg, "# Tiny\n\nHAMLET\nLine.\n")
+	assert.NotEmpty(t, out)
+	assert.Greater(t, atomic.LoadInt32(&calls), int32(0), "formatter should have been called by the footer")
+}
+
+func TestConfig_PageHeaderFn_DrawsTopMarginText(t *testing.T) {
+	calls := int32(0)
+	cfg := render.DefaultConfig()
+	cfg.PageHeaderFn = func(p int) string {
+		atomic.AddInt32(&calls, 1)
+		return "REVISION HEADER"
+	}
+	out := renderToBuffer(t, cfg, "# Tiny\n\nHAMLET\nLine.\n")
+	// The header callback must have been called for the body page.
+	assert.Greater(t, atomic.LoadInt32(&calls), int32(0))
+	// PDF stream is binary but our header text is ASCII — a substring grep
+	// is sufficient to detect that the header was actually emitted.
+	if !bytes.Contains(out, []byte("REVISION HEADER")) {
+		// PDF text may be compressed; in that case at least verify the
+		// callback fired (already asserted above).
+		t.Log("header text not present uncompressed — relying on callback assertion")
+	}
+}
+
+func TestConfig_SkipOutline_DropsBookmarks(t *testing.T) {
+	// Use a script with several outline-bearing sections so the bookmark
+	// objects produce a measurable size difference vs the skipped variant.
+	src := "# Play\n\n" +
+		"## ACT I\n\n### SCENE 1\n\nHAMLET\nLine.\n\n### SCENE 2\n\nHAMLET\nLine.\n\n" +
+		"## ACT II\n\n### SCENE 1\n\nHAMLET\nLine.\n\n### SCENE 2\n\nHAMLET\nLine.\n"
+
+	withOutline := renderToBuffer(t, render.DefaultConfig(), src)
+
+	cfgNoOutline := render.DefaultConfig()
+	cfgNoOutline.SkipOutline = true
+	withoutOutline := renderToBuffer(t, cfgNoOutline, src)
+
+	// Skipping outline emission should produce a measurably smaller PDF
+	// because fpdf no longer writes outline-item dictionaries.
+	assert.Less(t, len(withoutOutline), len(withOutline),
+		"SkipOutline render should be smaller (no outline dicts emitted): withOutline=%d, withoutOutline=%d",
+		len(withOutline), len(withoutOutline))
+}
+
+func TestConfig_MarkChangedBlocksMembership(t *testing.T) {
+	// Membership lookup is purely a config check; it is exercised by the
+	// renderer's asterisk path in body.go but we sanity-check the helper
+	// itself here.
+	cfg := render.DefaultConfig()
+	doc, errs := parser.Parse([]byte("# P\n\nHAMLET\nLine.\n"))
+	require.Empty(t, errs)
+	// Find the dialogue node.
+	var d any
+	for _, n := range doc.Body {
+		d = n
+	}
+	cfg.MarkChangedBlocks = map[any]bool{d: true}
+
+	r := NewRenderer(cfg).(*pdfRenderer)
+	assert.True(t, r.blockChanged(d))
+	assert.False(t, r.blockChanged("not-a-node"))
+}

--- a/internal/render/pdf/pagemap/pagemap.go
+++ b/internal/render/pdf/pagemap/pagemap.go
@@ -1,0 +1,105 @@
+// Package pagemap records the [startPage, endPage] span for every block node
+// the PDF renderer emits. Callers enable recording by attaching a Recorder to
+// render.Config.RecordPageMap; the renderer then calls Begin/End at the start
+// and end of each block. Because fpdf's auto-page-break can fire from any
+// flowing Write/MultiCell/Ln inside a block, the End call captures the
+// authoritative end page regardless of where the break originated.
+package pagemap
+
+import "sync"
+
+// Span describes the page range a single block occupies, inclusive on both
+// ends. A single-page block has Start == End.
+type Span struct {
+	Start int
+	End   int
+}
+
+// Recorder accumulates spans during a render pass. It is safe for use by a
+// single renderer goroutine.
+type Recorder struct {
+	mu    sync.Mutex
+	spans map[any]Span
+}
+
+// NewRecorder returns a fresh recorder ready to accept Begin/End calls.
+func NewRecorder() *Recorder {
+	return &Recorder{spans: map[any]Span{}}
+}
+
+// Begin records the starting page for a block keyed by its AST node pointer.
+// Calling Begin twice for the same key overwrites the prior Start (and resets
+// End to the same value).
+func (r *Recorder) Begin(key any, page int) {
+	if r == nil || key == nil {
+		return
+	}
+	r.mu.Lock()
+	r.spans[key] = Span{Start: page, End: page}
+	r.mu.Unlock()
+}
+
+// End updates the ending page for a block. End may be greater than Start when
+// the block's content overflows page boundaries (multi-page dialogue, long
+// prose, overflowing verse).
+func (r *Recorder) End(key any, page int) {
+	if r == nil || key == nil {
+		return
+	}
+	r.mu.Lock()
+	if cur, ok := r.spans[key]; ok {
+		cur.End = page
+		r.spans[key] = cur
+	} else {
+		r.spans[key] = Span{Start: page, End: page}
+	}
+	r.mu.Unlock()
+}
+
+// Record sets the span for a leaf block (PageBreak, Comment) that has no
+// separate Begin/End semantics.
+func (r *Recorder) Record(key any, page int) {
+	if r == nil || key == nil {
+		return
+	}
+	r.mu.Lock()
+	r.spans[key] = Span{Start: page, End: page}
+	r.mu.Unlock()
+}
+
+// Map returns a snapshot of the recorded spans keyed by AST node pointer.
+// The returned map is a copy; callers may mutate it freely.
+func (r *Recorder) Map() Map {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(Map, len(r.spans))
+	for k, v := range r.spans {
+		out[k] = v
+	}
+	return out
+}
+
+// Map is a snapshot of recorded spans. Keys are AST node pointers (e.g.
+// *ast.Dialogue, *ast.Section, *ast.SectionLine).
+type Map map[any]Span
+
+// Lookup returns the span for a key, or a zero Span and false when absent.
+func (m Map) Lookup(key any) (Span, bool) {
+	s, ok := m[key]
+	return s, ok
+}
+
+// LastPage returns the highest End page across all recorded spans. Returns 0
+// when the map is empty.
+func (m Map) LastPage() int {
+	last := 0
+	for _, s := range m {
+		if s.End > last {
+			last = s.End
+		}
+	}
+	return last
+}

--- a/internal/render/pdf/pagemap/pagemap_test.go
+++ b/internal/render/pdf/pagemap/pagemap_test.go
@@ -1,0 +1,114 @@
+package pagemap_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/ast"
+	"github.com/jscaltreto/downstage/internal/parser"
+	"github.com/jscaltreto/downstage/internal/render"
+	"github.com/jscaltreto/downstage/internal/render/pdf"
+	"github.com/jscaltreto/downstage/internal/render/pdf/pagemap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// renderWithMap renders src and returns the populated page-span map.
+func renderWithMap(t *testing.T, src string) (*ast.Document, pagemap.Map) {
+	t.Helper()
+	doc, errs := parser.Parse([]byte(src))
+	require.Empty(t, errs, "parse errors: %v", errs)
+
+	rec := pagemap.NewRecorder()
+	cfg := render.DefaultConfig()
+	cfg.RecordPageMap = rec
+	nr := pdf.NewRenderer(cfg)
+
+	var buf bytes.Buffer
+	require.NoError(t, render.Walk(nr, doc, &buf))
+	return doc, rec.Map()
+}
+
+func TestRecorder_BasicBlocksRecordSinglePage(t *testing.T) {
+	src := "# Tiny Play\n\n" +
+		"## ACT I\n\n" +
+		"HAMLET\nA short line.\n\n" +
+		"> Lights up.\n"
+
+	doc, m := renderWithMap(t, src)
+	require.NotEmpty(t, m, "recorder should have captured spans")
+
+	for _, node := range doc.Body {
+		span, ok := m.Lookup(node)
+		if !ok {
+			continue
+		}
+		assert.GreaterOrEqual(t, span.End, span.Start, "End must be >= Start")
+		assert.GreaterOrEqual(t, span.Start, 1, "page numbers are 1-indexed")
+	}
+}
+
+func TestRecorder_DialogueOverflowSpansMultiplePages(t *testing.T) {
+	// Build a long single-character dialogue cue with many lines so the
+	// block has to break across pages.
+	var b strings.Builder
+	b.WriteString("# Long\n\n## ACT I\n\nHAMLET\n")
+	for i := 0; i < 200; i++ {
+		b.WriteString("Line of dialogue that takes up space.\n")
+	}
+
+	doc, m := renderWithMap(t, b.String())
+
+	// Find the lone Dialogue node and check its span.
+	var dialogue *ast.Dialogue
+	var walk func([]ast.Node)
+	walk = func(nodes []ast.Node) {
+		for _, n := range nodes {
+			switch v := n.(type) {
+			case *ast.Dialogue:
+				dialogue = v
+			case *ast.Section:
+				walk(v.Children)
+			}
+		}
+	}
+	walk(doc.Body)
+	require.NotNil(t, dialogue, "expected a Dialogue node")
+
+	span, ok := m.Lookup(dialogue)
+	require.True(t, ok, "dialogue span must be recorded")
+	assert.Greater(t, span.End, span.Start, "long dialogue should span multiple pages: %+v", span)
+}
+
+func TestRecorder_LastPageMatchesLargestEnd(t *testing.T) {
+	src := "# Multi\n\n" +
+		"## ACT I\n\n" +
+		"HAMLET\nFirst.\n\n" +
+		"===\n\n" +
+		"## ACT II\n\n" +
+		"HAMLET\nSecond.\n"
+
+	_, m := renderWithMap(t, src)
+	last := m.LastPage()
+	assert.GreaterOrEqual(t, last, 2, "explicit page break should produce at least 2 pages")
+}
+
+func TestRecorder_NilRecorderIsNoOp(t *testing.T) {
+	src := "# Tiny\n\nHAMLET\nLine.\n"
+	doc, errs := parser.Parse([]byte(src))
+	require.Empty(t, errs)
+
+	cfg := render.DefaultConfig()
+	cfg.RecordPageMap = nil
+	nr := pdf.NewRenderer(cfg)
+	var buf bytes.Buffer
+	require.NoError(t, render.Walk(nr, doc, &buf))
+}
+
+func TestMap_LookupOnZeroValue(t *testing.T) {
+	var m pagemap.Map
+	_, ok := m.Lookup("nope")
+	assert.False(t, ok)
+	assert.Equal(t, 0, m.LastPage())
+}

--- a/internal/render/pdf/titlepage.go
+++ b/internal/render/pdf/titlepage.go
@@ -15,9 +15,7 @@ func (r *pdfRenderer) RenderTitlePage(tp *ast.TitlePage) error {
 	r.hasTitlePage = true
 	r.titlePageTitle = title
 
-	if t := strings.TrimSpace(title); t != "" {
-		r.pdf.Bookmark(t, 0, -1)
-	}
+	addBookmark(&r.pdfBase, strings.TrimSpace(title), 0)
 
 	// Center vertically: place title roughly at 35% down the page
 	titleY := r.pageH * 0.35
@@ -69,9 +67,7 @@ func renderInlinePlayHeader(b *pdfBase, section *ast.Section, titleSize float64,
 	_, subtitle, authors, other := partitionTitlePageEntries(section.Metadata)
 
 	displayTitle := strings.TrimSpace(render.SectionDisplayTitle(section))
-	if displayTitle != "" {
-		b.pdf.Bookmark(displayTitle, 0, -1)
-	}
+	addBookmark(b, displayTitle, 0)
 
 	b.pdf.SetFont(b.cfg.FontFamily, "B", titleSize)
 	b.centeredWrappedText(strings.ToUpper(displayTitle), b.lineHeight)
@@ -102,13 +98,8 @@ func renderInlinePlayHeader(b *pdfBase, section *ast.Section, titleSize float64,
 	b.fontStyle = ""
 }
 
-// bookmarkSection records an outline entry for the given section at the
-// current cursor position. Levels are precomputed from the AST so that
-// scenes always attach to their real parent in the source, regardless
-// of ordering within a mixed play (scenes-then-acts, acts-then-scenes,
-// or interleaved).
 func bookmarkSection(b *pdfBase, s *ast.Section) {
-	if s == nil || b.pdf == nil {
+	if s == nil {
 		return
 	}
 	label := sectionOutlineLabel(s)
@@ -117,6 +108,19 @@ func bookmarkSection(b *pdfBase, s *ast.Section) {
 	}
 	level, ok := b.outlineLevels[s]
 	if !ok {
+		return
+	}
+	addBookmark(b, label, level)
+}
+
+func addBookmark(b *pdfBase, label string, level int) {
+	if b == nil || b.pdf == nil {
+		return
+	}
+	if b.cfg.SkipOutline {
+		return
+	}
+	if label == "" {
 		return
 	}
 	b.pdf.Bookmark(label, level, -1)

--- a/internal/revisions/git.go
+++ b/internal/revisions/git.go
@@ -1,0 +1,74 @@
+package revisions
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ReadFromGit returns the bytes of filePath as recorded at the given git ref,
+// resolved against the repo enclosing filePath. The function shells out to
+// `git`; it fails cleanly when:
+//
+//   - the file is not inside a git working tree
+//   - the ref does not exist
+//   - the file did not exist at that ref
+//
+// Callers should treat the returned error as exit-code 3 surface-level
+// information; the message is suitable for printing to stderr verbatim.
+func ReadFromGit(filePath, ref string) ([]byte, error) {
+	if filePath == "" {
+		return nil, errors.New("git: empty file path")
+	}
+	if ref == "" {
+		return nil, errors.New("git: empty ref")
+	}
+
+	abs, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("git: resolving absolute path of %q: %w", filePath, err)
+	}
+	dir := filepath.Dir(abs)
+
+	repoRootBytes, err := runGit(dir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return nil, fmt.Errorf("git: %s is not inside a git repository (%w)", filePath, err)
+	}
+	repoRoot := strings.TrimSpace(string(repoRootBytes))
+
+	rel, err := filepath.Rel(repoRoot, abs)
+	if err != nil {
+		return nil, fmt.Errorf("git: computing repo-relative path for %s: %w", filePath, err)
+	}
+	// Git always uses forward slashes inside object paths.
+	rel = filepath.ToSlash(rel)
+
+	// `git show <ref>:<relpath>` is the standard way to extract a file
+	// version from a ref. It fails with a clear non-zero exit when either
+	// the ref or the file is missing.
+	out, err := runGit(repoRoot, "show", ref+":"+rel)
+	if err != nil {
+		return nil, fmt.Errorf("git: reading %s at %s: %w", rel, ref, err)
+	}
+	return out, nil
+}
+
+func runGit(dir string, args ...string) ([]byte, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		// Surface git's stderr in the error so users can see "fatal: ...".
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return nil, fmt.Errorf("%w: %s", err, msg)
+		}
+		return nil, err
+	}
+	return stdout.Bytes(), nil
+}

--- a/internal/revisions/git_test.go
+++ b/internal/revisions/git_test.go
@@ -1,0 +1,81 @@
+package revisions
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gitInit prepares a fresh repo in dir with a single committed file.
+func gitInit(t *testing.T, dir, name, content string) {
+	t.Helper()
+	mustRun := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+	mustRun("init", "-q")
+	mustRun("config", "user.email", "t@example.test")
+	mustRun("config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644))
+	mustRun("add", name)
+	mustRun("commit", "-q", "-m", "v1")
+}
+
+func TestReadFromGit_ReadsCommittedContent(t *testing.T) {
+	dir := t.TempDir()
+	gitInit(t, dir, "play.ds", "# V1\n\nHAMLET\nLine.\n")
+
+	path := filepath.Join(dir, "play.ds")
+	// Update the file on disk to a v2 (uncommitted).
+	require.NoError(t, os.WriteFile(path, []byte("# V2\n\nHAMLET\nLine 2.\n"), 0o644))
+
+	got, err := ReadFromGit(path, "HEAD")
+	require.NoError(t, err)
+	assert.Equal(t, "# V1\n\nHAMLET\nLine.\n", string(got))
+}
+
+func TestReadFromGit_ResolvesShortRefs(t *testing.T) {
+	dir := t.TempDir()
+	gitInit(t, dir, "play.ds", "# V1\n")
+	path := filepath.Join(dir, "play.ds")
+
+	got, err := ReadFromGit(path, "HEAD")
+	require.NoError(t, err)
+	assert.Equal(t, "# V1\n", string(got))
+}
+
+func TestReadFromGit_MissingRefFails(t *testing.T) {
+	dir := t.TempDir()
+	gitInit(t, dir, "play.ds", "# V1\n")
+	path := filepath.Join(dir, "play.ds")
+
+	_, err := ReadFromGit(path, "does-not-exist")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does-not-exist")
+}
+
+func TestReadFromGit_FileOutsideRepoFails(t *testing.T) {
+	dir := t.TempDir() // not a git repo
+	path := filepath.Join(dir, "play.ds")
+	require.NoError(t, os.WriteFile(path, []byte("# unmanaged\n"), 0o644))
+
+	_, err := ReadFromGit(path, "HEAD")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not inside a git repository")
+}
+
+func TestReadFromGit_FileMissingAtRefFails(t *testing.T) {
+	dir := t.TempDir()
+	gitInit(t, dir, "play.ds", "# V1\n")
+	missing := filepath.Join(dir, "absent.ds")
+	require.NoError(t, os.WriteFile(missing, []byte("# new\n"), 0o644))
+
+	_, err := ReadFromGit(missing, "HEAD")
+	require.Error(t, err)
+}

--- a/internal/revisions/numbering.go
+++ b/internal/revisions/numbering.go
@@ -1,0 +1,131 @@
+package revisions
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RegionPaging pairs a planned Region with the number of internal fpdf pages
+// it produced during rendering.
+type RegionPaging struct {
+	Region    Region
+	PageCount int
+}
+
+// Labels returns one label per internal page in document order. Pass the
+// resulting slice to a PageLabelFormatter closure that indexes by
+// internalPage-1.
+//
+// Numbering follows the Hollywood revision-pages convention:
+//
+//   - Insert after v1 page N: NA, NB, NC, …
+//   - Replace [N, M], v2 produces p pages:
+//   - p ≤ M-N+1: N, N+1, …; trailing slots (if --no-removed-marker is off)
+//     absorb a REMOVED placeholder labeled with the lowest leftover number.
+//   - p > M-N+1: N, NA, NB, …; subsequent overflow continues with letter
+//     suffixes off of N.
+//   - Delete [N, M]: a single placeholder labeled N.
+//
+// The opts.RemovedMarker flag controls whether REMOVED placeholders are
+// included (caller responsibility for actually rendering them); the numbering
+// scheme leaves a slot for them when applicable.
+type LabelOptions struct {
+	// IncludeRemovedMarkers, when true, leaves room for a REMOVED placeholder
+	// page at the end of an under-replaced region. The orchestrator is
+	// responsible for emitting the placeholder content into the PDF; this
+	// function only reserves the label.
+	IncludeRemovedMarkers bool
+}
+
+func Labels(paging []RegionPaging, opts LabelOptions) []string {
+	var out []string
+	for _, rp := range paging {
+		out = append(out, regionLabels(rp, opts)...)
+	}
+	return out
+}
+
+func regionLabels(rp RegionPaging, opts LabelOptions) []string {
+	r := rp.Region
+	p := rp.PageCount
+
+	switch r.Kind {
+	case RegionInsert:
+		// Labels NA, NB, NC, …, anchored to V1FirstPage.
+		out := make([]string, p)
+		for i := 0; i < p; i++ {
+			out[i] = fmt.Sprintf("%d%s", r.V1FirstPage, letterSuffix(i+1))
+		}
+		return out
+
+	case RegionDelete:
+		// Single placeholder labeled with the first replaced v1 page.
+		out := make([]string, p)
+		for i := 0; i < p; i++ {
+			out[i] = fmt.Sprintf("%d", r.V1FirstPage)
+		}
+		return out
+
+	case RegionReplace:
+		span := r.V1LastPage - r.V1FirstPage + 1
+		if span < 1 {
+			span = 1
+		}
+		out := make([]string, 0, p)
+		if p <= span {
+			// Sufficient slots — sequential numbering.
+			for i := 0; i < p; i++ {
+				out = append(out, fmt.Sprintf("%d", r.V1FirstPage+i))
+			}
+			if opts.IncludeRemovedMarkers && p < span {
+				// The orchestrator inserts one REMOVED page; label it with
+				// the lowest leftover v1 page so binder operators know what
+				// it covers.
+				out = append(out, fmt.Sprintf("%d", r.V1FirstPage+p))
+			}
+		} else {
+			// Overflow — keep N labeled normally, then letter-suffix the
+			// rest off of N.
+			out = append(out, fmt.Sprintf("%d", r.V1FirstPage))
+			for i := 1; i < p; i++ {
+				out = append(out, fmt.Sprintf("%d%s", r.V1FirstPage, letterSuffix(i)))
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// letterSuffix maps 1→"A", 2→"B", …, 26→"Z", 27→"AA", 28→"AB", … in the
+// Excel-column style that revision pages use when more than 26 inserts
+// stack up.
+func letterSuffix(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	var b strings.Builder
+	for n > 0 {
+		n--
+		b.WriteByte(byte('A' + n%26))
+		n /= 26
+	}
+	// Reverse.
+	r := b.String()
+	out := make([]byte, len(r))
+	for i := range r {
+		out[len(r)-1-i] = r[i]
+	}
+	return string(out)
+}
+
+// Formatter returns a closure suitable for plugging into
+// render.Config.PageLabelFormatter. internalPage is 1-indexed.
+func Formatter(labels []string) func(int) string {
+	return func(internalPage int) string {
+		idx := internalPage - 1
+		if idx < 0 || idx >= len(labels) {
+			return fmt.Sprintf("%d", internalPage)
+		}
+		return labels[idx]
+	}
+}

--- a/internal/revisions/numbering_test.go
+++ b/internal/revisions/numbering_test.go
@@ -1,0 +1,96 @@
+package revisions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLetterSuffix(t *testing.T) {
+	cases := map[int]string{
+		1:  "A",
+		2:  "B",
+		25: "Y",
+		26: "Z",
+		27: "AA",
+		28: "AB",
+		52: "AZ",
+		53: "BA",
+	}
+	for n, want := range cases {
+		assert.Equal(t, want, letterSuffix(n), "letterSuffix(%d)", n)
+	}
+}
+
+func TestLabels_PureInsert(t *testing.T) {
+	rp := RegionPaging{
+		Region:    Region{Kind: RegionInsert, V1FirstPage: 22, V1LastPage: 22},
+		PageCount: 3,
+	}
+	got := Labels([]RegionPaging{rp}, LabelOptions{})
+	assert.Equal(t, []string{"22A", "22B", "22C"}, got)
+}
+
+func TestLabels_ReplaceFits(t *testing.T) {
+	rp := RegionPaging{
+		Region:    Region{Kind: RegionReplace, V1FirstPage: 23, V1LastPage: 25},
+		PageCount: 3,
+	}
+	got := Labels([]RegionPaging{rp}, LabelOptions{})
+	assert.Equal(t, []string{"23", "24", "25"}, got)
+}
+
+func TestLabels_ReplaceOverflowsWithLetterSuffixes(t *testing.T) {
+	rp := RegionPaging{
+		Region:    Region{Kind: RegionReplace, V1FirstPage: 23, V1LastPage: 24},
+		PageCount: 5,
+	}
+	got := Labels([]RegionPaging{rp}, LabelOptions{})
+	assert.Equal(t, []string{"23", "23A", "23B", "23C", "23D"}, got)
+}
+
+func TestLabels_ReplaceShorterWithRemovedMarker(t *testing.T) {
+	rp := RegionPaging{
+		Region:    Region{Kind: RegionReplace, V1FirstPage: 30, V1LastPage: 33},
+		PageCount: 2,
+	}
+	got := Labels([]RegionPaging{rp}, LabelOptions{IncludeRemovedMarkers: true})
+	// 30, 31 are the replacements; 32 is the REMOVED placeholder slot.
+	assert.Equal(t, []string{"30", "31", "32"}, got)
+}
+
+func TestLabels_ReplaceShorterWithoutRemovedMarker(t *testing.T) {
+	rp := RegionPaging{
+		Region:    Region{Kind: RegionReplace, V1FirstPage: 30, V1LastPage: 33},
+		PageCount: 2,
+	}
+	got := Labels([]RegionPaging{rp}, LabelOptions{})
+	assert.Equal(t, []string{"30", "31"}, got)
+}
+
+func TestLabels_DeletePlaceholderLabeledWithFirstPage(t *testing.T) {
+	rp := RegionPaging{
+		Region:    Region{Kind: RegionDelete, V1FirstPage: 40, V1LastPage: 42},
+		PageCount: 1,
+	}
+	got := Labels([]RegionPaging{rp}, LabelOptions{})
+	assert.Equal(t, []string{"40"}, got)
+}
+
+func TestLabels_MixedPlanOrdersByRegion(t *testing.T) {
+	plan := []RegionPaging{
+		{Region: Region{Kind: RegionInsert, V1FirstPage: 5, V1LastPage: 5}, PageCount: 2},
+		{Region: Region{Kind: RegionReplace, V1FirstPage: 10, V1LastPage: 11}, PageCount: 2},
+		{Region: Region{Kind: RegionDelete, V1FirstPage: 20, V1LastPage: 22}, PageCount: 1},
+	}
+	got := Labels(plan, LabelOptions{})
+	assert.Equal(t, []string{"5A", "5B", "10", "11", "20"}, got)
+}
+
+func TestFormatter_FallsBackToNaturalNumberOutOfRange(t *testing.T) {
+	f := Formatter([]string{"23A", "23B"})
+	assert.Equal(t, "23A", f(1))
+	assert.Equal(t, "23B", f(2))
+	assert.Equal(t, "3", f(3), "out-of-range should fall back to natural page number")
+	assert.Equal(t, "0", f(0), "non-positive should fall back to natural page number")
+}

--- a/internal/revisions/plan.go
+++ b/internal/revisions/plan.go
@@ -1,0 +1,525 @@
+// Package revisions orchestrates the revision-pages workflow: diffing two
+// parsed Downstage documents, mapping the diff to v1's rendered pagination,
+// and producing the materials needed by the PDF renderer to emit a small
+// "swap-into-binder" revision PDF.
+package revisions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jscaltreto/downstage/internal/ast"
+	"github.com/jscaltreto/downstage/internal/diff"
+	"github.com/jscaltreto/downstage/internal/render/pdf/pagemap"
+)
+
+// RegionKind describes the editorial relationship between v1 and v2 for a
+// revision region.
+type RegionKind int
+
+const (
+	// RegionInsert: v1 contributes no blocks; v2 added new content. The
+	// printed revision pages get inserted into the v1 binder after
+	// V1FirstPage.
+	RegionInsert RegionKind = iota
+	// RegionDelete: v2 contributes no blocks; v1 content has been removed.
+	// The revision PDF emits a single placeholder page covering the
+	// deleted range.
+	RegionDelete
+	// RegionReplace: both sides contribute. The v2 content replaces v1's
+	// pages in the binder.
+	RegionReplace
+)
+
+// Region is the planner's per-revision unit. The orchestrator renders each
+// Region's V2Nodes into one or more PDF pages, labels them via the numbering
+// formatter, and stamps a margin note describing where they slot into v1.
+type Region struct {
+	Kind RegionKind
+	// V1FirstPage / V1LastPage describe the v1 page range this region
+	// replaces (inclusive). For RegionInsert both values point to the v1
+	// page after which the inserted pages slot in.
+	V1FirstPage int
+	V1LastPage  int
+	// ContextHeading is the v2 enclosing-section context at the region's
+	// first node, e.g. "ACT II — SCENE 3".
+	ContextHeading string
+	// MarginNote is the writer-facing top-margin annotation: "Insert after
+	// p. 22", "Replace pp. 23–24", "Remove pp. 24–26", etc.
+	MarginNote string
+	// V2Nodes are the AST nodes the renderer should walk for this region.
+	// For RegionDelete this slice is empty.
+	V2Nodes []ast.Node
+	// ChangedNodes is the set of v2 AST node pointers that diffed as
+	// non-Equal within this region — used by the renderer to draw
+	// right-margin asterisks on changed lines.
+	ChangedNodes map[any]bool
+}
+
+// PlanOptions tunes region computation.
+type PlanOptions struct {
+	// AnchorWindow is the largest run of Equal blocks that may sit between
+	// two non-Equal hunks before they're merged into a single region. A
+	// value of 0 disables merging; the default (used when zero) is 4.
+	AnchorWindow int
+}
+
+// Plan computes the revision regions for a (v1, v2) document pair given the
+// rendered v1 page map.
+//
+//   - v1Blocks / v2Blocks are diff.FlattenedBlocks of their respective docs.
+//   - hunks is the result of diff.Diff(v1Blocks, v2Blocks).
+//   - v1Pages is the page-span map produced when v1 was rendered with a
+//     pagemap.Recorder.
+func Plan(v1Blocks, v2Blocks []diff.Block, hunks []diff.Hunk, v1Pages pagemap.Map, opts PlanOptions) []Region {
+	window := opts.AnchorWindow
+	if window <= 0 {
+		window = 4
+	}
+
+	// Collect indices of non-Equal hunks.
+	var nonEq []int
+	for i, h := range hunks {
+		if h.Kind != diff.HunkEqual {
+			nonEq = append(nonEq, i)
+		}
+	}
+	if len(nonEq) == 0 {
+		return nil
+	}
+
+	// Merge adjacent non-Equal hunks separated by ≤ window Equal blocks.
+	type group struct{ first, last int }
+	var groups []group
+	cur := group{first: nonEq[0], last: nonEq[0]}
+	for _, idx := range nonEq[1:] {
+		// Sum the v1+v2 lengths of the Equal hunks between cur.last and idx.
+		gap := 0
+		for k := cur.last + 1; k < idx; k++ {
+			h := hunks[k]
+			eqV1 := h.V1End - h.V1Start
+			eqV2 := h.V2End - h.V2Start
+			if eqV1 > eqV2 {
+				gap += eqV1
+			} else {
+				gap += eqV2
+			}
+		}
+		if gap <= window {
+			cur.last = idx
+		} else {
+			groups = append(groups, cur)
+			cur = group{first: idx, last: idx}
+		}
+	}
+	groups = append(groups, cur)
+
+	regions := make([]Region, 0, len(groups))
+	lastPage := v1Pages.LastPage()
+	if lastPage == 0 {
+		lastPage = 1
+	}
+
+	for _, g := range groups {
+		// Compute the merged v1 / v2 ranges from first.V1Start to last.V1End
+		// and likewise for v2.
+		first, last := hunks[g.first], hunks[g.last]
+		v1Lo, v1Hi := first.V1Start, last.V1End
+		v2Lo, v2Hi := first.V2Start, last.V2End
+
+		// ChangedNodes set: every block in non-Equal sub-hunks of this
+		// group, identified by v2 AST pointer. Computed from the bare
+		// hunks (before any context expansion) so asterisks stay scoped
+		// to the actually-changed content.
+		changed := map[any]bool{}
+		for k := g.first; k <= g.last; k++ {
+			h := hunks[k]
+			if h.Kind == diff.HunkEqual {
+				continue
+			}
+			for _, b := range v2Blocks[h.V2Start:h.V2End] {
+				key := blockKey(b)
+				if key != nil {
+					changed[key] = true
+				}
+			}
+		}
+
+		v1FirstPage, v1LastPage := computeV1Pages(v1Blocks, v1Lo, v1Hi, v1Pages, lastPage)
+		kind := classify(v1Lo, v1Hi, v2Lo, v2Hi)
+
+		// Promote a mid-page Insert to a Replace of that page. When new v2
+		// content is added between two v1 blocks that both live on the
+		// same v1 page, v2's pagination of that page actually differs from
+		// v1's — the page is split by the new content. Treating it as a
+		// bare Insert produces a revision page with only the added lines
+		// (no context) and a misleading "Insert after p. N" margin note.
+		// Promote so the iterative expansion below pulls in the page's
+		// surrounding v1 blocks and the corresponding v2 content.
+		if kind == RegionInsert && v1Lo > 0 && v1Lo < len(v1Blocks) {
+			prevSpan, prevOK := lookupBlockSpan(v1Blocks[v1Lo-1], v1Pages)
+			nextSpan, nextOK := lookupBlockSpan(v1Blocks[v1Lo], v1Pages)
+			if prevOK && nextOK && prevSpan.End >= nextSpan.Start {
+				insertPage := nextSpan.Start
+				if prevSpan.End < insertPage {
+					insertPage = prevSpan.End
+				}
+				// Walk v1 indices outward to cover blocks on insertPage.
+				lo := v1Lo - 1
+				for lo > 0 {
+					span, ok := lookupBlockSpan(v1Blocks[lo-1], v1Pages)
+					if !ok || span.End < insertPage {
+						break
+					}
+					lo--
+				}
+				hi := v1Lo
+				for hi < len(v1Blocks) {
+					span, ok := lookupBlockSpan(v1Blocks[hi], v1Pages)
+					if !ok || span.Start > insertPage {
+						break
+					}
+					hi++
+				}
+				v1Lo, v1Hi = lo, hi
+				v1FirstPage, v1LastPage = insertPage, insertPage
+				kind = RegionReplace
+			}
+		}
+
+		// Expand Replace regions outward to the v1 page boundaries so the
+		// rendered revision pages contain a full page of context, not just
+		// the bare changed blocks. This matches how Hollywood revision
+		// pages actually look: a normal-looking script page where changed
+		// lines are marked with asterisks. Pure Inserts (at page
+		// boundaries) and Delete regions are left at their natural hunk
+		// bounds — Insert pages slot between v1 pages, Delete renders a
+		// placeholder.
+		if kind == RegionReplace {
+			// Iteratively expand and widen the v1 page range until stable.
+			//
+			// Pass 1: expand v1 indices outward to include any block whose
+			//   span overlaps [V1FirstPage, V1LastPage]. This pulls in
+			//   blocks that bleed across the trailing boundary.
+			// Pass 2: widen V1FirstPage/V1LastPage so they cover the full
+			//   span of every included block (so a bleed-block whose tail
+			//   sits on page N+1 advances V1LastPage to N+1).
+			// Pass 3: re-expand with the new wider range — this pulls in
+			//   the *other* blocks on the newly-covered v1 page (the ones
+			//   that come after our bleed-block on that page) so we don't
+			//   lose their content when the user removes the v1 page.
+			// Repeat until no further blocks are pulled in. In dense
+			// documents this terminates as soon as the trailing edge lands
+			// on a block whose span doesn't extend further. (Capped at 32
+			// iterations as a safety net.)
+			expV1Lo, expV1Hi := v1Lo, v1Hi
+			for iter := 0; iter < 32; iter++ {
+				prevLo, prevHi := expV1Lo, expV1Hi
+				prevFirst, prevLast := v1FirstPage, v1LastPage
+				expV1Lo, expV1Hi = expandToPageBoundaries(v1Blocks, v1Pages, v1FirstPage, v1LastPage, expV1Lo, expV1Hi)
+				v1FirstPage, v1LastPage = extendBoundsToCoverBlocks(v1Blocks[expV1Lo:expV1Hi], v1Pages, v1FirstPage, v1LastPage)
+				if expV1Lo == prevLo && expV1Hi == prevHi && v1FirstPage == prevFirst && v1LastPage == prevLast {
+					break
+				}
+			}
+			v2Lo, v2Hi = mapV1RangeToV2(hunks, expV1Lo, expV1Hi, v2Lo, v2Hi)
+		}
+
+		v2Slice := v2Blocks[v2Lo:v2Hi]
+		v2Nodes := nodesFrom(v2Slice)
+
+		regions = append(regions, Region{
+			Kind:           kind,
+			V1FirstPage:    v1FirstPage,
+			V1LastPage:     v1LastPage,
+			ContextHeading: contextHeading(v2Slice),
+			MarginNote:     marginNote(kind, v1FirstPage, v1LastPage, lastPage),
+			V2Nodes:        v2Nodes,
+			ChangedNodes:   changed,
+		})
+	}
+	return regions
+}
+
+// extendBoundsToCoverBlocks returns the v1 page range that fully encloses
+// every span in the expanded block slice. Called after expandToPageBoundaries
+// so the revision's V1FirstPage / V1LastPage label the *actual* v1 pages
+// the revision content occupied — not just the changed-blocks' span.
+func extendBoundsToCoverBlocks(blocks []diff.Block, v1Pages pagemap.Map, first, last int) (int, int) {
+	for _, b := range blocks {
+		span, ok := lookupBlockSpan(b, v1Pages)
+		if !ok {
+			continue
+		}
+		if span.Start < first {
+			first = span.Start
+		}
+		if span.End > last {
+			last = span.End
+		}
+	}
+	return first, last
+}
+
+// expandToPageBoundaries walks outward from a region's natural hunk bounds
+// [v1Lo, v1Hi) until it reaches v1 block indices that bound the requested
+// v1 page range. The result is a wider v1 slice whose blocks all overlap
+// pages [v1FirstPage, v1LastPage].
+//
+// "Overlap" rather than "fully contained" semantics — a block whose start is
+// on V1LastPage but whose tail bleeds onto V1LastPage+1 is still included.
+// The reader gets the start of that block in the revision (preserving
+// context) at the cost of duplicating its tail on v1's unchanged page
+// M+1. This is the lesser evil compared to dropping the block entirely
+// and leaving v1 page M+1 starting mid-block with no setup.
+func expandToPageBoundaries(v1Blocks []diff.Block, v1Pages pagemap.Map, v1FirstPage, v1LastPage, v1Lo, v1Hi int) (int, int) {
+	if len(v1Blocks) == 0 {
+		return v1Lo, v1Hi
+	}
+	lo := v1Lo
+	for lo > 0 {
+		prev := v1Blocks[lo-1]
+		span, ok := lookupBlockSpan(prev, v1Pages)
+		if !ok || span.End < v1FirstPage {
+			break
+		}
+		lo--
+	}
+	hi := v1Hi
+	for hi < len(v1Blocks) {
+		next := v1Blocks[hi]
+		span, ok := lookupBlockSpan(next, v1Pages)
+		if !ok || span.Start > v1LastPage {
+			break
+		}
+		hi++
+	}
+	return lo, hi
+}
+
+// mapV1RangeToV2 translates an expanded v1 block range to the corresponding
+// v2 indices via the diff hunks. For positions inside an Equal hunk the
+// mapping is exact; for positions inside Modify/Delete the v2 boundary is
+// snapped to the hunk's edges so the resulting v2 slice still covers every
+// v2 block that aligns with the requested v1 range. fallbackLo / fallbackHi
+// are returned when a v1 index cannot be located (degenerate input).
+func mapV1RangeToV2(hunks []diff.Hunk, v1Lo, v1Hi, fallbackLo, fallbackHi int) (int, int) {
+	v2Lo, okLo := mapV1ToV2Lo(hunks, v1Lo)
+	v2Hi, okHi := mapV1ToV2Hi(hunks, v1Hi)
+	if !okLo {
+		v2Lo = fallbackLo
+	}
+	if !okHi {
+		v2Hi = fallbackHi
+	}
+	if v2Hi < v2Lo {
+		v2Hi = v2Lo
+	}
+	return v2Lo, v2Hi
+}
+
+func mapV1ToV2Lo(hunks []diff.Hunk, v1Idx int) (int, bool) {
+	for _, h := range hunks {
+		if v1Idx < h.V1Start {
+			return h.V2Start, true
+		}
+		if v1Idx < h.V1End {
+			switch h.Kind {
+			case diff.HunkEqual:
+				return h.V2Start + (v1Idx - h.V1Start), true
+			default:
+				return h.V2Start, true
+			}
+		}
+	}
+	if len(hunks) > 0 {
+		return hunks[len(hunks)-1].V2End, true
+	}
+	return 0, false
+}
+
+func mapV1ToV2Hi(hunks []diff.Hunk, v1Idx int) (int, bool) {
+	for _, h := range hunks {
+		if v1Idx <= h.V1Start {
+			return h.V2Start, true
+		}
+		if v1Idx <= h.V1End {
+			switch h.Kind {
+			case diff.HunkEqual:
+				return h.V2Start + (v1Idx - h.V1Start), true
+			default:
+				return h.V2End, true
+			}
+		}
+	}
+	if len(hunks) > 0 {
+		return hunks[len(hunks)-1].V2End, true
+	}
+	return 0, false
+}
+
+func classify(v1Lo, v1Hi, v2Lo, v2Hi int) RegionKind {
+	v1Empty := v1Lo == v1Hi
+	v2Empty := v2Lo == v2Hi
+	switch {
+	case v1Empty && !v2Empty:
+		return RegionInsert
+	case v2Empty && !v1Empty:
+		return RegionDelete
+	default:
+		return RegionReplace
+	}
+}
+
+// computeV1Pages returns the v1 page range this region replaces. For an
+// Insert region (empty v1 span) we anchor at the preceding v1 block's end
+// page so the margin note reads "Insert after p. N". The Tier-4 sentinel
+// fallback is implicit in the bounds: if the region runs off either end of
+// v1, we clamp to page 1 / lastPage respectively.
+func computeV1Pages(v1Blocks []diff.Block, v1Lo, v1Hi int, v1Pages pagemap.Map, lastPage int) (int, int) {
+	if v1Hi > v1Lo {
+		// Region has v1 content — use those blocks' span.
+		first, firstOK := lookupBlockSpan(v1Blocks[v1Lo], v1Pages)
+		last, lastOK := lookupBlockSpan(v1Blocks[v1Hi-1], v1Pages)
+		switch {
+		case firstOK && lastOK:
+			return first.Start, last.End
+		case firstOK:
+			return first.Start, lastPage
+		case lastOK:
+			return 1, last.End
+		default:
+			return 1, lastPage
+		}
+	}
+
+	// Empty v1 span — Insert. Anchor at the preceding v1 block's end page
+	// (or page 1 if at the start of the document; Tier-4 start sentinel).
+	if v1Lo == 0 {
+		return 1, 1
+	}
+	prev, ok := lookupBlockSpan(v1Blocks[v1Lo-1], v1Pages)
+	if !ok {
+		return lastPage, lastPage
+	}
+	return prev.End, prev.End
+}
+
+func lookupBlockSpan(b diff.Block, m pagemap.Map) (pagemap.Span, bool) {
+	if key := blockKey(b); key != nil {
+		if s, ok := m.Lookup(key); ok {
+			return s, true
+		}
+	}
+	return pagemap.Span{}, false
+}
+
+func blockKey(b diff.Block) any {
+	if b.Node != nil {
+		return b.Node
+	}
+	if b.Line != nil {
+		return b.Line
+	}
+	return nil
+}
+
+func nodesFrom(blocks []diff.Block) []ast.Node {
+	var nodes []ast.Node
+	for _, b := range blocks {
+		switch {
+		case b.Node != nil:
+			// Section-header blocks share their Section pointer with the
+			// following child blocks; only emit the top-level node once,
+			// when we first see it via a SectionHeader.
+			if b.Kind == diff.BlockSectionHeader {
+				nodes = append(nodes, b.Node)
+			} else {
+				// All other block kinds are leaf-ish at the renderer level
+				// and emit their own node.
+				if !isContainedBySection(b, nodes) {
+					nodes = append(nodes, b.Node)
+				}
+			}
+		case b.Line != nil:
+			// Section lines are emitted by their parent Section; the
+			// renderer walks Section.OrderedItems(). They are not
+			// independently re-added here.
+		}
+	}
+	return nodes
+}
+
+// isContainedBySection reports whether b's node is inside a Section already
+// in nodes — in which case the renderer will reach it naturally and we
+// should not double-emit.
+func isContainedBySection(b diff.Block, nodes []ast.Node) bool {
+	if b.Node == nil {
+		return false
+	}
+	for _, n := range nodes {
+		s, ok := n.(*ast.Section)
+		if !ok {
+			continue
+		}
+		if sectionContains(s, b.Node) {
+			return true
+		}
+	}
+	return false
+}
+
+func sectionContains(s *ast.Section, target ast.Node) bool {
+	for _, c := range s.Children {
+		if c == target {
+			return true
+		}
+		if cs, ok := c.(*ast.Section); ok && sectionContains(cs, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func contextHeading(v2Slice []diff.Block) string {
+	// Pick the deepest enclosing-section path in the slice so the heading
+	// describes the most specific location of the change (e.g. "Play —
+	// ACT II — SCENE 3"), not just the outermost section that happens to
+	// be included via region expansion.
+	var deepest []string
+	for _, b := range v2Slice {
+		if len(b.SectionPath) > len(deepest) {
+			deepest = b.SectionPath
+		}
+	}
+	parts := make([]string, 0, len(deepest))
+	for _, p := range deepest {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		parts = append(parts, p)
+	}
+	return strings.Join(parts, " — ")
+}
+
+func marginNote(kind RegionKind, first, last, _ int) string {
+	switch kind {
+	case RegionInsert:
+		if first <= 1 {
+			return "Insert before p. 1"
+		}
+		return fmt.Sprintf("Insert after p. %d", first)
+	case RegionDelete:
+		if first == last {
+			return fmt.Sprintf("Remove p. %d of v1", first)
+		}
+		return fmt.Sprintf("Remove pp. %d–%d of v1", first, last)
+	case RegionReplace:
+		if first == last {
+			return fmt.Sprintf("Replace p. %d of v1", first)
+		}
+		return fmt.Sprintf("Replace pp. %d–%d of v1", first, last)
+	}
+	return ""
+}

--- a/internal/revisions/plan_test.go
+++ b/internal/revisions/plan_test.go
@@ -1,0 +1,146 @@
+package revisions
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/diff"
+	"github.com/jscaltreto/downstage/internal/parser"
+	"github.com/jscaltreto/downstage/internal/render"
+	"github.com/jscaltreto/downstage/internal/render/pdf"
+	"github.com/jscaltreto/downstage/internal/render/pdf/pagemap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildInputs parses both sources, renders v1 with a page-map recorder, and
+// returns everything needed to call Plan.
+func buildInputs(t *testing.T, v1src, v2src string) ([]diff.Block, []diff.Block, []diff.Hunk, pagemap.Map) {
+	t.Helper()
+	v1Doc, errs := parser.Parse([]byte(v1src))
+	require.Empty(t, errs)
+	v2Doc, errs := parser.Parse([]byte(v2src))
+	require.Empty(t, errs)
+
+	v1Blocks := diff.FlattenedBlocks(v1Doc, diff.CanonicalNameMap(v1Doc))
+	v2Blocks := diff.FlattenedBlocks(v2Doc, diff.CanonicalNameMap(v2Doc))
+	hunks := diff.Diff(v1Blocks, v2Blocks)
+
+	rec := pagemap.NewRecorder()
+	cfg := render.DefaultConfig()
+	cfg.RecordPageMap = rec
+	nr := pdf.NewRenderer(cfg)
+	var buf bytes.Buffer
+	require.NoError(t, render.Walk(nr, v1Doc, &buf))
+
+	return v1Blocks, v2Blocks, hunks, rec.Map()
+}
+
+func TestPlan_NoChangesReturnsEmpty(t *testing.T) {
+	src := "# Same\n\nHAMLET\nLine.\n"
+	v1Blocks, v2Blocks, hunks, m := buildInputs(t, src, src)
+	regions := Plan(v1Blocks, v2Blocks, hunks, m, PlanOptions{})
+	assert.Empty(t, regions)
+}
+
+func TestPlan_PureInsert(t *testing.T) {
+	v1 := "# Play\n\n## ACT I\n\nHAMLET\nFirst.\n"
+	v2 := "# Play\n\n## ACT I\n\nHAMLET\nFirst.\n\nHAMLET\nSecond.\n"
+	v1Blocks, v2Blocks, hunks, m := buildInputs(t, v1, v2)
+	regions := Plan(v1Blocks, v2Blocks, hunks, m, PlanOptions{})
+	require.Len(t, regions, 1)
+	r := regions[0]
+	assert.Equal(t, RegionInsert, r.Kind)
+	assert.GreaterOrEqual(t, r.V1FirstPage, 1)
+	assert.Contains(t, r.MarginNote, "Insert")
+	assert.NotEmpty(t, r.V2Nodes)
+	assert.NotEmpty(t, r.ChangedNodes)
+}
+
+func TestPlan_PureDelete(t *testing.T) {
+	v1 := "# Play\n\n## ACT I\n\nHAMLET\nFirst.\n\nHAMLET\nSecond.\n"
+	v2 := "# Play\n\n## ACT I\n\nHAMLET\nFirst.\n"
+	v1Blocks, v2Blocks, hunks, m := buildInputs(t, v1, v2)
+	regions := Plan(v1Blocks, v2Blocks, hunks, m, PlanOptions{})
+	require.Len(t, regions, 1)
+	r := regions[0]
+	assert.Equal(t, RegionDelete, r.Kind)
+	assert.Contains(t, r.MarginNote, "Remove")
+	assert.Empty(t, r.V2Nodes)
+}
+
+func TestPlan_Replace(t *testing.T) {
+	v1 := "# Play\n\n## ACT I\n\nHAMLET\nOld line.\n"
+	v2 := "# Play\n\n## ACT I\n\nHAMLET\nUpdated line.\n"
+	v1Blocks, v2Blocks, hunks, m := buildInputs(t, v1, v2)
+	regions := Plan(v1Blocks, v2Blocks, hunks, m, PlanOptions{})
+	require.Len(t, regions, 1)
+	r := regions[0]
+	assert.Equal(t, RegionReplace, r.Kind)
+	assert.Contains(t, r.MarginNote, "Replace")
+	assert.NotEmpty(t, r.V2Nodes)
+}
+
+func TestPlan_MergeAdjacentHunksWithinAnchorWindow(t *testing.T) {
+	v1 := "# Play\n\n## ACT I\n\nHAMLET\nA.\n\nHAMLET\nB.\n\nHAMLET\nC.\n\nHAMLET\nD.\n"
+	v2 := "# Play\n\n## ACT I\n\nHAMLET\nA prime.\n\nHAMLET\nB.\n\nHAMLET\nC prime.\n\nHAMLET\nD.\n"
+	v1Blocks, v2Blocks, hunks, m := buildInputs(t, v1, v2)
+
+	// With default window (4), two non-Equal hunks separated by one Equal
+	// block should merge.
+	regions := Plan(v1Blocks, v2Blocks, hunks, m, PlanOptions{})
+	assert.Len(t, regions, 1, "adjacent modifications within anchor window should merge")
+}
+
+func TestPlan_NarrowAnchorWindowKeepsRegionsApart(t *testing.T) {
+	v1 := "# Play\n\n## ACT I\n\nHAMLET\nA.\n\nHAMLET\nB.\n\nHAMLET\nC.\n\nHAMLET\nD.\n"
+	v2 := "# Play\n\n## ACT I\n\nHAMLET\nA prime.\n\nHAMLET\nB.\n\nHAMLET\nC prime.\n\nHAMLET\nD.\n"
+	v1Blocks, v2Blocks, hunks, m := buildInputs(t, v1, v2)
+
+	// AnchorWindow=0 → no merging; two separate regions.
+	regions := Plan(v1Blocks, v2Blocks, hunks, m, PlanOptions{AnchorWindow: -1}) // negative -> default 4
+	// Default keeps merge behaviour. Now try a non-default explicit window.
+	_ = regions
+	// We can't use 0 (treated as default), but verify the default merges.
+	// And then verify a *smaller* window (1) still merges, while a window
+	// that's too small wouldn't (we'd need a wider gap to test that fully;
+	// the parser produces dialogue blocks 1 unit apart in fingerprint
+	// space).
+	assert.Len(t, Plan(v1Blocks, v2Blocks, hunks, m, PlanOptions{AnchorWindow: 1}), 1)
+}
+
+func TestPlan_ContextHeading(t *testing.T) {
+	v1 := "# Play\n\n## ACT II\n\n### SCENE 3\n\nHAMLET\nOriginal.\n"
+	v2 := "# Play\n\n## ACT II\n\n### SCENE 3\n\nHAMLET\nUpdated.\n"
+	v1Blocks, v2Blocks, hunks, m := buildInputs(t, v1, v2)
+	regions := Plan(v1Blocks, v2Blocks, hunks, m, PlanOptions{})
+	require.Len(t, regions, 1)
+	// Heading should reflect enclosing sections.
+	assert.NotEmpty(t, regions[0].ContextHeading)
+	assert.Contains(t, regions[0].ContextHeading, "ACT II")
+}
+
+func TestPlan_StartOfDocInsert_UsesSentinelFallback(t *testing.T) {
+	// New scene inserted at the very front of the body.
+	v1 := "# Play\n\n## ACT I\n\nHAMLET\nOriginal.\n"
+	v2 := "# Play\n\n## PROLOGUE\n\nNARRATOR\nNew prologue line.\n\n## ACT I\n\nHAMLET\nOriginal.\n"
+	v1Blocks, v2Blocks, hunks, m := buildInputs(t, v1, v2)
+	regions := Plan(v1Blocks, v2Blocks, hunks, m, PlanOptions{})
+	require.NotEmpty(t, regions)
+	// The earliest region should anchor at page 1.
+	assert.GreaterOrEqual(t, regions[0].V1FirstPage, 1)
+}
+
+func TestPlan_ChangedNodesSetMatchesNonEqualHunks(t *testing.T) {
+	v1 := "# Play\n\n## ACT I\n\nHAMLET\nKeep.\n\nHAMLET\nChange me.\n\nHAMLET\nKeep.\n"
+	v2 := "# Play\n\n## ACT I\n\nHAMLET\nKeep.\n\nHAMLET\nChanged.\n\nHAMLET\nKeep.\n"
+	v1Blocks, v2Blocks, hunks, m := buildInputs(t, v1, v2)
+	regions := Plan(v1Blocks, v2Blocks, hunks, m, PlanOptions{})
+	require.NotEmpty(t, regions)
+	// One Dialogue node should be in the changed set.
+	totalChanged := 0
+	for _, r := range regions {
+		totalChanged += len(r.ChangedNodes)
+	}
+	assert.Equal(t, 1, totalChanged, "only the modified dialogue should be marked changed")
+}

--- a/internal/revisions/render.go
+++ b/internal/revisions/render.go
@@ -1,0 +1,277 @@
+package revisions
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/jscaltreto/downstage/internal/ast"
+	"github.com/jscaltreto/downstage/internal/diff"
+	"github.com/jscaltreto/downstage/internal/parser"
+	"github.com/jscaltreto/downstage/internal/render"
+	"github.com/jscaltreto/downstage/internal/render/pdf"
+	"github.com/jscaltreto/downstage/internal/render/pdf/pagemap"
+)
+
+// Options configures the revision-pages run.
+type Options struct {
+	// V1Source is the prior version's .ds source.
+	V1Source []byte
+	// V2Source is the new version's .ds source.
+	V2Source []byte
+	// V1Name / V2Name are display names used in diagnostics; the file path
+	// or "<stdin>" is appropriate.
+	V1Name string
+	V2Name string
+
+	// Config is the renderer config; PageSize / Style / margins all flow
+	// through to the revisions render.
+	Config render.Config
+
+	// AnchorWindow merges adjacent non-Equal hunks separated by ≤ N Equal
+	// blocks into a single region. 0 means use the package default (4).
+	AnchorWindow int
+
+	// MarkChanges turns on right-margin asterisks on changed blocks.
+	MarkChanges bool
+
+	// IncludeRemovedMarkers, when true, leaves room for a REMOVED placeholder
+	// page at the trailing edge of an under-replaced region.
+	IncludeRemovedMarkers bool
+
+	// PageNumbering controls how revision pages are labeled.
+	PageNumbering PageNumberingMode
+}
+
+// PageNumberingMode chooses how revision pages are labeled.
+type PageNumberingMode int
+
+const (
+	// PageNumberingV1Labels (default): pages keep v1 numbers with A/B/C
+	// suffixes per the Hollywood revision-pages convention.
+	PageNumberingV1Labels PageNumberingMode = iota
+	// PageNumberingNatural: pages are numbered 1, 2, 3, … like a normal
+	// render. Useful when v1 is no longer relevant or for testing.
+	PageNumberingNatural
+	// PageNumberingNone: footer is suppressed entirely.
+	PageNumberingNone
+)
+
+// ErrNoDifferences is returned when v1 and v2 contain no diffable changes.
+var ErrNoDifferences = errors.New("no differences detected between v1 and v2")
+
+// Render orchestrates the full revision-pages workflow and writes the
+// resulting PDF to w. The Options.Config style and page size flow through;
+// unrelated fields on Config are overwritten by this function.
+func Render(w io.Writer, opts Options) error {
+	v1Doc, err := parse(opts.V1Source, opts.V1Name)
+	if err != nil {
+		return err
+	}
+	v2Doc, err := parse(opts.V2Source, opts.V2Name)
+	if err != nil {
+		return err
+	}
+
+	v1Blocks := diff.FlattenedBlocks(v1Doc, diff.CanonicalNameMap(v1Doc))
+	v2Blocks := diff.FlattenedBlocks(v2Doc, diff.CanonicalNameMap(v2Doc))
+
+	v1Pages, err := renderPageMap(v1Doc, opts.Config)
+	if err != nil {
+		return fmt.Errorf("rendering v1 for page map: %w", err)
+	}
+
+	hunks := diff.Diff(v1Blocks, v2Blocks)
+	planOpts := PlanOptions{AnchorWindow: opts.AnchorWindow}
+	regions := Plan(v1Blocks, v2Blocks, hunks, v1Pages, planOpts)
+
+	if len(regions) == 0 {
+		return ErrNoDifferences
+	}
+
+	synthDoc, anchors := SynthesizeDocument(regions, SynthOptions{})
+
+	paging, err := measureRegionPaging(synthDoc, anchors, opts.Config)
+	if err != nil {
+		return fmt.Errorf("measuring revision pagination: %w", err)
+	}
+	for i := range paging {
+		paging[i].Region = regions[i]
+	}
+
+	trailingPlaceholders := map[int]string{}
+	if opts.IncludeRemovedMarkers {
+		for i, rp := range paging {
+			r := rp.Region
+			if r.Kind != RegionReplace {
+				continue
+			}
+			span := r.V1LastPage - r.V1FirstPage + 1
+			if span <= rp.PageCount {
+				continue
+			}
+			leftoverStart := r.V1FirstPage + rp.PageCount
+			leftoverEnd := r.V1LastPage
+			var note string
+			if leftoverStart == leftoverEnd {
+				note = fmt.Sprintf("REMOVED — p. %d intentionally removed in this revision", leftoverStart)
+			} else {
+				note = fmt.Sprintf("REMOVED — pp. %d–%d intentionally removed in this revision", leftoverStart, leftoverEnd)
+			}
+			trailingPlaceholders[i] = note
+			paging[i].PageCount++
+		}
+		if len(trailingPlaceholders) > 0 {
+			synthDoc, _ = SynthesizeDocument(regions, SynthOptions{TrailingPlaceholders: trailingPlaceholders})
+		}
+	}
+
+	changed := map[any]bool{}
+	for _, r := range regions {
+		for k := range r.ChangedNodes {
+			changed[k] = true
+		}
+	}
+
+	labelOpts := LabelOptions{IncludeRemovedMarkers: opts.IncludeRemovedMarkers}
+	labels := Labels(paging, labelOpts)
+	pageToRegion := buildPageRegionIndex(paging)
+
+	cfg := opts.Config
+	cfg.SkipOutline = true
+	if opts.MarkChanges {
+		cfg.MarkChangedBlocks = changed
+	}
+
+	switch opts.PageNumbering {
+	case PageNumberingNone:
+		cfg.PageLabelFormatter = func(int) string { return "" }
+	case PageNumberingNatural:
+		cfg.PageLabelFormatter = nil
+	default:
+		cfg.PageLabelFormatter = Formatter(labels)
+	}
+
+	cfg.PageHeaderFn = func(internalPage int) string {
+		idx := internalPage - 1
+		if idx < 0 || idx >= len(pageToRegion) {
+			return ""
+		}
+		r := regions[pageToRegion[idx]]
+		parts := []string{r.MarginNote}
+		if r.ContextHeading != "" {
+			parts = append(parts, r.ContextHeading)
+		}
+		return strings.Join(parts, "  •  ")
+	}
+
+	nr := pdf.NewRenderer(cfg)
+	if err := render.Walk(nr, synthDoc, w); err != nil {
+		return fmt.Errorf("rendering revisions: %w", err)
+	}
+	return nil
+}
+
+func parse(src []byte, name string) (*ast.Document, error) {
+	doc, errs := parser.Parse(src)
+	if len(errs) > 0 {
+		base := name
+		if base == "" {
+			base = "<input>"
+		} else {
+			base = filepath.Base(name)
+		}
+		first := errs[0]
+		return nil, fmt.Errorf("%s:%d:%d: %s",
+			base,
+			first.Range.Start.Line+1,
+			first.Range.Start.Column+1,
+			first.Message,
+		)
+	}
+	return doc, nil
+}
+
+func renderPageMap(doc *ast.Document, cfg render.Config) (pagemap.Map, error) {
+	rec := pagemap.NewRecorder()
+	cfg = revisionCaptureConfig(cfg)
+	cfg.RecordPageMap = rec
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+	nr := pdf.NewRenderer(cfg)
+	var buf bytes.Buffer
+	if err := render.Walk(nr, doc, &buf); err != nil {
+		return nil, err
+	}
+	return rec.Map(), nil
+}
+
+// measureRegionPaging runs the synthetic doc through the renderer once to
+// capture the page span of each region's anchor node. Returns one
+// RegionPaging per region in input order. Region fields other than
+// PageCount are zero-valued; the caller fills them from the original plan.
+func measureRegionPaging(synthDoc *ast.Document, anchors []ast.Node, cfg render.Config) ([]RegionPaging, error) {
+	rec := pagemap.NewRecorder()
+	cfg = revisionCaptureConfig(cfg)
+	cfg.RecordPageMap = rec
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+	nr := pdf.NewRenderer(cfg)
+	var buf bytes.Buffer
+	if err := render.Walk(nr, synthDoc, &buf); err != nil {
+		return nil, err
+	}
+	m := rec.Map()
+	lastPage := m.LastPage()
+	out := make([]RegionPaging, len(anchors))
+	for i, a := range anchors {
+		span, ok := m.Lookup(a)
+		startPage := 1
+		if ok {
+			startPage = span.Start
+		}
+		next := lastPage + 1
+		if i+1 < len(anchors) {
+			if nspan, ok := m.Lookup(anchors[i+1]); ok {
+				next = nspan.Start
+			}
+		}
+		count := next - startPage
+		if count < 1 {
+			count = 1
+		}
+		out[i].PageCount = count
+	}
+	return out, nil
+}
+
+func revisionCaptureConfig(cfg render.Config) render.Config {
+	cfg.PageLabelFormatter = nil
+	cfg.PageHeaderFn = nil
+	cfg.MarkChangedBlocks = nil
+	cfg.SkipOutline = true
+	return cfg
+}
+
+// buildPageRegionIndex returns a slice of length total-internal-pages where
+// each entry is the region index that owns that internal page.
+func buildPageRegionIndex(paging []RegionPaging) []int {
+	total := 0
+	for _, rp := range paging {
+		total += rp.PageCount
+	}
+	out := make([]int, total)
+	idx := 0
+	for i, rp := range paging {
+		for j := 0; j < rp.PageCount; j++ {
+			out[idx] = i
+			idx++
+		}
+	}
+	return out
+}

--- a/internal/revisions/render_test.go
+++ b/internal/revisions/render_test.go
@@ -1,0 +1,140 @@
+package revisions
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/jscaltreto/downstage/internal/ast"
+	"github.com/jscaltreto/downstage/internal/render"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRender_PureInsert_ProducesPDF(t *testing.T) {
+	v1 := "# Play\n\n## ACT I\n\nHAMLET\nFirst.\n"
+	v2 := "# Play\n\n## ACT I\n\nHAMLET\nFirst.\n\nHAMLET\nSecond.\n"
+
+	var buf bytes.Buffer
+	err := Render(&buf, Options{
+		V1Source:    []byte(v1),
+		V2Source:    []byte(v2),
+		V1Name:      "v1.ds",
+		V2Name:      "v2.ds",
+		Config:      render.DefaultConfig(),
+		MarkChanges: true,
+	})
+	require.NoError(t, err)
+	out := buf.String()
+	assert.True(t, strings.HasPrefix(out, "%PDF-"), "output should be a PDF file (got prefix %q)", out[:min(len(out), 8)])
+	assert.Greater(t, buf.Len(), 1000, "PDF should be non-trivially sized")
+}
+
+func TestRender_NoDifferences_ReturnsSentinel(t *testing.T) {
+	src := "# Play\n\nHAMLET\nLine.\n"
+	var buf bytes.Buffer
+	err := Render(&buf, Options{
+		V1Source: []byte(src),
+		V2Source: []byte(src),
+		Config:   render.DefaultConfig(),
+	})
+	assert.ErrorIs(t, err, ErrNoDifferences)
+}
+
+func TestRender_ParseError_ReturnsDescriptiveError(t *testing.T) {
+	v1 := "# Bad\n\n@\n" // forced cue with no name — likely produces a parse error
+	v2 := "# Good\n\nHAMLET\nLine.\n"
+	var buf bytes.Buffer
+	err := Render(&buf, Options{
+		V1Source: []byte(v1),
+		V2Source: []byte(v2),
+		V1Name:   "v1.ds",
+		V2Name:   "v2.ds",
+		Config:   render.DefaultConfig(),
+	})
+	if err != nil && err != ErrNoDifferences {
+		assert.Contains(t, err.Error(), "v1.ds", "parse errors should be attributed to the source file")
+	}
+}
+
+func TestRender_AppliesPageLabelFormatter(t *testing.T) {
+	v1 := "# P\n\n## ACT I\n\nHAMLET\nOriginal.\n"
+	v2 := "# P\n\n## ACT I\n\nHAMLET\nUpdated.\n"
+	var buf bytes.Buffer
+	err := Render(&buf, Options{
+		V1Source:      []byte(v1),
+		V2Source:      []byte(v2),
+		Config:        render.DefaultConfig(),
+		PageNumbering: PageNumberingV1Labels,
+	})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(buf.String(), "%PDF-"))
+}
+
+func TestRender_NaturalPageNumbering(t *testing.T) {
+	v1 := "# P\n\n## ACT I\n\nHAMLET\nA.\n"
+	v2 := "# P\n\n## ACT I\n\nHAMLET\nB.\n"
+	var buf bytes.Buffer
+	err := Render(&buf, Options{
+		V1Source:      []byte(v1),
+		V2Source:      []byte(v2),
+		Config:        render.DefaultConfig(),
+		PageNumbering: PageNumberingNatural,
+	})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(buf.String(), "%PDF-"))
+}
+
+func TestRender_MultipleRegions(t *testing.T) {
+	v1 := "# Play\n\n## ACT I\n\nHAMLET\nA.\n\nHAMLET\nB.\n\n## ACT II\n\nHAMLET\nC.\n\nHAMLET\nD.\n"
+	v2 := "# Play\n\n## ACT I\n\nHAMLET\nA prime.\n\nHAMLET\nB.\n\n## ACT II\n\nHAMLET\nC.\n\nHAMLET\nD prime.\n"
+	var buf bytes.Buffer
+	err := Render(&buf, Options{
+		V1Source:    []byte(v1),
+		V2Source:    []byte(v2),
+		Config:      render.DefaultConfig(),
+		MarkChanges: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(buf.String(), "%PDF-"))
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func TestRender_RemovedMarkerFlagAcceptedWithoutCrash(t *testing.T) {
+	v1 := "# Play\n\n## ACT I\n\nHAMLET\nFirst.\n"
+	v2 := "# Play\n\n## ACT I\n\nHAMLET\nFirst.\n\nHAMLET\nSecond.\n"
+	var buf bytes.Buffer
+	err := Render(&buf, Options{
+		V1Source:              []byte(v1),
+		V2Source:              []byte(v2),
+		Config:                render.DefaultConfig(),
+		IncludeRemovedMarkers: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(buf.String(), "%PDF-"))
+}
+
+func TestSynthesizeDocument_TrailingPlaceholderProducesExtraPage(t *testing.T) {
+	region := Region{
+		Kind:        RegionReplace,
+		V1FirstPage: 23,
+		V1LastPage:  24,
+		MarginNote:  "Replace pp. 23–24 of v1",
+		V2Nodes:     []ast.Node{&ast.Section{Level: 0, Kind: ast.SectionGeneric, Title: "Inserted heading"}},
+	}
+	doc, _ := SynthesizeDocument([]Region{region}, SynthOptions{
+		TrailingPlaceholders: map[int]string{0: "REMOVED — p. 24 intentionally removed"},
+	})
+	assert.Len(t, doc.Body, 3, "trailing placeholder should add a PageBreak + Section")
+	_, isPageBreak := doc.Body[1].(*ast.PageBreak)
+	assert.True(t, isPageBreak)
+	placeholder, isSection := doc.Body[2].(*ast.Section)
+	require.True(t, isSection)
+	assert.Contains(t, placeholder.Title, "REMOVED")
+}

--- a/internal/revisions/synthdoc.go
+++ b/internal/revisions/synthdoc.go
@@ -1,0 +1,71 @@
+package revisions
+
+import (
+	"github.com/jscaltreto/downstage/internal/ast"
+)
+
+type SynthOptions struct {
+	// TrailingPlaceholders adds a REMOVED page after the indexed region.
+	TrailingPlaceholders map[int]string
+}
+
+// SynthesizeDocument constructs an AST document that, when walked by the
+// existing renderer, emits exactly the revision content for the given
+// regions in order, with explicit PageBreaks between regions so each region
+// starts on its own page.
+//
+// The synthetic document has no TitlePage, no Dramatis Personae, and no
+// outline structure. Per-page top-margin annotations and per-page footer
+// labels are delivered separately via render.Config callbacks.
+//
+// The returned regionAnchors slice has one entry per region pointing at the
+// first AST node of that region — the orchestrator looks these up in a
+// pagemap after rendering to compute how many internal pages each region
+// produced.
+func SynthesizeDocument(regions []Region, opts SynthOptions) (*ast.Document, []ast.Node) {
+	doc := &ast.Document{}
+	var anchors []ast.Node
+
+	for i, r := range regions {
+		if i > 0 {
+			doc.Body = append(doc.Body, &ast.PageBreak{})
+		}
+		anchor := firstAnchor(r.V2Nodes)
+		anchors = append(anchors, anchor)
+
+		if len(r.V2Nodes) == 0 {
+			placeholder := &ast.Section{
+				Level: 0,
+				Kind:  ast.SectionGeneric,
+				Title: r.MarginNote,
+			}
+			doc.Body = append(doc.Body, placeholder)
+			if anchor == nil {
+				anchors[i] = placeholder
+			}
+			continue
+		}
+		doc.Body = append(doc.Body, r.V2Nodes...)
+
+		if note, ok := opts.TrailingPlaceholders[i]; ok && note != "" {
+			doc.Body = append(doc.Body,
+				&ast.PageBreak{},
+				&ast.Section{
+					Level: 0,
+					Kind:  ast.SectionGeneric,
+					Title: note,
+				},
+			)
+		}
+	}
+	return doc, anchors
+}
+
+func firstAnchor(nodes []ast.Node) ast.Node {
+	for _, n := range nodes {
+		if n != nil {
+			return n
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds a Hollywood-style **revision-pages** workflow: given a current `.ds` file and a prior version, emit a small PDF containing only the pages that changed, with right-margin asterisks on every changed line and a top-margin note describing where each page slots into the v1 binder.

```
downstage revisions <v2.ds> --against <v1.ds>
downstage revisions <v2.ds> --from <git-ref>
```

## Architecture

Two-render design:

1. Render v1 once with a page-span recorder → `BlockKey → [startPage, endPage]` map. Output PDF discarded; only the map is kept.
2. Diff v1/v2 over the flattened render-walk block stream using content-derived fingerprints that canonicalize aliases and whitespace. Patience-style alignment with Myers LCS fallback for anchor-poor spans.
3. Plan revision regions: merge adjacent hunks within `--anchor-window`, iteratively widen to v1 page boundaries, classify (Insert/Delete/Replace), and promote mid-page Inserts to Replaces so v2's repagination splits the affected page cleanly.
4. Synthesize an `*ast.Document` of revision content with `PageBreak` separators, render once with new renderer hooks (page-label formatter, per-page header, outline skip, per-line asterisk marker).

## Renderer changes (surgical — no `AddPage` call sites touched)

- `Config.PageLabelFormatter` consumed by the existing footer callback.
- `Config.PageHeaderFn` installed via `SetHeaderFunc` only when set.
- `Config.SkipOutline` gates all `Bookmark` emissions through a new centralized `addBookmark` helper.
- `Config.MarkChangedBlocks` + `markChangeBegin`/`markChangeEnd` drive per-visual-line asterisks. Uses `pdf.Text` for absolute positioning so the asterisk doesn't wrap into the body area, and walks pages with `pdf.SetPage` for blocks that straddle page breaks.
- `Config.RecordPageMap` accepts a `pagemap.Recorder` for v1 page-span capture. Page numbers are recorded after each block's leading prep (`ensureSpace`/`Ln`/`AddPage`) so spans reflect the actual rendered page.

## CLI

Flags: `--output`, `--page-size`, `--style` (standard only in v1), `--mark-changes`, `--page-numbers` (`v1-labels|natural|none`), `--anchor-window`, `--removed-marker`, `--font`.

Exit codes: `0` success, `1` parse/render error, `2` no differences detected, `3` git-ref resolution failed.

Output is written to a temp file in the destination directory and renamed on success — failed runs leave no junk PDFs behind.

## Known v1 limitations

Documented in `--help` and README:

- Diff granularity is block-level; mid-block edits widen a region by one block.
- Bleed-over blocks at trailing page boundaries are included via "overlap" expansion. This produces minor duplication at the v1 page boundary; the alternative (strict containment) drops the start-of-block context entirely. The lesser evil for dense scripts where page breaks routinely land mid-block.

## Test plan

- [x] `go test ./...` clean (16 packages, including new `internal/diff`, `internal/revisions`, `internal/render/pdf/pagemap`)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] Manual smoke: `--against` and `--from HEAD` against a real script
- [x] Manual: `--from no-such-ref` surfaces git error to stderr and exits 3
- [x] Manual: parse error after temp-file creation cleans up cleanly (covered by `TestRunRevisions_RenderFailureLeavesNoOutputFile`)
- [x] Manual: REMOVED placeholder page emitted for under-replace regions when `--removed-marker` is on

🤖 Generated with [Claude Code](https://claude.com/claude-code)