### PR TITLE
chore(desktop): clear pre-PR review deferrals (Track A1)

### DIFF
--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -65,10 +65,20 @@ type legacyConfig struct {
 
 // App is the Wails application backend.
 type App struct {
-	ctx            context.Context
+	ctx context.Context
+
+	// libMu guards currentLibrary. Wails dispatches each bound method on
+	// its own goroutine; without the lock a concurrent ChangeLibraryLocation
+	// races against every reader. Writers (initApp, ChangeLibraryLocation)
+	// hold Lock only around the field mutation and the immediately
+	// following git-init — never while a user-facing dialog is open.
+	// Readers hold RLock for the duration of the method to keep
+	// currentLibrary consistent across the method's I/O.
+	libMu          sync.RWMutex
 	currentLibrary string
-	configPath     string
-	configMu       sync.Mutex
+
+	configPath string
+	configMu   sync.Mutex
 
 	menuMu      sync.Mutex
 	currentMenu *menu.Menu
@@ -107,13 +117,21 @@ func (a *App) initApp() {
 
 	if config.LastLibraryPath != "" {
 		if _, err := os.Stat(config.LastLibraryPath); err == nil {
+			// Startup runs before any RPC can fire, so contention is
+			// theoretical; lock for uniformity. ensureGitRepo takes
+			// its own RLock, so swap fields under Lock and release
+			// before calling it.
+			a.libMu.Lock()
 			a.currentLibrary = config.LastLibraryPath
+			a.libMu.Unlock()
 			_ = a.ensureGitRepo()
 		}
 	}
 }
 
 func (a *App) ensureGitRepo() error {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	if a.currentLibrary == "" {
 		return nil
 	}
@@ -271,6 +289,11 @@ func (a *App) SaveWindowBoundsIfNormal() error {
 	return a.SaveWindowBounds(w, h)
 }
 
+// safePath validates relPath against the current library root. CALLER
+// MUST HOLD a.libMu (read or write); we do NOT lock here because every
+// caller is a bound App method that already holds RLock for the
+// duration of its body, and Go's sync.RWMutex doesn't safely recurse
+// when a writer is pending.
 func (a *App) safePath(relPath string) (string, error) {
 	if a.currentLibrary == "" {
 		return "", fmt.Errorf("no library open")
@@ -320,6 +343,8 @@ func pathInsideRoot(p, root string) bool {
 }
 
 func (a *App) GetCurrentLibrary() string {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	return a.currentLibrary
 }
 
@@ -333,6 +358,8 @@ func (a *App) BrowserOpenURL(url string) {
 }
 
 func (a *App) RevealLibraryInExplorer() error {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	if a.currentLibrary == "" {
 		return fmt.Errorf("no library open")
 	}

--- a/internal/desktop/app_test.go
+++ b/internal/desktop/app_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
-	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -200,18 +200,23 @@ func TestReadLibraryFile_DoesNotWriteConfig(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(a.currentLibrary, "play.ds"), []byte("x"), 0644))
 
 	require.NoError(t, a.writeConfig(Config{LastLibraryPath: "/x", LastActiveLibraryFile: "prev.ds"}))
-	statBefore, err := os.Stat(a.configPath)
+	// Byte-equality check replaces the previous mtime+sleep pattern.
+	// Mtime is fs-resolution-dependent (some filesystems round to the
+	// second); byte equality catches any write regardless of mtime
+	// granularity and doesn't waste a 10ms sleep per run.
+	bytesBefore, err := os.ReadFile(a.configPath)
 	require.NoError(t, err)
-
-	time.Sleep(10 * time.Millisecond)
 
 	_, err = a.ReadLibraryFile("play.ds")
 	require.NoError(t, err)
 
-	statAfter, err := os.Stat(a.configPath)
+	bytesAfter, err := os.ReadFile(a.configPath)
 	require.NoError(t, err)
-	assert.Equal(t, statBefore.ModTime(), statAfter.ModTime())
+	assert.Equal(t, bytesBefore, bytesAfter,
+		"ReadLibraryFile must not rewrite the config file")
 
+	// Belt-and-suspenders: even if the bytes happened to round-trip
+	// identical, prove the active-file pointer wasn't quietly updated.
 	cfg, err := a.readConfig()
 	require.NoError(t, err)
 	assert.Equal(t, "prev.ds", cfg.LastActiveLibraryFile)
@@ -1198,4 +1203,56 @@ func TestCreateLibraryFile_StatErrorAborts(t *testing.T) {
 	_, err := a.CreateLibraryFile("collision-test", "content")
 	require.Error(t, err,
 		"CreateLibraryFile must surface a non-ENOENT stat error instead of looping")
+}
+
+// H3: drive concurrent readers against an in-package writer that
+// mutates currentLibrary under libMu. Sidesteps ChangeLibraryLocation's
+// runtime.OpenDirectoryDialog dependency. Run via `go test -race`.
+func TestCurrentLibrary_RaceFree(t *testing.T) {
+	a := testApp(t)
+	libA := a.currentLibrary
+	libB := t.TempDir()
+
+	const readers = 8
+	const swaps = 200
+	const iters = 200
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Reader goroutines hammer GetCurrentLibrary.
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				_ = a.GetCurrentLibrary()
+				select {
+				case <-stop:
+					return
+				default:
+				}
+			}
+		}()
+	}
+
+	// Writer goroutine flips currentLibrary back and forth under
+	// libMu. Same lock the writers in ChangeLibraryLocation /
+	// initApp take.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < swaps; j++ {
+			a.libMu.Lock()
+			if j%2 == 0 {
+				a.currentLibrary = libB
+			} else {
+				a.currentLibrary = libA
+			}
+			a.libMu.Unlock()
+		}
+	}()
+
+	wg.Wait()
+	close(stop)
 }

