### PR TITLE
chore: surface dependency bumps in release-please changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,13 @@
   "packages": {
     ".": {
       "package-name": "downstage",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance" },
+        { "type": "chore", "section": "Dependencies", "scope": "deps" }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Add a `Dependencies` section to release-please's changelog config that captures `chore(deps)` commits.

- Dependabot bumps still don't trigger releases on their own (`chore` doesn't bump version)
- When a `feat` or `fix` lands and a release-PR is created, dependabot bumps are bundled into the release notes under their own section
- Uses scope filter `chore + scope: deps` to avoid catching unrelated chore commits

## Test plan

- [ ] Merge this PR; release-please workflow runs on the next push to main
- [ ] Once a future `feat:` or `fix:` lands alongside merged `chore(deps):` commits, confirm the resulting release-PR's notes include a Dependencies section