### PR TITLE
chore: harden dependabot config and gate marketplace publishes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,19 +5,46 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      go-patch:
+        update-types: ["patch"]
 
   - package-ecosystem: npm
     directory: /editors/vscode
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      vscode-patch:
+        update-types: ["patch"]
+
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      web-patch:
+        update-types: ["patch"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      actions-patch:
+        update-types: ["patch"]

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,9 @@ jobs:
     needs:
       - vscode-vsix
       - upload-vsix
+    environment:
+      name: marketplace-publish
+      url: https://marketplace.visualstudio.com/items?itemName=downstage.downstage-vscode
     permissions:
       contents: read
 
@@ -238,6 +241,9 @@ jobs:
     needs:
       - vscode-vsix
       - upload-vsix
+    environment:
+      name: marketplace-publish
+      url: https://open-vsx.org/extension/downstage/downstage-vscode
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary

- Group patch-only dependabot updates per ecosystem; minor/major stay as individual PRs
- Add 5-day cooldown across all ecosystems (security advisories bypass it)
- Add missing `/web` npm directory to dependabot coverage
- Auto-merge dependabot patch PRs once CI passes (gated by branch protection)
- Bind VS Code Marketplace and Open VSX publish jobs to a `marketplace-publish` environment so `VSCE_PAT` / `OVSX_TOKEN` are only injected after manual approval

## Prerequisites for full effect

- [ ] Repo Settings → General → "Allow auto-merge" is enabled
- [ ] Branch protection on `main` requires CI checks (otherwise auto-merge merges immediately)
- [ ] `marketplace-publish` environment exists with required reviewer + tag rule `v*`, and holds `VSCE_PAT` / `OVSX_TOKEN` (repo-level copies removed)

## Test plan

- [ ] Merge this PR; confirm `dependabot-automerge` workflow appears in Actions
- [ ] After next dependabot patch PR opens, confirm it auto-merges once CI passes
- [ ] Cut a throwaway tag (e.g. `v0.0.0-test1`) and confirm `publish-vscode-marketplace` / `publish-open-vsx` block on approval; delete tag + any artifacts after