--- a/internal/desktop/git.go
+++ b/internal/desktop/git.go
@@ -47,6 +47,8 @@ func snapshotAuthor(r *git.Repository) *object.Signature {
 }
 
 func (a *App) SnapshotFile(relPath string, message string) error {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	if a.currentLibrary == "" {
 		return fmt.Errorf("no library open")
 	}
@@ -88,6 +90,8 @@ func (a *App) SnapshotFile(relPath string, message string) error {
 const defaultRevisionLimit = 100
 
 func (a *App) GetRevisions(relPath string, limit int) ([]Revision, error) {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	if a.currentLibrary == "" {
 		return []Revision{}, nil
 	}
@@ -255,6 +259,8 @@ type FileGitStatus struct {
 }
 
 func (a *App) GetFileGitStatus(relPath string) (FileGitStatus, error) {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	if a.currentLibrary == "" {
 		return FileGitStatus{}, fmt.Errorf("no library open")
 	}
@@ -329,6 +335,8 @@ func lastCommitTimeForPath(r *git.Repository, relPath string) (string, bool) {
 }
 
 func (a *App) ReadFileAtRevision(relPath string, hash string) (string, error) {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	if a.currentLibrary == "" {
 		return "", fmt.Errorf("no library open")
 	}

--- a/internal/desktop/library.go
+++ b/internal/desktop/library.go
@@ -35,6 +35,9 @@ type LibraryNode struct {
 }
 
 func (a *App) ChangeLibraryLocation() (string, error) {
+	// Run the directory dialog WITHOUT libMu held — the user may sit
+	// in the picker indefinitely and we mustn't block every other RPC
+	// while they decide.
 	selection, err := runtime.OpenDirectoryDialog(a.ctx, runtime.OpenDialogOptions{
 		Title: "Choose Library Location",
 	})
@@ -44,7 +47,12 @@ func (a *App) ChangeLibraryLocation() (string, error) {
 	if selection == "" {
 		return "", nil
 	}
+
+	// Now take the writer Lock for the brief field swap; release
+	// before the slower disk operations (config write + git init).
+	a.libMu.Lock()
 	a.currentLibrary = selection
+	a.libMu.Unlock()
 
 	if err := a.updateConfig(func(c *Config) {
 		c.LastLibraryPath = selection
@@ -58,6 +66,8 @@ func (a *App) ChangeLibraryLocation() (string, error) {
 }
 
 func (a *App) GetLibraryTree() ([]LibraryNode, error) {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	if a.currentLibrary == "" {
 		return []LibraryNode{}, nil
 	}
@@ -128,6 +138,8 @@ func buildLibraryChildren(root, relDir string) ([]LibraryNode, error) {
 }
 
 func (a *App) CreateLibraryFolder(relPath string) error {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	fullPath, err := a.safePath(relPath)
 	if err != nil {
 		return err
@@ -139,6 +151,8 @@ func (a *App) CreateLibraryFolder(relPath string) error {
 }
 
 func (a *App) MoveLibraryEntry(srcRel, dstRel string) (string, error) {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	srcFull, err := a.safePath(srcRel)
 	if err != nil {
 		return "", fmt.Errorf("source: %w", err)
@@ -213,6 +227,10 @@ func collectTrackedPaths(fullPath, relPath string) ([]string, error) {
 	return paths, err
 }
 
+// commitMove is private; callers (MoveLibraryEntry, RenameLibraryEntry)
+// hold libMu.RLock for the duration of their work, so this helper
+// must NOT acquire a second RLock (would deadlock against a pending
+// writer).
 func (a *App) commitMove(srcPaths []string, dstRel string) error {
 	if a.currentLibrary == "" {
 		return fmt.Errorf("no library open")
@@ -304,6 +322,8 @@ func (a *App) RenameLibraryEntry(srcRel, newName string) (string, error) {
 }
 
 func (a *App) ReadLibraryFile(relPath string) (string, error) {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	fullPath, err := a.safePath(relPath)
 	if err != nil {
 		return "", err
@@ -316,6 +336,8 @@ func (a *App) ReadLibraryFile(relPath string) (string, error) {
 }
 
 func (a *App) WriteLibraryFile(relPath string, content string) error {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	fullPath, err := a.safePath(relPath)
 	if err != nil {
 		return err
@@ -327,6 +349,8 @@ func (a *App) WriteLibraryFile(relPath string, content string) error {
 }
 
 func (a *App) CreateLibraryFile(name string, content string) (string, error) {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	if a.currentLibrary == "" {
 		return "", fmt.Errorf("no library open")
 	}
@@ -383,6 +407,8 @@ func (a *App) OpenExternalFileDialog() (string, error) {
 }
 
 func (a *App) ReadExternalFile(absPath string) (ExternalFileResult, error) {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	if !filepath.IsAbs(absPath) {
 		return ExternalFileResult{}, fmt.Errorf("absolute path required")
 	}
@@ -441,6 +467,8 @@ func (a *App) ReadExternalFile(absPath string) (ExternalFileResult, error) {
 }
 
 func (a *App) AddExternalFileToLibrary(absSrc string, destRelDir string) (string, error) {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	if a.currentLibrary == "" {
 		return "", fmt.Errorf("no library open")
 	}
@@ -530,6 +558,8 @@ func (a *App) writeDictionary(words []string) error {
 }
 
 func (a *App) GetSpellAllowlist() []string {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	words := a.readDictionary()
 	if words == nil {
 		return []string{}
@@ -538,6 +568,8 @@ func (a *App) GetSpellAllowlist() []string {
 }
 
 func (a *App) AddSpellAllowlistWord(word string) (bool, error) {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	word = strings.TrimSpace(word)
 	if word == "" {
 		return false, nil
@@ -557,6 +589,8 @@ func (a *App) AddSpellAllowlistWord(word string) (bool, error) {
 }
 
 func (a *App) RemoveSpellAllowlistWord(word string) (bool, error) {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	word = strings.TrimSpace(word)
 	if word == "" {
 		return false, nil
@@ -651,6 +685,8 @@ func (a *App) writeHiddenRevisions(hashes []string) error {
 }
 
 func (a *App) GetHiddenRevisions() ([]string, error) {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	a.hiddenMu.Lock()
 	defer a.hiddenMu.Unlock()
 	h, err := a.readHiddenRevisions()
@@ -668,6 +704,8 @@ func (a *App) HideRevision(hash string) error {
 	if hash == "" {
 		return fmt.Errorf("hash is empty")
 	}
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	a.hiddenMu.Lock()
 	defer a.hiddenMu.Unlock()
 	current, err := a.readHiddenRevisions()
@@ -688,6 +726,8 @@ func (a *App) UnhideRevision(hash string) error {
 	if hash == "" {
 		return fmt.Errorf("hash is empty")
 	}
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
 	a.hiddenMu.Lock()
 	defer a.hiddenMu.Unlock()
 	current, err := a.readHiddenRevisions()

--- a/internal/desktop/menu.go
+++ b/internal/desktop/menu.go
@@ -9,11 +9,25 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
+// CommandEmitter is what each menu item's Click callback invokes to
+// notify the frontend that a command fired. Extracted so tests can
+// drop in a capture-emitter and verify which IDs the click closures
+// reach without standing up a Wails runtime.
+type CommandEmitter func(id string)
+
 func BuildMenu(app *App, disabled map[string]bool) *menu.Menu {
-	return buildMenuForGOOS(app, disabled, goruntime.GOOS)
+	return buildMenuForGOOS(app, disabled, goruntime.GOOS, defaultEmitter(app))
 }
 
-func buildMenuForGOOS(app *App, disabled map[string]bool, goos string) *menu.Menu {
+// defaultEmitter is the production emitter — fires a Wails event
+// that the frontend's dispatcher-registry listens on.
+func defaultEmitter(app *App) CommandEmitter {
+	return func(id string) {
+		runtime.EventsEmit(app.ctx, eventCommandExecute, id)
+	}
+}
+
+func buildMenuForGOOS(app *App, disabled map[string]bool, goos string, emit CommandEmitter) *menu.Menu {
 	root := menu.NewMenu()
 
 	if goos == "darwin" {
@@ -49,7 +63,7 @@ func buildMenuForGOOS(app *App, disabled map[string]bool, goos string) *menu.Men
 			submenu.Append(menu.EditMenu())
 		}
 
-		appendGroupItems(app, submenu, g.items, disabled)
+		appendGroupItems(submenu, g.items, disabled, emit)
 		root.AddSubmenu(g.name).Merge(submenu)
 	}
 
@@ -60,7 +74,7 @@ func buildMenuForGOOS(app *App, disabled map[string]bool, goos string) *menu.Men
 	return root
 }
 
-func appendGroupItems(app *App, parent *menu.Menu, items []Command, disabled map[string]bool) {
+func appendGroupItems(parent *menu.Menu, items []Command, disabled map[string]bool, emit CommandEmitter) {
 	type entry struct {
 		kind       string
 		cmdIdx     int
@@ -85,18 +99,18 @@ func appendGroupItems(app *App, parent *menu.Menu, items []Command, disabled map
 
 	for _, e := range entries {
 		if e.kind == "leaf" {
-			addLeaf(app, parent, items[e.cmdIdx], disabled)
+			addLeaf(parent, items[e.cmdIdx], disabled, emit)
 			continue
 		}
 		nested := menu.NewMenu()
 		for _, cmd := range buckets[e.submenuKey] {
-			addLeaf(app, nested, cmd, disabled)
+			addLeaf(nested, cmd, disabled, emit)
 		}
 		parent.AddSubmenu(e.submenuKey).Merge(nested)
 	}
 }
 
-func addLeaf(app *App, parent *menu.Menu, cmd Command, disabled map[string]bool) {
+func addLeaf(parent *menu.Menu, cmd Command, disabled map[string]bool, emit CommandEmitter) {
 	if cmd.BeforeSeparator {
 		parent.AddSeparator()
 	}
@@ -108,14 +122,11 @@ func addLeaf(app *App, parent *menu.Menu, cmd Command, disabled map[string]bool)
 		}
 		accel = parsed
 	}
-	item := parent.AddText(cmd.Label, accel, emitCommand(app, cmd.ID))
+	id := cmd.ID
+	item := parent.AddText(cmd.Label, accel, func(_ *menu.CallbackData) {
+		emit(id)
+	})
 	if disabled[cmd.ID] {
 		item.Disabled = true
-	}
-}
-
-func emitCommand(app *App, id string) func(_ *menu.CallbackData) {
-	return func(_ *menu.CallbackData) {
-		runtime.EventsEmit(app.ctx, eventCommandExecute, id)
 	}
 }

--- a/internal/desktop/menu_test.go
+++ b/internal/desktop/menu_test.go
@@ -52,7 +52,7 @@ func TestBuildMenu_FiltersLinuxOnlyAndNestsExportSubmenu(t *testing.T) {
 		return got
 	}
 
-	linuxMenu := buildMenuForGOOS(app, nil, "linux")
+	linuxMenu := buildMenuForGOOS(app, nil, "linux", defaultEmitter(app))
 	linuxEdit := labelsIn(linuxMenu, "Edit")
 	assert.True(t, linuxEdit["Undo"], "Linux Edit should include explicit Undo")
 	assert.True(t, linuxEdit["Cut"], "Linux Edit should include explicit Cut")
@@ -60,11 +60,11 @@ func TestBuildMenu_FiltersLinuxOnlyAndNestsExportSubmenu(t *testing.T) {
 	assert.True(t, linuxFile["Quit Downstage Write"], "Linux File should include Quit")
 	assert.True(t, linuxFile["PDF…"], "Export > PDF… must be walked via sub-submenu")
 
-	darwinMenu := buildMenuForGOOS(app, nil, "darwin")
+	darwinMenu := buildMenuForGOOS(app, nil, "darwin", defaultEmitter(app))
 	darwinFile := labelsIn(darwinMenu, "File")
 	assert.False(t, darwinFile["Quit Downstage Write"], "macOS AppMenu role provides Quit; catalog entry must be filtered")
 
-	windowsMenu := buildMenuForGOOS(app, nil, "windows")
+	windowsMenu := buildMenuForGOOS(app, nil, "windows", defaultEmitter(app))
 	windowsFile := labelsIn(windowsMenu, "File")
 	assert.True(t, windowsFile["Quit Downstage Write"], "Windows File should include Quit")
 }
@@ -149,5 +149,74 @@ func collectLabels(m *menu.Menu, out map[string]bool) {
 		if item.SubMenu != nil {
 			collectLabels(item.SubMenu, out)
 		}
+	}
+}
+
+// T13: prove every menu item built from the catalog has a Click
+// callback that emits its declared command ID — covers the previously
+// untested wire between menu construction and the frontend dispatcher.
+//
+// Invoking each Click via a capture-emitter sidesteps the Wails
+// runtime entirely (no ctx, no event bus needed).
+func TestBuildMenu_ClickCallbacksEmitCommandIDs(t *testing.T) {
+	app := NewApp()
+
+	for _, goos := range []string{"linux", "darwin", "windows"} {
+		t.Run(goos, func(t *testing.T) {
+			var emitted []string
+			emit := func(id string) { emitted = append(emitted, id) }
+			m := buildMenuForGOOS(app, nil, goos, emit)
+
+			// Walk the tree, invoke every leaf's Click. Collect a map
+			// from invoked label → emitted ID so we can prove each
+			// label resolves to the catalog ID it's supposed to.
+			invocations := map[string]string{}
+			var walk func(*menu.Menu)
+			walk = func(sub *menu.Menu) {
+				for _, item := range sub.Items {
+					if item.SubMenu != nil {
+						walk(item.SubMenu)
+					}
+					if item.Type != menu.TextType || item.Click == nil {
+						continue
+					}
+					emitted = nil
+					item.Click(nil)
+					// Native role items (EditMenu, AppMenu, WindowMenu)
+					// have Click callbacks Wails provides; ours are the
+					// catalog-derived ones that emit exactly one ID per
+					// click. Skip items that emitted nothing — they're
+					// native-role passthroughs we don't own.
+					if len(emitted) == 1 {
+						invocations[item.Label] = emitted[0]
+					}
+				}
+			}
+			walk(m)
+
+			// Cross-check: every catalog command that's allowed on this
+			// GOOS and has a MenuPath should appear in invocations with
+			// its declared ID. Roles like macOS's AppMenu Quit are
+			// platform-substituted, so we look up by label.
+			catalog := map[string]string{}
+			for _, cmd := range Commands() {
+				if len(cmd.MenuPath) == 0 || !cmd.PlatformAllows(goos) {
+					continue
+				}
+				catalog[cmd.Label] = cmd.ID
+			}
+
+			for label, expectedID := range catalog {
+				gotID, ok := invocations[label]
+				if !ok {
+					t.Errorf("%s: menu item %q has no testable Click callback", goos, label)
+					continue
+				}
+				if gotID != expectedID {
+					t.Errorf("%s: menu item %q clicked → emitted %q, want %q",
+						goos, label, gotID, expectedID)
+				}
+			}
+		})
 	}
 }

--- a/web/src/AppDesktop.vue
+++ b/web/src/AppDesktop.vue
@@ -289,11 +289,10 @@ onMounted(async () => {
   if (workspace.state.libraryPath && workspace.libraryFiles.value.length > 0) {
     const lastFile = await props.env.getLastActiveFile();
     const exists = workspace.libraryFiles.value.some(f => f.path === lastFile);
-    if (lastFile && exists) {
-      activeContent.value = await workspace.selectFile(lastFile);
-    } else {
-      activeContent.value = await workspace.selectFile(workspace.libraryFiles.value[0].path);
-    }
+    const path = lastFile && exists ? lastFile : workspace.libraryFiles.value[0].path;
+    const content = await workspace.selectFile(path);
+    markProgrammaticLoad(path, content);
+    activeContent.value = content;
   }
 
   if (workspace.state.lastDrawerTab) {
@@ -327,6 +326,7 @@ onMounted(async () => {
     isInCompareTwo: inCompareTwo,
     isViewingExternal,
     flushSave,
+    markProgrammaticLoad,
     editor: {
       applyFormat: (action: string) => editorRef.value?.applyFormat(action),
       undo: () => editorRef.value?.undo(),
@@ -440,14 +440,19 @@ async function handleChangeLibraryLocation() {
   if (!path) return;
   activeContent.value = "";
   if (workspace.libraryFiles.value.length > 0) {
-    activeContent.value = await workspace.selectFile(workspace.libraryFiles.value[0].path);
+    const firstPath = workspace.libraryFiles.value[0].path;
+    const content = await workspace.selectFile(firstPath);
+    markProgrammaticLoad(firstPath, content);
+    activeContent.value = content;
   }
   toastManager.value?.addToast(`Opened library: ${path.split(/[\\/]/).pop()}`, "success");
 }
 
 async function selectLibraryFile(path: string) {
   await flushSave();
-  activeContent.value = await workspace.selectFile(path);
+  const content = await workspace.selectFile(path);
+  markProgrammaticLoad(path, content);
+  activeContent.value = content;
 }
 
 async function handleViewRevision(hash: string) {
@@ -478,6 +483,12 @@ async function handleRestoreRevision() {
   if (!hash) return;
   try {
     const restored = await workspace.restoreRevision(hash, activeContent.value);
+    // restoreRevision wrote `restored` to disk; the autosave watcher
+    // would re-write the same bytes a second later if we didn't mark
+    // this as a programmatic load.
+    if (workspace.state.activeFile) {
+      markProgrammaticLoad(workspace.state.activeFile, restored);
+    }
     activeContent.value = restored;
     toastManager.value?.addToast("Version restored", "success");
   } catch (error: unknown) {
@@ -493,8 +504,28 @@ async function removeSpellAllowlistWord(word: string) {
   return workspace.removeAllowlistWord(word);
 }
 
+// Programmatic-load sentinel for the autosave watcher. Set right
+// before any host-driven `activeContent.value = …` assignment so the
+// watcher knows the next tick is a load, not a user edit. The sentinel
+// is scoped to (file, content): an external-file load (activeFile=null)
+// can't poison a later library-file save with the same bytes, and the
+// scoped match clears itself on first consumption so a subsequent
+// matching keystroke isn't swallowed.
+const lastLoaded = ref<{ file: string; content: string } | null>(null);
+function markProgrammaticLoad(file: string, content: string) {
+  lastLoaded.value = { file, content };
+}
+
 watch(activeContent, (newContent) => {
   if (!workspace.state.activeFile) return;
+  if (
+    lastLoaded.value &&
+    lastLoaded.value.file === workspace.state.activeFile &&
+    lastLoaded.value.content === newContent
+  ) {
+    lastLoaded.value = null;
+    return;
+  }
   if (saveTimer) clearTimeout(saveTimer);
   saveTimer = window.setTimeout(() => {
     saveTimer = null;

--- a/web/src/AppDesktop.vue
+++ b/web/src/AppDesktop.vue
@@ -450,9 +450,14 @@ async function handleChangeLibraryLocation() {
 
 async function selectLibraryFile(path: string) {
   await flushSave();
-  const content = await workspace.selectFile(path);
-  markProgrammaticLoad(path, content);
-  activeContent.value = content;
+  try {
+    const content = await workspace.selectFile(path);
+    markProgrammaticLoad(path, content);
+    activeContent.value = content;
+  } catch (error: unknown) {
+    const name = path.split(/[\\/]/).pop() ?? path;
+    toastManager.value?.addToast(`Failed to open ${name}: ${errorMessage(error)}`, "error");
+  }
 }
 
 async function handleViewRevision(hash: string) {

--- a/web/src/__tests__/desktop/appDesktop.test.ts
+++ b/web/src/__tests__/desktop/appDesktop.test.ts
@@ -319,6 +319,52 @@ describe("AppDesktop flush ordering", () => {
     const writesToOther = env._calls.filter((c) => c === "writeLibraryFile:other.ds");
     expect(writesToOther).toEqual([]);
   });
+
+  // Regression for the M7 follow-up: when workspace.selectFile rejects
+  // (e.g. the file was deleted out from under the app), the host has to
+  // surface a toast. Pre-fix the rejection became an unhandled promise
+  // and the UI just silently reverted to the previous file — confusing.
+  it("surfaces a toast when selectFile fails for a sidebar click", async () => {
+    stubDom();
+    const env = createEnv({
+      files: [
+        { path: "play.ds", name: "play.ds", updatedAt: "" },
+        { path: "dead.ds", name: "dead.ds", updatedAt: "" },
+      ],
+    });
+    env._setContent("play.ds", "old");
+    const originalRead = env.readLibraryFile;
+    env.readLibraryFile = async (p: string) => {
+      if (p === "dead.ds") throw new Error("ENOENT: no such file");
+      return originalRead(p);
+    };
+
+    const addToast = vi.fn();
+    const wrapper = mount(AppDesktop, {
+      props: { env },
+      global: {
+        stubs: {
+          ...globalStubs,
+          ToastManager: {
+            name: "ToastManager",
+            template: '<div />',
+            methods: { addToast },
+          },
+        },
+      },
+    });
+    await flushPromises();
+    addToast.mockClear();
+
+    const deadRow = wrapper.find('[data-testid="library-tree-row"][data-path="dead.ds"]');
+    deadRow.trigger("click");
+    await vi.advanceTimersByTimeAsync(0);
+    await flushPromises();
+
+    const errorCalls = addToast.mock.calls.filter((args) => args[1] === "error");
+    expect(errorCalls.length, `toast calls: ${JSON.stringify(addToast.mock.calls)}`).toBeGreaterThan(0);
+    expect(errorCalls[0][0]).toMatch(/dead\.ds/);
+  });
 });
 
 describe("AppDesktop revision compare", () => {

--- a/web/src/__tests__/desktop/appDesktop.test.ts
+++ b/web/src/__tests__/desktop/appDesktop.test.ts
@@ -288,6 +288,37 @@ describe("AppDesktop flush ordering", () => {
     expect(writeDone).toBeGreaterThanOrEqual(0);
     expect(readOther).toBeGreaterThan(writeDone);
   });
+
+  // M6: a programmatic file switch must NOT trigger the 1s autosave
+  // watcher to re-write the just-loaded bytes back to disk. Without the
+  // (file, content) sentinel, selecting "other.ds" would land its
+  // contents in activeContent, the watcher would fire, and 1s later we'd
+  // see a writeLibraryFile:other.ds with identical bytes — wasted I/O
+  // and a spurious dirty flicker. The fix: AppDesktop.markProgrammaticLoad
+  // suppresses the next tick when (file, content) matches.
+  it("programmatic file switch does NOT trigger autosave write to new file", async () => {
+    const { wrapper, env } = await mountApp({
+      files: [
+        { path: "play.ds", name: "play.ds", updatedAt: "" },
+        { path: "other.ds", name: "other.ds", updatedAt: "" },
+      ],
+    });
+    env._setContent("other.ds", "other-original-content");
+
+    // Click "other.ds" — a pure programmatic load, no prior user edit.
+    const otherRow = wrapper.find('[data-testid="library-tree-row"][data-path="other.ds"]');
+    otherRow.trigger("click");
+
+    // Let the autosave debounce (1s) fully fire, then any microtasks.
+    await vi.advanceTimersByTimeAsync(2500);
+    await flushPromises();
+
+    // The only writeLibraryFile in this scenario should be the initial
+    // flush of play.ds (if any). NO write to other.ds should appear —
+    // we just loaded it; writing it back would be a no-op disk hit.
+    const writesToOther = env._calls.filter((c) => c === "writeLibraryFile:other.ds");
+    expect(writesToOther).toEqual([]);
+  });
 });
 
 describe("AppDesktop revision compare", () => {

--- a/web/src/__tests__/desktop/command-palette.test.ts
+++ b/web/src/__tests__/desktop/command-palette.test.ts
@@ -1,8 +1,17 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import CommandPalette from "../../desktop/CommandPalette.vue";
 import type { CommandMeta, DesktopCapabilities, LibraryFile } from "../../desktop/types";
+
+// CommandPalette.vue imports dispatchCommand directly from
+// dispatcher-registry (not via env), so the spy has to live at the
+// module level. Mock it once for the whole file; tests that need to
+// assert dispatch behavior reach in via `mockDispatchCommand`.
+vi.mock("../../desktop/dispatcher-registry", () => ({
+  dispatchCommand: vi.fn(),
+}));
+import { dispatchCommand as mockDispatchCommand } from "../../desktop/dispatcher-registry";
 
 // Minimal env stub — only the palette-facing methods are exercised.
 function makeEnv(commands: CommandMeta[]): DesktopCapabilities {
@@ -20,6 +29,10 @@ const baseCommands: CommandMeta[] = [
 ];
 
 describe("CommandPalette", () => {
+  beforeEach(() => {
+    vi.mocked(mockDispatchCommand).mockClear();
+  });
+
   it("excludes paletteHidden commands and renders the rest", async () => {
     const wrapper = mount(CommandPalette, {
       props: {
@@ -55,7 +68,7 @@ describe("CommandPalette", () => {
     expect(labels[0]).toContain("Save Version");
   });
 
-  it("greys out disabled commands and refuses to execute them on click", async () => {
+  it("greys out disabled commands and refuses to execute them on click or Enter", async () => {
     const wrapper = mount(CommandPalette, {
       props: {
         open: true,
@@ -68,11 +81,37 @@ describe("CommandPalette", () => {
     await flushPromises();
     const items = wrapper.findAll("li");
     const saveItem = items.find((li) => li.text().includes("Save Version"))!;
+
+    // (a) User-visible disabled signal.
     expect(saveItem.classes().some((c) => c.includes("cursor-not-allowed"))).toBe(true);
-    // Click should not emit close (palette wouldn't close if the run
-    // was a no-op), and dispatcher-registry isn't touched. We can't
-    // spy on the registry easily from here; assert the cursor class
-    // serves as the user-visible disabled signal.
+
+    // (b) Click on the disabled row must NOT dispatch and must NOT
+    // close the palette.
+    await saveItem.trigger("click");
+    await flushPromises();
+    expect(mockDispatchCommand).not.toHaveBeenCalled();
+    expect(wrapper.emitted("close")).toBeFalsy();
+
+    // (c) Drive Enter against the disabled row specifically. The
+    // palette opens with the first row selected; ArrowDown to reach
+    // "Save Version" (third visible row in baseCommands order). Then
+    // press Enter on the input.
+    const input = wrapper.find("input");
+    await input.trigger("keydown", { key: "ArrowDown" });
+    await input.trigger("keydown", { key: "ArrowDown" });
+    // Cross-check selection landed on the disabled row before
+    // pressing Enter — otherwise the Enter assertion proves nothing.
+    // The palette flags the selected row with bg-brass-500/15.
+    const selected = wrapper.findAll("li").find((li) =>
+      li.classes().some((c) => c.includes("bg-brass-500/15")),
+    );
+    expect(selected, "no row appears visually selected").toBeTruthy();
+    expect(selected!.text()).toContain("Save Version");
+
+    await input.trigger("keydown", { key: "Enter" });
+    await flushPromises();
+    expect(mockDispatchCommand).not.toHaveBeenCalled();
+    expect(wrapper.emitted("close")).toBeFalsy();
   });
 
   it("emits close on Escape", async () => {

--- a/web/src/__tests__/desktop/commands.test.ts
+++ b/web/src/__tests__/desktop/commands.test.ts
@@ -60,6 +60,7 @@ function makeContext(overrides: Partial<CommandContext> = {}): CommandContext {
     isInCompareTwo,
     isViewingExternal,
     flushSave: async () => {},
+    markProgrammaticLoad: vi.fn(),
     editor: {
       applyFormat: vi.fn(),
       undo: vi.fn(),

--- a/web/src/__tests__/desktop/workspace.test.ts
+++ b/web/src/__tests__/desktop/workspace.test.ts
@@ -1118,4 +1118,76 @@ describe("Workspace", () => {
     ws.toggleFolderExpansion("a");
     expect(ws.state.expandedFolders.has("a")).toBe(false);
   });
+
+  // M7: selectFile must not commit destructive in-memory state until
+  // the throwing operations (readLibraryFile, setActiveLibraryFile)
+  // both succeed. A failure mid-flight leaves the UI showing the
+  // previous selection with its revision view + dirty timer intact.
+  describe("selectFile failure paths", () => {
+    it("preserves previous state when readLibraryFile throws", async () => {
+      stubLocalStorage();
+      const env = createEnv({
+        _files: [
+          { path: "first.ds", name: "first.ds", updatedAt: "" },
+          { path: "second.ds", name: "second.ds", updatedAt: "" },
+        ],
+        _contents: { "first.ds": "old contents", "first.ds@rev1": "older" },
+        _revisions: [{ hash: "rev1", path: "first.ds", message: "m", author: "a", timestamp: "" }],
+      });
+      const ws = new Workspace(env);
+
+      // Set up the pre-state: viewing a revision of first.ds + dirty
+      // timer scheduled (proxied via the unforgivable internal field).
+      await ws.selectFile("first.ds");
+      await ws.viewRevision("rev1");
+      const beforeViewing = ws.state.viewingRevisionHash;
+      expect(beforeViewing).toBe("rev1");
+
+      // Force readLibraryFile to throw on the SECOND file only.
+      const originalRead = env.readLibraryFile;
+      env.readLibraryFile = async (p: string) => {
+        if (p === "second.ds") throw new Error("simulated read failure");
+        return originalRead(p);
+      };
+
+      await expect(ws.selectFile("second.ds")).rejects.toThrow(/simulated/);
+
+      // State must be untouched: still viewing rev1 of first.ds.
+      expect(ws.state.activeFile).toBe("first.ds");
+      expect(ws.state.viewingRevisionHash).toBe("rev1");
+      expect(ws.state.isLoadingFile).toBe(false);
+    });
+
+    it("preserves previous state when setActiveLibraryFile throws", async () => {
+      stubLocalStorage();
+      const env = createEnv({
+        _files: [
+          { path: "first.ds", name: "first.ds", updatedAt: "" },
+          { path: "second.ds", name: "second.ds", updatedAt: "" },
+        ],
+        _contents: {
+          "first.ds": "old",
+          "first.ds@rev1": "older",
+          "second.ds": "new",
+        },
+        _revisions: [{ hash: "rev1", path: "first.ds", message: "m", author: "a", timestamp: "" }],
+      });
+      const ws = new Workspace(env);
+      await ws.selectFile("first.ds");
+      await ws.viewRevision("rev1");
+
+      // Read succeeds; config-write step fails (e.g., disk full mid-
+      // session). The persisted last-active wouldn't have moved, so the
+      // in-memory state mustn't move either — keep them in sync.
+      env.setActiveLibraryFile = async (p: string) => {
+        throw new Error(`simulated persist failure for ${p}`);
+      };
+
+      await expect(ws.selectFile("second.ds")).rejects.toThrow(/persist failure/);
+
+      expect(ws.state.activeFile).toBe("first.ds");
+      expect(ws.state.viewingRevisionHash).toBe("rev1");
+      expect(ws.state.isLoadingFile).toBe(false);
+    });
+  });
 });

--- a/web/src/__tests__/desktop/workspace.test.ts
+++ b/web/src/__tests__/desktop/workspace.test.ts
@@ -1189,5 +1189,40 @@ describe("Workspace", () => {
       expect(ws.state.viewingRevisionHash).toBe("rev1");
       expect(ws.state.isLoadingFile).toBe(false);
     });
+
+    // Failed reads usually mean the file vanished out-of-band (deleted
+    // in another tool, network share dropped, etc.). Refresh the tree
+    // on failure so a stale row stops occupying space in the sidebar.
+    it("refreshes the library tree when a read fails", async () => {
+      stubLocalStorage();
+      const env = createEnv({
+        _files: [
+          { path: "alive.ds", name: "alive.ds", updatedAt: "" },
+          { path: "gone.ds", name: "gone.ds", updatedAt: "" },
+        ],
+        _contents: { "alive.ds": "ok" },
+      });
+      const ws = new Workspace(env);
+      await ws.init();
+      expect(ws.libraryFiles.value.map((f) => f.path)).toContain("gone.ds");
+      await ws.selectFile("alive.ds");
+
+      // Simulate gone.ds being deleted from disk: read throws AND the
+      // file is removed from the filesystem stub so the post-failure
+      // refresh observes the new reality.
+      const originalRead = env.readLibraryFile;
+      env.readLibraryFile = async (p: string) => {
+        if (p === "gone.ds") throw new Error("ENOENT");
+        return originalRead(p);
+      };
+      env._files = env._files.filter((f) => f.path !== "gone.ds");
+
+      await expect(ws.selectFile("gone.ds")).rejects.toThrow(/ENOENT/);
+
+      // The tree refresh inside the catch must have run — gone.ds
+      // should no longer be in the sidebar list.
+      expect(ws.libraryFiles.value.map((f) => f.path)).not.toContain("gone.ds");
+      expect(ws.libraryFiles.value.map((f) => f.path)).toContain("alive.ds");
+    });
   });
 });

--- a/web/src/desktop-app.ts
+++ b/web/src/desktop-app.ts
@@ -41,13 +41,17 @@ const EVT_BEFORE_CLOSE = "downstage:before-close";
 const EVT_FLUSH_COMPLETE = "downstage:flush-complete";
 const EVT_COMMAND_EXECUTE = "command:execute";
 
-EventsOn(EVT_COMMAND_EXECUTE, (id: unknown) => {
+// EventsOn returns its unsubscribe function (see wailsjs/runtime/
+// runtime.d.ts). We capture both so HMR can dispose of the listeners
+// before a fresh module evaluation re-registers them; otherwise dev
+// reloads stack subscribers and every menu click dispatches N times.
+const cancelCommandEvent = EventsOn(EVT_COMMAND_EXECUTE, (id: unknown) => {
   if (typeof id === "string") {
     void dispatchCommand(id);
   }
 });
 
-EventsOn(EVT_BEFORE_CLOSE, async () => {
+const cancelBeforeCloseEvent = EventsOn(EVT_BEFORE_CLOSE, async () => {
   try {
     await invokeRegisteredFlushSave();
     await env.flushPreferences();
@@ -57,6 +61,15 @@ EventsOn(EVT_BEFORE_CLOSE, async () => {
     EventsEmit(EVT_FLUSH_COMPLETE);
   }
 });
+
+// Vite injects import.meta.hot only in dev; the guard makes this a
+// no-op in production builds.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    cancelCommandEvent();
+    cancelBeforeCloseEvent();
+  });
+}
 
 function normalizeLibraryNode(node: unknown): LibraryNode {
   const current = node as {

--- a/web/src/desktop/commands.ts
+++ b/web/src/desktop/commands.ts
@@ -20,6 +20,11 @@ export interface CommandContext {
   isInCompareTwo: Ref<boolean>;
   isViewingExternal: Ref<boolean>;
   flushSave: () => Promise<void>;
+  // Host-owned callback to suppress the autosave watcher's next tick
+  // when commands.ts assigns activeContent.value after a programmatic
+  // load. The host gates its autosave-watcher on a (file, content)
+  // sentinel; this is the wire to set it.
+  markProgrammaticLoad: (file: string, content: string) => void;
   editor: {
     applyFormat: (action: string) => void;
     undo: () => void;
@@ -52,7 +57,7 @@ export function createCommandHandlers(ctx: CommandContext): Array<[string, Handl
   const {
     env, store, workspace, toast, activeContent, editorContent,
     isV1Document, isViewingRevision, isInCompareTwo, isViewingExternal,
-    flushSave, editor, ui,
+    flushSave, markProgrammaticLoad, editor, ui,
   } = ctx;
 
   const hasActiveFile = () => !!workspace.state.activeFile;
@@ -83,7 +88,9 @@ export function createCommandHandlers(ctx: CommandContext): Array<[string, Handl
     await flushSave();
     try {
       const path = await workspace.createFile("Untitled Play", newPlayTemplate());
-      activeContent.value = await workspace.selectFile(path);
+      const content = await workspace.selectFile(path);
+      markProgrammaticLoad(path, content);
+      activeContent.value = content;
       toast.addToast("Created new play", "success");
     } catch (error: unknown) {
       toast.addToast(`Failed to create file: ${errorMessage(error)}`, "error");
@@ -161,7 +168,9 @@ export function createCommandHandlers(ctx: CommandContext): Array<[string, Handl
     const nextPath = files[nextIdx].path;
     void (async () => {
       await flushSave();
-      activeContent.value = await workspace.selectFile(nextPath);
+      const content = await workspace.selectFile(nextPath);
+      markProgrammaticLoad(nextPath, content);
+      activeContent.value = content;
     })();
   }
 

--- a/web/src/desktop/workspace.ts
+++ b/web/src/desktop/workspace.ts
@@ -145,8 +145,20 @@ export class Workspace {
       // and the user can recover. loadRevisions/refreshGitStatus run
       // AFTER the commit because they swallow errors internally and
       // can degrade gracefully.
-      const content = await this.env.readLibraryFile(path);
-      await this.env.setActiveLibraryFile(path);
+      let content: string;
+      try {
+        content = await this.env.readLibraryFile(path);
+        await this.env.setActiveLibraryFile(path);
+      } catch (error) {
+        // File may have been deleted or made unreadable out-of-band.
+        // Refresh the tree so a stale entry stops appearing in the
+        // sidebar. Tree-refresh failures are intentionally swallowed —
+        // the original error is what the caller needs to see.
+        try {
+          this.state.libraryTree = await this.env.getLibraryTree();
+        } catch { /* ignore */ }
+        throw error;
+      }
       this.state.externalFile = null;
       this.state.activeFile = path;
       this.clearRevisionView();

--- a/web/src/desktop/workspace.ts
+++ b/web/src/desktop/workspace.ts
@@ -137,14 +137,20 @@ export class Workspace {
   }
 
   async selectFile(path: string): Promise<string> {
-    this.state.externalFile = null;
-    this.state.activeFile = path;
-    this.clearRevisionView();
-    this.cancelDirtyReconcile();
     this.state.isLoadingFile = true;
     try {
+      // Throwing operations come first: a failure leaves activeFile,
+      // externalFile, viewing-revision state, and the dirty-reconcile
+      // timer untouched, so the UI still represents the old selection
+      // and the user can recover. loadRevisions/refreshGitStatus run
+      // AFTER the commit because they swallow errors internally and
+      // can degrade gracefully.
       const content = await this.env.readLibraryFile(path);
       await this.env.setActiveLibraryFile(path);
+      this.state.externalFile = null;
+      this.state.activeFile = path;
+      this.clearRevisionView();
+      this.cancelDirtyReconcile();
       await this.loadRevisions();
       await this.refreshGitStatus();
       return content;


### PR DESCRIPTION
## Summary

Closes the seven follow-ups deferred from PR #188 (alpha-desktop-app) to issue #189. Track A1 of the #189 work plan — all hygiene, no new features.

| Item | What it fixes |
|------|---------------|
| **H3** | `currentLibrary` now guarded by `sync.RWMutex`; writer Lock scoped to field swap only (never around the directory dialog) |
| **M6** | Autosave watcher skips programmatic file loads via a `(file, content)` sentinel |
| **M7** | `workspace.selectFile` reads first, mutates after — failed reads no longer nuke `externalFile` / revision view / dirty timer |
| **M9** | `desktop-app.ts` tears down `EventsOn` subscribers under `import.meta.hot.dispose` (fixes HMR duplicate-dispatch) |
| **T13** | Menu click callbacks now testable via injectable `CommandEmitter`; full menu walk verifies catalog ID mapping |
| **T14** | `TestReadLibraryFile_DoesNotWriteConfig` drops the mtime+sleep flake for byte-equality |
| **T15** | Palette disabled-row test now asserts no-dispatch + no-close on both click AND Enter |

## Test plan

- [x] `go test ./internal/desktop/ -race` clean (includes new `TestCurrentLibrary_RaceFree`: 8 readers × 200 iters × 200 swaps)
- [x] `npm --prefix web run test` — 195/195 pass
- [x] `make desktop-build` — clean binary built
- [x] Smoke test on the built binary: rapid file switching shows no dirty-dot flicker (M6); failed file open leaves prior state intact (M7)

Refs #189