### PR TITLE
feat(desktop): sidebar delete/restore + library-wide change reconciliation (Track A2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Extension Development Host.
 
 [`cmd/downstage-write/`](cmd/downstage-write/) is a native desktop build —
 the same Vue editor wrapped in a [Wails](https://wails.io/) shell with a
-project-folder workflow: open a directory, edit `.ds` files in place,
+single-library workflow: open a directory of `.ds` files, edit in place,
 snapshot revisions with git, and restore older versions from a native
 menu + command palette.
 

--- a/internal/desktop/app_test.go
+++ b/internal/desktop/app_test.go
@@ -608,7 +608,11 @@ func TestGetRevisions_IgnoresSiblingOnlyCommits(t *testing.T) {
 	require.NoError(t, a.WriteLibraryFile("other.ds", "other content"))
 	require.NoError(t, a.SnapshotFile("other.ds", "initial other"))
 
+	// Simulate a finalize-permanent-delete: remove the sibling and commit
+	// just that path. DeleteLibraryFile no longer commits (it's a soft
+	// delete now); the permanent path is CommitPaths after os.Remove.
 	require.NoError(t, a.DeleteLibraryFile("other.ds"))
+	require.NoError(t, a.CommitPaths([]string{"other.ds"}, "Delete other.ds"))
 
 	revisions, err := a.GetRevisions("play.ds", 0)
 	require.NoError(t, err)

--- a/internal/desktop/app_test.go
+++ b/internal/desktop/app_test.go
@@ -594,6 +594,28 @@ func TestGetRevisions_NoLibraryReturnsEmptySlice(t *testing.T) {
 	require.Len(t, revisions, 0)
 }
 
+// CommitPaths can produce a commit that touches a sibling file (e.g.
+// "Delete other.ds") while leaving the active file untouched. Such a
+// commit must NOT appear in the active file's revisions list — otherwise
+// the user sees a bogus "Delete other.ds" row that, when restored,
+// rewrites the active file to itself and appears to do nothing.
+func TestGetRevisions_IgnoresSiblingOnlyCommits(t *testing.T) {
+	a := testApp(t)
+
+	require.NoError(t, a.WriteLibraryFile("play.ds", "play content"))
+	require.NoError(t, a.SnapshotFile("play.ds", "initial play"))
+
+	require.NoError(t, a.WriteLibraryFile("other.ds", "other content"))
+	require.NoError(t, a.SnapshotFile("other.ds", "initial other"))
+
+	require.NoError(t, a.DeleteLibraryFile("other.ds"))
+
+	revisions, err := a.GetRevisions("play.ds", 0)
+	require.NoError(t, err)
+	require.Len(t, revisions, 1, "delete of sibling file must not appear in play.ds history")
+	assert.Equal(t, "initial play", revisions[0].Message)
+}
+
 func TestReadLibraryFile_BlocksTraversal(t *testing.T) {
 	a := testApp(t)
 

--- a/internal/desktop/commands.go
+++ b/internal/desktop/commands.go
@@ -76,7 +76,11 @@ const (
 	CmdInsertSong      = "insert.song"
 	CmdInsertPageBreak = "insert.pageBreak"
 
-	CmdLibraryNewFolder = "library.newFolder"
+	CmdLibraryNewFolder     = "library.newFolder"
+	CmdLibraryDelete        = "library.delete"
+	CmdLibraryRestore       = "library.restoreFile"
+	CmdLibraryReviewChanges = "library.reviewChanges"
+	CmdLibraryCommitChanges = "library.commitChanges"
 
 	CmdHelpToggle = "help.toggle"
 	CmdHelpGitHub = "help.github"
@@ -137,6 +141,10 @@ func Commands() []Command {
 		{ID: CmdFormatStrikethrough, Label: "Strikethrough", Category: CategoryFormat, Accelerator: "cmdorctrl+shift+x", MenuPath: []string{"Format"}},
 
 		{ID: CmdLibraryNewFolder, Label: "New Folder", Category: CategoryFile},
+		{ID: CmdLibraryDelete, Label: "Delete File…", Category: CategoryFile, PaletteHidden: true},
+		{ID: CmdLibraryRestore, Label: "Restore Deleted File", Category: CategoryFile, PaletteHidden: true},
+		{ID: CmdLibraryReviewChanges, Label: "Review Library Changes…", Category: CategoryFile},
+		{ID: CmdLibraryCommitChanges, Label: "Commit Library Changes", Category: CategoryFile, PaletteHidden: true},
 
 		{ID: CmdHelpToggle, Label: "View Help", Category: CategoryHelp, Accelerator: "cmdorctrl+shift+/", MenuPath: []string{"Help"}},
 		{ID: CmdHelpGitHub, Label: "GitHub", Category: CategoryHelp, MenuPath: []string{"Help"}, BeforeSeparator: true},

--- a/internal/desktop/git.go
+++ b/internal/desktop/git.go
@@ -127,7 +127,6 @@ func (a *App) GetRevisions(relPath string, limit int) ([]Revision, error) {
 	tracked := filepath.ToSlash(filepath.Clean(relPath))
 	revisions := make([]Revision, 0, limit)
 
-	firstCommit := true
 	errStop := errors.New("stop")
 
 	err = iter.ForEach(func(c *object.Commit) error {
@@ -156,12 +155,16 @@ func (a *App) GetRevisions(relPath string, limit int) ([]Revision, error) {
 			}
 		}
 
+		// A commit shows up in this file's history only when the commit
+		// actually touched it: either the root commit introduces it, or the
+		// blob differs from the parent. CommitPaths can produce commits that
+		// touch sibling files only — those must not appear in this file's
+		// revisions list (and they're not restorable, which is what trips up
+		// "Restore this version" if they sneak in).
 		includeCommit := false
 		switch {
 		case renameSource != "":
 			includeCommit = false
-		case firstCommit && !blob.IsZero():
-			includeCommit = true
 		case parent == nil && !blob.IsZero():
 			includeCommit = true
 		case blob != parentBlob:
@@ -189,7 +192,6 @@ func (a *App) GetRevisions(relPath string, limit int) ([]Revision, error) {
 			}
 		}
 
-		firstCommit = false
 		return nil
 	})
 	if err != nil && !errors.Is(err, errStop) {

--- a/internal/desktop/git.go
+++ b/internal/desktop/git.go
@@ -6,11 +6,14 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/format/index"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/storer"
 )
@@ -332,6 +335,257 @@ func lastCommitTimeForPath(r *git.Repository, relPath string) (string, bool) {
 		return "", false
 	}
 	return c.Author.When.UTC().Format(time.RFC3339), true
+}
+
+type DirtyKind string
+
+const (
+	DirtyUntracked DirtyKind = "untracked"
+	DirtyModified  DirtyKind = "modified"
+	DirtyDeleted   DirtyKind = "deleted"
+)
+
+type DirtyPath struct {
+	Path string    `json:"path"`
+	Kind DirtyKind `json:"kind"`
+}
+
+type LibraryDirty struct {
+	Plays    []DirtyPath `json:"plays"`
+	Sidecars []DirtyPath `json:"sidecars"`
+	Other    []DirtyPath `json:"other"`
+	Count    int         `json:"count"`
+}
+
+const downstageSidecarPrefix = ".downstage/"
+
+func (a *App) GetLibraryDirty() (LibraryDirty, error) {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
+	empty := LibraryDirty{Plays: []DirtyPath{}, Sidecars: []DirtyPath{}, Other: []DirtyPath{}}
+	if a.currentLibrary == "" {
+		return empty, nil
+	}
+
+	r, err := git.PlainOpen(a.currentLibrary)
+	if errors.Is(err, git.ErrRepositoryNotExists) {
+		return empty, nil
+	}
+	if err != nil {
+		return empty, err
+	}
+	w, err := r.Worktree()
+	if err != nil {
+		return empty, err
+	}
+	status, err := w.Status()
+	if err != nil {
+		return empty, err
+	}
+
+	out := empty
+	for path, entry := range status {
+		if entry.Staging == git.Unmodified && entry.Worktree == git.Unmodified {
+			continue
+		}
+		kind := classifyDirty(entry)
+		dp := DirtyPath{Path: path, Kind: kind}
+		switch {
+		case strings.HasPrefix(path, downstageSidecarPrefix):
+			out.Sidecars = append(out.Sidecars, dp)
+		case strings.HasSuffix(path, ".ds"):
+			out.Plays = append(out.Plays, dp)
+		default:
+			out.Other = append(out.Other, dp)
+		}
+	}
+	sortDirty(out.Plays)
+	sortDirty(out.Sidecars)
+	sortDirty(out.Other)
+	out.Count = len(out.Plays) + len(out.Sidecars) + len(out.Other)
+	return out, nil
+}
+
+func classifyDirty(entry *git.FileStatus) DirtyKind {
+	// Worktree state takes priority — it's what the user sees.
+	switch entry.Worktree {
+	case git.Untracked:
+		return DirtyUntracked
+	case git.Deleted:
+		return DirtyDeleted
+	}
+	switch entry.Staging {
+	case git.Untracked:
+		return DirtyUntracked
+	case git.Deleted:
+		return DirtyDeleted
+	}
+	return DirtyModified
+}
+
+func sortDirty(s []DirtyPath) {
+	sort.SliceStable(s, func(i, j int) bool { return s[i].Path < s[j].Path })
+}
+
+// CommitPaths stages exactly the paths provided (Add for paths that exist on
+// disk, Remove for paths that have been deleted) and commits once with the
+// given message. Returns ErrNothingToSnapshot if no path produced a change.
+func (a *App) CommitPaths(paths []string, message string) error {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
+	return a.commitPathsLocked(paths, message)
+}
+
+// commitPathsLocked is the lock-free body of CommitPaths. CALLER MUST HOLD
+// a.libMu (read or write). Use this from inside other locked methods to
+// avoid re-acquiring the lock (Go's sync.RWMutex doesn't recurse safely).
+func (a *App) commitPathsLocked(paths []string, message string) error {
+	if len(paths) == 0 {
+		return fmt.Errorf("no paths provided")
+	}
+	if strings.TrimSpace(message) == "" {
+		return fmt.Errorf("commit message is empty")
+	}
+	if a.currentLibrary == "" {
+		return fmt.Errorf("no library open")
+	}
+
+	r, err := git.PlainOpen(a.currentLibrary)
+	if errors.Is(err, git.ErrRepositoryNotExists) {
+		r, err = git.PlainInit(a.currentLibrary, false)
+	}
+	if err != nil {
+		return err
+	}
+	w, err := r.Worktree()
+	if err != nil {
+		return err
+	}
+
+	for _, p := range paths {
+		clean := filepath.ToSlash(filepath.Clean(p))
+		if _, err := a.safePath(clean); err != nil {
+			return fmt.Errorf("path %q: %w", p, err)
+		}
+		fullPath := filepath.Join(a.currentLibrary, clean)
+		if _, statErr := os.Stat(fullPath); statErr == nil {
+			if _, err := w.Add(clean); err != nil {
+				return fmt.Errorf("add %q: %w", clean, err)
+			}
+		} else if errors.Is(statErr, fs.ErrNotExist) {
+			// File missing on disk: stage the deletion. If the path was
+			// untracked (never in the index), Remove errors with
+			// ErrEntryNotFound — that just means there's nothing to commit
+			// for this path, which is fine for the batch.
+			if _, err := w.Remove(clean); err != nil && !errors.Is(err, index.ErrEntryNotFound) {
+				return fmt.Errorf("remove %q: %w", clean, err)
+			}
+		} else {
+			return fmt.Errorf("stat %q: %w", clean, statErr)
+		}
+	}
+
+	status, err := w.Status()
+	if err != nil {
+		return err
+	}
+	if status.IsClean() {
+		return ErrNothingToSnapshot
+	}
+
+	_, err = w.Commit(message, &git.CommitOptions{Author: snapshotAuthor(r)})
+	return err
+}
+
+// DiscardPaths reverts each path to its HEAD state without committing.
+// Per-kind dispatch: untracked files are removed from disk, modified and
+// deleted files are restored from HEAD.
+func (a *App) DiscardPaths(paths []string) error {
+	if len(paths) == 0 {
+		return fmt.Errorf("no paths provided")
+	}
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
+	if a.currentLibrary == "" {
+		return fmt.Errorf("no library open")
+	}
+
+	r, err := git.PlainOpen(a.currentLibrary)
+	if errors.Is(err, git.ErrRepositoryNotExists) {
+		return fmt.Errorf("library is not a git repository")
+	}
+	if err != nil {
+		return err
+	}
+	w, err := r.Worktree()
+	if err != nil {
+		return err
+	}
+	status, err := w.Status()
+	if err != nil {
+		return err
+	}
+
+	for _, p := range paths {
+		clean := filepath.ToSlash(filepath.Clean(p))
+		if _, err := a.safePath(clean); err != nil {
+			return fmt.Errorf("path %q: %w", p, err)
+		}
+		entry, ok := status[clean]
+		if !ok {
+			continue
+		}
+		kind := classifyDirty(entry)
+		switch kind {
+		case DirtyUntracked:
+			fullPath := filepath.Join(a.currentLibrary, clean)
+			if err := os.Remove(fullPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				return fmt.Errorf("remove untracked %q: %w", clean, err)
+			}
+		case DirtyModified, DirtyDeleted:
+			if err := restoreFromHEAD(r, a.currentLibrary, clean); err != nil {
+				return fmt.Errorf("restore %q: %w", clean, err)
+			}
+			if _, err := w.Add(clean); err != nil {
+				return fmt.Errorf("re-stage %q: %w", clean, err)
+			}
+		}
+	}
+	return nil
+}
+
+// restoreFromHEAD reads the blob for relPath from HEAD's tree and writes it
+// to disk at root/relPath. Caller is responsible for re-staging via w.Add.
+// Returns an error if relPath does not exist in HEAD.
+func restoreFromHEAD(r *git.Repository, root, relPath string) error {
+	head, err := r.Head()
+	if err != nil {
+		return fmt.Errorf("read HEAD: %w", err)
+	}
+	commit, err := r.CommitObject(head.Hash())
+	if err != nil {
+		return fmt.Errorf("load HEAD commit: %w", err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return fmt.Errorf("HEAD tree: %w", err)
+	}
+	file, err := tree.File(relPath)
+	if err != nil {
+		return fmt.Errorf("file not in HEAD: %w", err)
+	}
+	contents, err := file.Contents()
+	if err != nil {
+		return fmt.Errorf("read blob: %w", err)
+	}
+	fullPath := filepath.Join(root, relPath)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+	if err := os.WriteFile(fullPath, []byte(contents), 0644); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	return nil
 }
 
 func (a *App) ReadFileAtRevision(relPath string, hash string) (string, error) {

--- a/internal/desktop/git_test.go
+++ b/internal/desktop/git_test.go
@@ -285,28 +285,37 @@ func TestDiscardPaths_RestoresModifiedAndDeleted_RemovesUntracked(t *testing.T) 
 
 // --- DeleteLibraryFile / RestoreLibraryFile ---
 
-func TestDeleteLibraryFile_RemovesAndCommits(t *testing.T) {
+// DeleteLibraryFile is a SOFT delete for tracked files — it removes the
+// file from disk but does NOT commit, so the deletion sits as worktree
+// status=Deleted and the Deleted section in the sidebar can offer a
+// Restore. Permanent deletion is a separate user action (CommitPaths via
+// the Deleted section's right-click "Permanently delete").
+func TestDeleteLibraryFile_TrackedFileSoftDelete(t *testing.T) {
 	isolateGitIdentity(t)
 	a := testApp(t)
 	require.NoError(t, a.WriteLibraryFile("doomed.ds", "bye"))
 	require.NoError(t, a.SnapshotFile("doomed.ds", "seed"))
 
+	r, err := git.PlainOpen(a.currentLibrary)
+	require.NoError(t, err)
+	headBefore, err := r.Head()
+	require.NoError(t, err)
+
 	require.NoError(t, a.DeleteLibraryFile("doomed.ds"))
 
-	_, err := os.Stat(filepath.Join(a.currentLibrary, "doomed.ds"))
+	_, err = os.Stat(filepath.Join(a.currentLibrary, "doomed.ds"))
 	assert.True(t, os.IsNotExist(err), "file removed from disk")
 
 	dirty, err := a.GetLibraryDirty()
 	require.NoError(t, err)
-	assert.Equal(t, 0, dirty.Count, "deletion was committed; no dirty state remains")
+	require.Equal(t, 1, dirty.Count, "deletion should show as a single dirty path")
+	require.Len(t, dirty.Plays, 1)
+	assert.Equal(t, "doomed.ds", dirty.Plays[0].Path)
+	assert.Equal(t, DirtyDeleted, dirty.Plays[0].Kind)
 
-	r, err := git.PlainOpen(a.currentLibrary)
+	headAfter, err := r.Head()
 	require.NoError(t, err)
-	ref, err := r.Head()
-	require.NoError(t, err)
-	c, err := r.CommitObject(ref.Hash())
-	require.NoError(t, err)
-	assert.Contains(t, c.Message, "Delete doomed.ds")
+	assert.Equal(t, headBefore.Hash(), headAfter.Hash(), "soft delete must not create a new commit")
 }
 
 func TestDeleteLibraryFile_UntrackedFileRemovedWithoutCommit(t *testing.T) {
@@ -330,6 +339,12 @@ func TestDeleteLibraryFile_UntrackedFileRemovedWithoutCommit(t *testing.T) {
 	c, err := r.CommitObject(ref.Hash())
 	require.NoError(t, err)
 	assert.Equal(t, "seed", c.Message, "untracked deletion should not create a commit")
+
+	// Untracked file leaves nothing behind in the dirty surface — there's
+	// no HEAD blob to restore from, so it's just gone.
+	dirty, err := a.GetLibraryDirty()
+	require.NoError(t, err)
+	assert.Equal(t, 0, dirty.Count, "untracked deletion leaves no dirty state")
 }
 
 func TestDeleteLibraryFile_RejectsDirectoryAndNonDs(t *testing.T) {

--- a/internal/desktop/git_test.go
+++ b/internal/desktop/git_test.go
@@ -138,3 +138,247 @@ func TestGetFileGitStatus_NoLibrary(t *testing.T) {
 	_, err := a.GetFileGitStatus("play.ds")
 	assert.Error(t, err)
 }
+
+// --- GetLibraryDirty / CommitPaths / DiscardPaths ---
+
+func TestGetLibraryDirty_CategorizesAndDetectsKinds(t *testing.T) {
+	isolateGitIdentity(t)
+	a := testApp(t)
+
+	// Seed: tracked play, then create dirty state of every kind.
+	require.NoError(t, a.WriteLibraryFile("act-one.ds", "v1"))
+	require.NoError(t, a.WriteLibraryFile("act-two.ds", "v1"))
+	require.NoError(t, a.SnapshotFile("act-one.ds", "initial one"))
+	require.NoError(t, a.SnapshotFile("act-two.ds", "initial two"))
+
+	// Modify act-one (modified), delete act-two (deleted), add new untracked.
+	require.NoError(t, a.WriteLibraryFile("act-one.ds", "v2"))
+	require.NoError(t, os.Remove(filepath.Join(a.currentLibrary, "act-two.ds")))
+	require.NoError(t, a.WriteLibraryFile("act-three.ds", "fresh"))
+
+	// Sidecar (the dictionary file): write directly via the library API,
+	// which leaves it uncommitted.
+	require.NoError(t, os.MkdirAll(filepath.Join(a.currentLibrary, ".downstage"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(a.currentLibrary, ".downstage/dictionary.txt"), []byte("word"), 0644))
+
+	// "Other" — non-.ds file outside .downstage.
+	require.NoError(t, os.WriteFile(filepath.Join(a.currentLibrary, "notes.md"), []byte("hi"), 0644))
+
+	dirty, err := a.GetLibraryDirty()
+	require.NoError(t, err)
+
+	kindByPath := func(paths []DirtyPath) map[string]DirtyKind {
+		m := map[string]DirtyKind{}
+		for _, p := range paths {
+			m[p.Path] = p.Kind
+		}
+		return m
+	}
+	plays := kindByPath(dirty.Plays)
+	assert.Equal(t, DirtyModified, plays["act-one.ds"], "act-one is modified")
+	assert.Equal(t, DirtyDeleted, plays["act-two.ds"], "act-two is deleted")
+	assert.Equal(t, DirtyUntracked, plays["act-three.ds"], "act-three is untracked")
+
+	sidecars := kindByPath(dirty.Sidecars)
+	assert.Equal(t, DirtyUntracked, sidecars[".downstage/dictionary.txt"], "sidecar surfaces in its own bucket")
+
+	other := kindByPath(dirty.Other)
+	assert.Equal(t, DirtyUntracked, other["notes.md"], "notes.md falls into Other")
+
+	assert.Equal(t, len(dirty.Plays)+len(dirty.Sidecars)+len(dirty.Other), dirty.Count)
+}
+
+func TestGetLibraryDirty_CleanRepoIsEmpty(t *testing.T) {
+	isolateGitIdentity(t)
+	a := testApp(t)
+	require.NoError(t, a.WriteLibraryFile("play.ds", "v1"))
+	require.NoError(t, a.SnapshotFile("play.ds", "initial"))
+
+	dirty, err := a.GetLibraryDirty()
+	require.NoError(t, err)
+	assert.Equal(t, 0, dirty.Count)
+}
+
+func TestGetLibraryDirty_NoRepoIsEmpty(t *testing.T) {
+	a := testApp(t)
+	dirty, err := a.GetLibraryDirty()
+	require.NoError(t, err)
+	assert.Equal(t, 0, dirty.Count, "no repo means no dirty surface yet")
+}
+
+func TestCommitPaths_BatchesAddAndRemoveIntoOneCommit(t *testing.T) {
+	isolateGitIdentity(t)
+	a := testApp(t)
+	require.NoError(t, a.WriteLibraryFile("a.ds", "v1"))
+	require.NoError(t, a.WriteLibraryFile("b.ds", "v1"))
+	require.NoError(t, a.SnapshotFile("a.ds", "seed a"))
+	require.NoError(t, a.SnapshotFile("b.ds", "seed b"))
+
+	// Modify a.ds, delete b.ds, add new c.ds.
+	require.NoError(t, a.WriteLibraryFile("a.ds", "v2"))
+	require.NoError(t, os.Remove(filepath.Join(a.currentLibrary, "b.ds")))
+	require.NoError(t, a.WriteLibraryFile("c.ds", "fresh"))
+
+	require.NoError(t, a.CommitPaths([]string{"a.ds", "b.ds", "c.ds"}, "Batch cleanup"))
+
+	dirty, err := a.GetLibraryDirty()
+	require.NoError(t, err)
+	assert.Equal(t, 0, dirty.Count, "all three paths should be clean after CommitPaths")
+
+	// A single new commit should be on HEAD with our message.
+	r, err := git.PlainOpen(a.currentLibrary)
+	require.NoError(t, err)
+	ref, err := r.Head()
+	require.NoError(t, err)
+	c, err := r.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	assert.Equal(t, "Batch cleanup", c.Message)
+}
+
+func TestCommitPaths_NothingToCommitReturnsSentinel(t *testing.T) {
+	isolateGitIdentity(t)
+	a := testApp(t)
+	require.NoError(t, a.WriteLibraryFile("play.ds", "v1"))
+	require.NoError(t, a.SnapshotFile("play.ds", "seed"))
+
+	err := a.CommitPaths([]string{"play.ds"}, "noop")
+	assert.ErrorIs(t, err, ErrNothingToSnapshot)
+}
+
+func TestCommitPaths_RejectsEmptyInput(t *testing.T) {
+	a := testApp(t)
+	assert.Error(t, a.CommitPaths(nil, "msg"))
+	assert.Error(t, a.CommitPaths([]string{"play.ds"}, ""))
+}
+
+func TestDiscardPaths_RestoresModifiedAndDeleted_RemovesUntracked(t *testing.T) {
+	isolateGitIdentity(t)
+	a := testApp(t)
+	require.NoError(t, a.WriteLibraryFile("mod.ds", "v1"))
+	require.NoError(t, a.WriteLibraryFile("gone.ds", "v1"))
+	require.NoError(t, a.SnapshotFile("mod.ds", "seed mod"))
+	require.NoError(t, a.SnapshotFile("gone.ds", "seed gone"))
+
+	// Modify mod, delete gone, add new untracked.
+	require.NoError(t, a.WriteLibraryFile("mod.ds", "DIRTY"))
+	require.NoError(t, os.Remove(filepath.Join(a.currentLibrary, "gone.ds")))
+	require.NoError(t, a.WriteLibraryFile("new.ds", "throwaway"))
+
+	require.NoError(t, a.DiscardPaths([]string{"mod.ds", "gone.ds", "new.ds"}))
+
+	// mod.ds should now match HEAD ("v1"), gone.ds should be back, new.ds removed.
+	modContent, err := a.ReadLibraryFile("mod.ds")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", modContent)
+
+	goneContent, err := a.ReadLibraryFile("gone.ds")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", goneContent)
+
+	_, err = os.Stat(filepath.Join(a.currentLibrary, "new.ds"))
+	assert.True(t, os.IsNotExist(err), "untracked new.ds should be removed from disk")
+
+	dirty, err := a.GetLibraryDirty()
+	require.NoError(t, err)
+	assert.Equal(t, 0, dirty.Count, "worktree should be clean after discard")
+}
+
+// --- DeleteLibraryFile / RestoreLibraryFile ---
+
+func TestDeleteLibraryFile_RemovesAndCommits(t *testing.T) {
+	isolateGitIdentity(t)
+	a := testApp(t)
+	require.NoError(t, a.WriteLibraryFile("doomed.ds", "bye"))
+	require.NoError(t, a.SnapshotFile("doomed.ds", "seed"))
+
+	require.NoError(t, a.DeleteLibraryFile("doomed.ds"))
+
+	_, err := os.Stat(filepath.Join(a.currentLibrary, "doomed.ds"))
+	assert.True(t, os.IsNotExist(err), "file removed from disk")
+
+	dirty, err := a.GetLibraryDirty()
+	require.NoError(t, err)
+	assert.Equal(t, 0, dirty.Count, "deletion was committed; no dirty state remains")
+
+	r, err := git.PlainOpen(a.currentLibrary)
+	require.NoError(t, err)
+	ref, err := r.Head()
+	require.NoError(t, err)
+	c, err := r.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	assert.Contains(t, c.Message, "Delete doomed.ds")
+}
+
+func TestDeleteLibraryFile_UntrackedFileRemovedWithoutCommit(t *testing.T) {
+	isolateGitIdentity(t)
+	a := testApp(t)
+	// Init repo with an unrelated file so HEAD exists.
+	require.NoError(t, a.WriteLibraryFile("anchor.ds", "x"))
+	require.NoError(t, a.SnapshotFile("anchor.ds", "seed"))
+
+	require.NoError(t, a.WriteLibraryFile("scratch.ds", "throwaway"))
+	require.NoError(t, a.DeleteLibraryFile("scratch.ds"))
+
+	_, err := os.Stat(filepath.Join(a.currentLibrary, "scratch.ds"))
+	assert.True(t, os.IsNotExist(err))
+
+	// No new commit beyond the seed.
+	r, err := git.PlainOpen(a.currentLibrary)
+	require.NoError(t, err)
+	ref, err := r.Head()
+	require.NoError(t, err)
+	c, err := r.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	assert.Equal(t, "seed", c.Message, "untracked deletion should not create a commit")
+}
+
+func TestDeleteLibraryFile_RejectsDirectoryAndNonDs(t *testing.T) {
+	isolateGitIdentity(t)
+	a := testApp(t)
+	require.NoError(t, os.MkdirAll(filepath.Join(a.currentLibrary, "subdir"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(a.currentLibrary, "notes.md"), []byte("hi"), 0644))
+
+	assert.Error(t, a.DeleteLibraryFile("subdir"), "directories rejected")
+	assert.Error(t, a.DeleteLibraryFile("notes.md"), "non-.ds files rejected")
+}
+
+func TestRestoreLibraryFile_ReturnsDeletedFileFromHEAD(t *testing.T) {
+	isolateGitIdentity(t)
+	a := testApp(t)
+	require.NoError(t, a.WriteLibraryFile("revive.ds", "saved content"))
+	require.NoError(t, a.SnapshotFile("revive.ds", "seed"))
+
+	// Out-of-band delete.
+	require.NoError(t, os.Remove(filepath.Join(a.currentLibrary, "revive.ds")))
+
+	require.NoError(t, a.RestoreLibraryFile("revive.ds"))
+
+	content, err := a.ReadLibraryFile("revive.ds")
+	require.NoError(t, err)
+	assert.Equal(t, "saved content", content)
+
+	dirty, err := a.GetLibraryDirty()
+	require.NoError(t, err)
+	assert.Equal(t, 0, dirty.Count, "restore should leave the worktree clean")
+}
+
+func TestRestoreLibraryFile_RefusesWhenFileIsModifiedNotDeleted(t *testing.T) {
+	isolateGitIdentity(t)
+	a := testApp(t)
+	require.NoError(t, a.WriteLibraryFile("play.ds", "v1"))
+	require.NoError(t, a.SnapshotFile("play.ds", "seed"))
+	require.NoError(t, a.WriteLibraryFile("play.ds", "v2-LOCAL"))
+
+	err := a.RestoreLibraryFile("play.ds")
+	assert.Error(t, err, "modified files should not be silently overwritten via Restore")
+}
+
+func TestRestoreLibraryFile_RefusesUnknownPath(t *testing.T) {
+	isolateGitIdentity(t)
+	a := testApp(t)
+	require.NoError(t, a.WriteLibraryFile("seed.ds", "x"))
+	require.NoError(t, a.SnapshotFile("seed.ds", "anchor"))
+
+	err := a.RestoreLibraryFile("never-existed.ds")
+	assert.Error(t, err)
+}

--- a/internal/desktop/library.go
+++ b/internal/desktop/library.go
@@ -301,6 +301,94 @@ func (a *App) commitMove(srcPaths []string, dstRel string) error {
 	return nil
 }
 
+// DeleteLibraryFile removes a single .ds file from disk and commits the
+// deletion. Sibling changes are intentionally NOT picked up — the snapshot/
+// review-changes flows are the explicit paths for those.
+func (a *App) DeleteLibraryFile(relPath string) error {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
+	if a.currentLibrary == "" {
+		return fmt.Errorf("no library open")
+	}
+	clean := filepath.ToSlash(filepath.Clean(relPath))
+	if !strings.HasSuffix(clean, ".ds") {
+		return fmt.Errorf("only .ds files can be deleted via this API")
+	}
+	fullPath, err := a.safePath(clean)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return fmt.Errorf("stat: %w", err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("path is a directory; use MoveLibraryEntry for folders")
+	}
+	if err := os.Remove(fullPath); err != nil {
+		return fmt.Errorf("remove: %w", err)
+	}
+	name := filepath.Base(clean)
+	msg := fmt.Sprintf("Delete %s", name)
+	if err := a.commitPathsLocked([]string{clean}, msg); err != nil {
+		if errors.Is(err, ErrNothingToSnapshot) {
+			// File was never tracked — disk removal is the whole job.
+			return nil
+		}
+		slog.Warn("delete: commit failed (file removed from disk)", "path", clean, "err", err)
+		return fmt.Errorf("commit deletion: %w", err)
+	}
+	return nil
+}
+
+// RestoreLibraryFile reads the path's HEAD blob and writes it back to disk,
+// re-staging the file so the worktree returns to clean. Precondition: the
+// path must currently be in Deleted state in the worktree. Restore over a
+// Modified file is rejected — the user should use DiscardPaths instead so
+// they can opt into losing local changes explicitly.
+func (a *App) RestoreLibraryFile(relPath string) error {
+	a.libMu.RLock()
+	defer a.libMu.RUnlock()
+	if a.currentLibrary == "" {
+		return fmt.Errorf("no library open")
+	}
+	clean := filepath.ToSlash(filepath.Clean(relPath))
+	if _, err := a.safePath(clean); err != nil {
+		return err
+	}
+
+	r, err := git.PlainOpen(a.currentLibrary)
+	if errors.Is(err, git.ErrRepositoryNotExists) {
+		return fmt.Errorf("library is not a git repository")
+	}
+	if err != nil {
+		return err
+	}
+	w, err := r.Worktree()
+	if err != nil {
+		return err
+	}
+	status, err := w.Status()
+	if err != nil {
+		return err
+	}
+	entry, ok := status[clean]
+	if !ok {
+		return fmt.Errorf("file %q is not in a restorable state", clean)
+	}
+	if classifyDirty(entry) != DirtyDeleted {
+		return fmt.Errorf("file %q is not deleted (use DiscardPaths to revert modifications)", clean)
+	}
+
+	if err := restoreFromHEAD(r, a.currentLibrary, clean); err != nil {
+		return err
+	}
+	if _, err := w.Add(clean); err != nil {
+		return fmt.Errorf("re-stage: %w", err)
+	}
+	return nil
+}
+
 func (a *App) RenameLibraryEntry(srcRel, newName string) (string, error) {
 	if newName == "" {
 		return "", fmt.Errorf("new name is empty")

--- a/internal/desktop/library.go
+++ b/internal/desktop/library.go
@@ -301,8 +301,13 @@ func (a *App) commitMove(srcPaths []string, dstRel string) error {
 	return nil
 }
 
-// DeleteLibraryFile removes a single .ds file from disk and commits the
-// deletion. Sibling changes are intentionally NOT picked up — the snapshot/
+// DeleteLibraryFile removes a single .ds file from disk WITHOUT committing
+// the deletion. For tracked files this leaves the worktree in a
+// status=Deleted state — the UI surfaces it in the Deleted section so the
+// user can Restore (from HEAD) or Permanently delete (commit). Untracked
+// files are gone for good, since there's no HEAD blob to restore from.
+//
+// Sibling changes are intentionally NOT picked up — the snapshot /
 // review-changes flows are the explicit paths for those.
 func (a *App) DeleteLibraryFile(relPath string) error {
 	a.libMu.RLock()
@@ -327,16 +332,6 @@ func (a *App) DeleteLibraryFile(relPath string) error {
 	}
 	if err := os.Remove(fullPath); err != nil {
 		return fmt.Errorf("remove: %w", err)
-	}
-	name := filepath.Base(clean)
-	msg := fmt.Sprintf("Delete %s", name)
-	if err := a.commitPathsLocked([]string{clean}, msg); err != nil {
-		if errors.Is(err, ErrNothingToSnapshot) {
-			// File was never tracked — disk removal is the whole job.
-			return nil
-		}
-		slog.Warn("delete: commit failed (file removed from disk)", "path", clean, "err", err)
-		return fmt.Errorf("commit deletion: %w", err)
 	}
 	return nil
 }

--- a/web/src/AppDesktop.vue
+++ b/web/src/AppDesktop.vue
@@ -21,6 +21,7 @@ import CommandPalette from './desktop/CommandPalette.vue';
 import Settings from './desktop/Settings.vue';
 import LibraryTree from './desktop/LibraryTree.vue';
 import PromptModal from './desktop/PromptModal.vue';
+import ConfirmModal from './desktop/ConfirmModal.vue';
 import StatusBar from './desktop/StatusBar.vue';
 import ReviewChangesModal from './desktop/ReviewChangesModal.vue';
 import ExportPdfModal from './components/shared/ExportPdfModal.vue';
@@ -151,6 +152,33 @@ const newFolderError = ref<string | null>(null);
 const reviewChangesOpen = ref(false);
 const reviewBusy = ref(false);
 
+interface ConfirmConfig {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  destructive: boolean;
+  onConfirm: () => void | Promise<void>;
+}
+const confirmOpen = ref(false);
+const confirmConfig = ref<ConfirmConfig | null>(null);
+
+function askConfirm(config: ConfirmConfig) {
+  confirmConfig.value = config;
+  confirmOpen.value = true;
+}
+
+async function onConfirmAccepted() {
+  const cfg = confirmConfig.value;
+  confirmOpen.value = false;
+  confirmConfig.value = null;
+  if (cfg) await cfg.onConfirm();
+}
+
+function onConfirmClosed() {
+  confirmOpen.value = false;
+  confirmConfig.value = null;
+}
+
 function openReviewChanges() {
   if (!workspace.state.libraryPath) return;
   void workspace.refreshLibraryDirty();
@@ -181,16 +209,21 @@ async function onReviewDiscard(paths: string[]) {
   }
 }
 
-async function requestDeleteFromTree(path: string) {
+function requestDeleteFromTree(path: string) {
   const name = path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path;
-  if (!confirm(`Delete ${name}? Git history is preserved — the file can be restored from the Deleted section.`)) return;
-  await performDelete(path);
+  askConfirm({
+    title: `Delete ${name}?`,
+    message: `Git history is preserved — the file can be restored from the Deleted section.`,
+    confirmLabel: 'Delete',
+    destructive: true,
+    onConfirm: () => performDelete(path),
+  });
 }
 
 function requestDeleteActiveFile() {
   const path = workspace.state.activeFile;
   if (!path) return;
-  void requestDeleteFromTree(path);
+  requestDeleteFromTree(path);
 }
 
 async function performDelete(path: string) {
@@ -224,17 +257,25 @@ async function requestRestoreFromTree(path: string) {
   }
 }
 
-async function requestPermanentDeleteFromTree(path: string) {
-  if (!confirm(`Permanently remove ${path}. Git history is preserved but the file will no longer appear in your library.`)) return;
-  reviewBusy.value = true;
-  try {
-    await workspace.commitDirtyPaths([path], `Delete ${path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path}`);
-    toastManager.value?.addToast(`Permanently deleted ${path}`, 'success');
-  } catch (error: unknown) {
-    toastManager.value?.addToast(`Permanent delete failed: ${errorMessage(error)}`, 'error');
-  } finally {
-    reviewBusy.value = false;
-  }
+function requestPermanentDeleteFromTree(path: string) {
+  const name = path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path;
+  askConfirm({
+    title: 'Permanently delete?',
+    message: `Permanently remove ${path}.\n\nGit history is preserved but the file will no longer appear in your library.`,
+    confirmLabel: 'Permanently delete',
+    destructive: true,
+    onConfirm: async () => {
+      reviewBusy.value = true;
+      try {
+        await workspace.commitDirtyPaths([path], `Delete ${name}`);
+        toastManager.value?.addToast(`Permanently deleted ${path}`, 'success');
+      } catch (error: unknown) {
+        toastManager.value?.addToast(`Permanent delete failed: ${errorMessage(error)}`, 'error');
+      } finally {
+        reviewBusy.value = false;
+      }
+    },
+  });
 }
 
 function openNewFolderPrompt(parentPath = '') {
@@ -1020,6 +1061,16 @@ watch(activeContent, (newContent) => {
       hide-page-size
       @close="exportDialogOpen = false"
       @confirm="handleExportConfirmed"
+    />
+    <ConfirmModal
+      v-if="confirmConfig"
+      :open="confirmOpen"
+      :title="confirmConfig.title"
+      :message="confirmConfig.message"
+      :confirm-label="confirmConfig.confirmLabel"
+      :destructive="confirmConfig.destructive"
+      @close="onConfirmClosed"
+      @confirm="onConfirmAccepted"
     />
   </div>
 </template>

--- a/web/src/AppDesktop.vue
+++ b/web/src/AppDesktop.vue
@@ -955,7 +955,7 @@ watch(activeContent, (newContent) => {
                 type="button"
                 @click="workspace.toggleSidebar()"
                 class="p-1.5 rounded-md hover:bg-black/5 dark:hover:bg-white/5 text-text-muted transition-colors"
-                :title="workspace.state.sidebarCollapsed ? 'Open Projects' : 'Close Projects'"
+                :title="workspace.state.sidebarCollapsed ? 'Open Library' : 'Close Library'"
               >
                 <FolderOpen class="w-4 h-4" />
               </button>

--- a/web/src/AppDesktop.vue
+++ b/web/src/AppDesktop.vue
@@ -214,7 +214,7 @@ function requestDeleteFromTree(path: string) {
   const name = path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path;
   askConfirm({
     title: `Delete ${displayFileName(name)}?`,
-    message: `Git history is preserved — the file can be restored from the Deleted section.`,
+    message: `The file will move to the Deleted section. You can restore it from there, or permanently delete it later.`,
     confirmLabel: 'Delete',
     destructive: true,
     onConfirm: () => performDelete(path),
@@ -240,7 +240,18 @@ async function performDelete(path: string) {
         activeContent.value = '';
       }
     }
-    toastManager.value?.addToast(`Deleted ${path}`, 'success');
+    // A tracked file lands in the Deleted section (worktree-status=Deleted).
+    // An untracked file is gone for good — no HEAD blob to restore. Tailor
+    // the toast so the restore promise only appears when restore is real.
+    const wasTracked = (workspace.state.libraryDirty?.plays ?? [])
+      .some((p) => p.path === path && p.kind === 'deleted');
+    const display = displayFileName(path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path);
+    toastManager.value?.addToast(
+      wasTracked
+        ? `Deleted ${display} — restore from the Deleted section`
+        : `Deleted ${display}`,
+      'success',
+    );
   } catch (error: unknown) {
     toastManager.value?.addToast(`Delete failed: ${errorMessage(error)}`, 'error');
   }

--- a/web/src/AppDesktop.vue
+++ b/web/src/AppDesktop.vue
@@ -22,6 +22,7 @@ import Settings from './desktop/Settings.vue';
 import LibraryTree from './desktop/LibraryTree.vue';
 import PromptModal from './desktop/PromptModal.vue';
 import StatusBar from './desktop/StatusBar.vue';
+import ReviewChangesModal from './desktop/ReviewChangesModal.vue';
 import ExportPdfModal from './components/shared/ExportPdfModal.vue';
 import RevisionDiffView from './desktop/RevisionDiffView.vue';
 import VersionsPanel from './desktop/VersionsPanel.vue';
@@ -146,6 +147,95 @@ async function handleExportConfirmed(opts: ExportPdfOptions) {
 const newFolderOpen = ref(false);
 const newFolderParent = ref('');
 const newFolderError = ref<string | null>(null);
+
+const reviewChangesOpen = ref(false);
+const reviewBusy = ref(false);
+
+function openReviewChanges() {
+  if (!workspace.state.libraryPath) return;
+  void workspace.refreshLibraryDirty();
+  reviewChangesOpen.value = true;
+}
+
+async function onReviewCommit(paths: string[], message: string) {
+  reviewBusy.value = true;
+  try {
+    await workspace.commitDirtyPaths(paths, message);
+    toastManager.value?.addToast(`Committed ${paths.length} change${paths.length === 1 ? '' : 's'}`, 'success');
+  } catch (error: unknown) {
+    toastManager.value?.addToast(`Commit failed: ${errorMessage(error)}`, 'error');
+  } finally {
+    reviewBusy.value = false;
+  }
+}
+
+async function onReviewDiscard(paths: string[]) {
+  reviewBusy.value = true;
+  try {
+    await workspace.discardDirtyPaths(paths);
+    toastManager.value?.addToast(`Discarded ${paths.length} change${paths.length === 1 ? '' : 's'}`, 'success');
+  } catch (error: unknown) {
+    toastManager.value?.addToast(`Discard failed: ${errorMessage(error)}`, 'error');
+  } finally {
+    reviewBusy.value = false;
+  }
+}
+
+async function requestDeleteFromTree(path: string) {
+  const name = path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path;
+  if (!confirm(`Delete ${name}? Git history is preserved — the file can be restored from the Deleted section.`)) return;
+  await performDelete(path);
+}
+
+function requestDeleteActiveFile() {
+  const path = workspace.state.activeFile;
+  if (!path) return;
+  void requestDeleteFromTree(path);
+}
+
+async function performDelete(path: string) {
+  try {
+    await flushSave();
+    await workspace.deleteFile(path);
+    if (workspace.state.activeFile === null) {
+      // Was the active file. Open the next live one (or leave editor empty).
+      const remaining = workspace.libraryFiles.value;
+      if (remaining.length > 0) {
+        await selectLibraryFile(remaining[0].path);
+      } else {
+        activeContent.value = '';
+      }
+    }
+    toastManager.value?.addToast(`Deleted ${path}`, 'success');
+  } catch (error: unknown) {
+    toastManager.value?.addToast(`Delete failed: ${errorMessage(error)}`, 'error');
+  }
+}
+
+async function requestRestoreFromTree(path: string) {
+  try {
+    await workspace.restoreFile(path);
+    const content = await workspace.selectFile(path);
+    markProgrammaticLoad(path, content);
+    activeContent.value = content;
+    toastManager.value?.addToast(`Restored ${path}`, 'success');
+  } catch (error: unknown) {
+    toastManager.value?.addToast(`Restore failed: ${errorMessage(error)}`, 'error');
+  }
+}
+
+async function requestPermanentDeleteFromTree(path: string) {
+  if (!confirm(`Permanently remove ${path}. Git history is preserved but the file will no longer appear in your library.`)) return;
+  reviewBusy.value = true;
+  try {
+    await workspace.commitDirtyPaths([path], `Delete ${path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path}`);
+    toastManager.value?.addToast(`Permanently deleted ${path}`, 'success');
+  } catch (error: unknown) {
+    toastManager.value?.addToast(`Permanent delete failed: ${errorMessage(error)}`, 'error');
+  } finally {
+    reviewBusy.value = false;
+  }
+}
 
 function openNewFolderPrompt(parentPath = '') {
   if (!workspace.state.libraryPath) {
@@ -345,6 +435,8 @@ onMounted(async () => {
       openNewFolderPrompt,
       openExportDialog,
       openSaveVersionPrompt,
+      openReviewChanges,
+      requestDeleteActiveFile,
     },
   };
   for (const [id, entry] of createCommandHandlers(ctx)) {
@@ -359,15 +451,40 @@ onMounted(async () => {
     void workspace.state.revisionViewMode;
     void workspace.state.compareSecondHash;
     void workspace.state.externalFile;
+    void workspace.state.libraryDirty?.count;
     void isV1Document.value;
     dispatcher?.scheduleRefresh();
   });
+
+  // Library-wide dirty surface: poll on a long interval while focused,
+  // and refresh immediately on every focus event so users tabbing back
+  // from a terminal see the latest state without waiting for the tick.
+  if (typeof window !== 'undefined') {
+    void workspace.refreshLibraryDirty();
+    workspace.startLibraryDirtyPolling();
+    window.addEventListener('focus', onWindowFocus);
+    window.addEventListener('blur', onWindowBlur);
+  }
 });
+
+function onWindowFocus() {
+  void workspace.refreshLibraryDirty();
+  workspace.startLibraryDirtyPolling();
+}
+
+function onWindowBlur() {
+  workspace.stopLibraryDirtyPolling();
+}
 
 onUnmounted(() => {
   registerFlushSave(null);
   registerDispatcher(null);
   window.removeEventListener('resize', scheduleBoundsSave);
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('focus', onWindowFocus);
+    window.removeEventListener('blur', onWindowBlur);
+  }
+  workspace.stopLibraryDirtyPolling();
   if (boundsSaveTimer !== null) {
     clearTimeout(boundsSaveTimer);
     boundsSaveTimer = null;
@@ -606,6 +723,9 @@ watch(activeContent, (newContent) => {
           @error="(message) => toastManager?.addToast(message, 'error')"
           @info="(message) => toastManager?.addToast(message, 'info')"
           @request-new-folder="openNewFolderPrompt"
+          @request-delete-file="requestDeleteFromTree"
+          @request-restore-file="requestRestoreFromTree"
+          @request-permanent-delete="requestPermanentDeleteFromTree"
         />
 
         <VersionsPanel
@@ -841,7 +961,18 @@ watch(activeContent, (newContent) => {
       :git-status="workspace.state.gitStatus"
       :has-library="!!workspace.state.libraryPath"
       :has-active-file="!!workspace.state.activeFile"
+      :library-dirty-count="workspace.state.libraryDirty?.count ?? 0"
       @reveal-library="handleRevealLibrary"
+      @review-library-changes="openReviewChanges"
+    />
+    <ReviewChangesModal
+      :open="reviewChangesOpen"
+      :dirty="workspace.state.libraryDirty"
+      :busy="reviewBusy"
+      @close="reviewChangesOpen = false"
+      @commit="onReviewCommit"
+      @discard="onReviewDiscard"
+      @refresh="() => workspace.refreshLibraryDirty()"
     />
     <ToastManager ref="toastManager" />
     <CommandPalette

--- a/web/src/AppDesktop.vue
+++ b/web/src/AppDesktop.vue
@@ -24,6 +24,7 @@ import PromptModal from './desktop/PromptModal.vue';
 import ConfirmModal from './desktop/ConfirmModal.vue';
 import StatusBar from './desktop/StatusBar.vue';
 import ReviewChangesModal from './desktop/ReviewChangesModal.vue';
+import { displayFileName } from './desktop/naming';
 import ExportPdfModal from './components/shared/ExportPdfModal.vue';
 import RevisionDiffView from './desktop/RevisionDiffView.vue';
 import VersionsPanel from './desktop/VersionsPanel.vue';
@@ -212,7 +213,7 @@ async function onReviewDiscard(paths: string[]) {
 function requestDeleteFromTree(path: string) {
   const name = path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path;
   askConfirm({
-    title: `Delete ${name}?`,
+    title: `Delete ${displayFileName(name)}?`,
     message: `Git history is preserved — the file can be restored from the Deleted section.`,
     confirmLabel: 'Delete',
     destructive: true,
@@ -315,7 +316,7 @@ const saveVersionError = ref<string | null>(null);
 function openSaveVersionPrompt() {
   if (!workspace.state.activeFile) return;
   const filename = workspace.state.activeFile.split(/[\\/]/).pop() || 'file';
-  saveVersionInitial.value = `Snapshot ${filename}`;
+  saveVersionInitial.value = `Snapshot ${displayFileName(filename)}`;
   saveVersionError.value = null;
   saveVersionOpen.value = true;
 }
@@ -346,9 +347,12 @@ let dispatcher: CommandDispatcher | null = null;
 const libraryNameBase = computed(
   () => workspace.state.libraryPath?.split(/[\\/]/).pop() ?? '',
 );
-const activeFileBase = computed(
-  () => workspace.state.activeFile?.split(/[\\/]/).pop() ?? '',
-);
+const activeFileBase = computed(() => {
+  const path = workspace.state.activeFile;
+  if (!path) return '';
+  const base = path.split(/[\\/]/).pop() ?? '';
+  return displayFileName(base);
+});
 
 const isViewingRevision = computed(
   () => workspace.state.viewingRevisionHash !== null,

--- a/web/src/__tests__/desktop/appDesktop.test.ts
+++ b/web/src/__tests__/desktop/appDesktop.test.ts
@@ -166,6 +166,14 @@ function createEnv(init: { files?: LibraryFile[]; openReturn?: string; revisions
     getSpellAllowlist: async () => { record("getSpellAllowlist"); return []; },
     addSpellAllowlistWord: async () => { record("addSpellAllowlistWord"); return true; },
     removeSpellAllowlistWord: async () => { record("removeSpellAllowlistWord"); return true; },
+    getLibraryDirty: async () => {
+      record("getLibraryDirty");
+      return { plays: [], sidecars: [], other: [], count: 0 };
+    },
+    commitPaths: async (paths, msg) => { record(`commitPaths:${paths.join(",")}:${msg}`); },
+    discardPaths: async (paths) => { record(`discardPaths:${paths.join(",")}`); },
+    deleteLibraryFile: async (p) => { record(`deleteLibraryFile:${p}`); },
+    restoreLibraryFile: async (p) => { record(`restoreLibraryFile:${p}`); },
   };
   return env;
 }

--- a/web/src/__tests__/desktop/command-palette.test.ts
+++ b/web/src/__tests__/desktop/command-palette.test.ts
@@ -146,8 +146,11 @@ describe("CommandPalette", () => {
     });
     await flushPromises();
     const labels = wrapper.findAll("li").map((li) => li.text());
-    expect(labels.some((l) => l.includes("act-one.ds"))).toBe(true);
-    expect(labels.some((l) => l.includes("act-two.ds"))).toBe(true);
+    // Display strips the .ds extension — writers see "act-one", not
+    // "act-one.ds", and the rename input enforces the same contract.
+    expect(labels.some((l) => l.includes("act-one"))).toBe(true);
+    expect(labels.some((l) => l.includes("act-two"))).toBe(true);
+    expect(labels.some((l) => l.includes(".ds"))).toBe(false);
     // No catalog labels should appear in file mode.
     expect(labels.some((l) => l.includes("New Play"))).toBe(false);
   });

--- a/web/src/__tests__/desktop/commands.test.ts
+++ b/web/src/__tests__/desktop/commands.test.ts
@@ -79,6 +79,8 @@ function makeContext(overrides: Partial<CommandContext> = {}): CommandContext {
       openSettings: vi.fn(),
       openExportDialog: vi.fn(),
       openSaveVersionPrompt: vi.fn(),
+      openReviewChanges: vi.fn(),
+      requestDeleteActiveFile: vi.fn(),
     },
     ...overrides,
   };

--- a/web/src/__tests__/desktop/naming.test.ts
+++ b/web/src/__tests__/desktop/naming.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { displayFileName, displayFilePath, normalizeFileRename } from "../../desktop/naming";
+
+describe("naming helpers", () => {
+  describe("displayFileName", () => {
+    it("strips a single trailing .ds", () => {
+      expect(displayFileName("Act One.ds")).toBe("Act One");
+    });
+
+    it("is case-insensitive on the extension", () => {
+      expect(displayFileName("Act One.DS")).toBe("Act One");
+    });
+
+    it("leaves non-.ds names alone", () => {
+      expect(displayFileName("notes.txt")).toBe("notes.txt");
+      expect(displayFileName("Act One")).toBe("Act One");
+    });
+
+    it("does not strip an embedded .ds in the middle", () => {
+      expect(displayFileName("things.ds.backup")).toBe("things.ds.backup");
+    });
+  });
+
+  describe("displayFilePath", () => {
+    it("strips .ds from the basename only", () => {
+      expect(displayFilePath("folder/Act One.ds")).toBe("folder/Act One");
+    });
+
+    it("handles root paths", () => {
+      expect(displayFilePath("Act One.ds")).toBe("Act One");
+    });
+
+    it("handles nested paths", () => {
+      expect(displayFilePath("a/b/c/Scene.ds")).toBe("a/b/c/Scene");
+    });
+  });
+
+  describe("normalizeFileRename", () => {
+    it("appends .ds to a bare name", () => {
+      expect(normalizeFileRename("Act One")).toBe("Act One.ds");
+    });
+
+    it("re-applies .ds when the user explicitly typed it", () => {
+      expect(normalizeFileRename("Act One.ds")).toBe("Act One.ds");
+    });
+
+    it("does not strip a non-.ds extension the user typed", () => {
+      // If the user genuinely typed ".txt", trust them. Resulting file
+      // is "Act One.txt.ds" — ugly, but better than the alternative of
+      // silently dropping characters from legitimate names like "v1.2".
+      expect(normalizeFileRename("Act One.txt")).toBe("Act One.txt.ds");
+    });
+
+    it("trims whitespace", () => {
+      expect(normalizeFileRename("  Act One  ")).toBe("Act One.ds");
+    });
+
+    it("returns empty string for empty input", () => {
+      expect(normalizeFileRename("")).toBe("");
+      expect(normalizeFileRename("   ")).toBe("");
+    });
+
+    it("preserves dots earlier in the name", () => {
+      expect(normalizeFileRename("Act 2.1")).toBe("Act 2.1.ds");
+    });
+  });
+});

--- a/web/src/__tests__/desktop/reviewChangesModal.test.ts
+++ b/web/src/__tests__/desktop/reviewChangesModal.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import ReviewChangesModal from "../../desktop/ReviewChangesModal.vue";
+import type { LibraryDirty } from "../../desktop/types";
+
+// BaseModal renders inside a teleport, which @vue/test-utils handles
+// poorly out of the box. Stub it to a transparent wrapper so we can
+// query the rendered children directly.
+const baseModalStub = {
+  name: "BaseModal",
+  props: ["open", "title"],
+  emits: ["close"],
+  template: '<div v-if="open" data-testid="modal-root"><slot /></div>',
+};
+
+const promptModalStub = {
+  name: "PromptModal",
+  props: ["open", "title", "label", "initialValue", "submitLabel"],
+  emits: ["close", "submit"],
+  template: '<div v-if="open" data-testid="prompt-stub"></div>',
+};
+
+function makeDirty(): LibraryDirty {
+  return {
+    plays: [
+      { path: "act-one.ds", kind: "modified" },
+      { path: "act-two.ds", kind: "untracked" },
+    ],
+    sidecars: [
+      { path: ".downstage/dictionary.txt", kind: "modified" },
+    ],
+    other: [],
+    count: 3,
+  };
+}
+
+function mountModal(props: Partial<{ open: boolean; dirty: LibraryDirty | null; busy: boolean }> = {}) {
+  return mount(ReviewChangesModal, {
+    props: {
+      open: true,
+      dirty: makeDirty(),
+      busy: false,
+      ...props,
+    },
+    global: {
+      stubs: {
+        BaseModal: baseModalStub,
+        PromptModal: promptModalStub,
+      },
+    },
+  });
+}
+
+describe("ReviewChangesModal", () => {
+  it("renders one section per non-empty category", async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    const headers = wrapper.findAll("h4").map((h) => h.text());
+    // Plays (2) + Library settings (1). Other was empty, so no section.
+    expect(headers.length).toBe(2);
+    expect(headers[0]).toContain("Plays");
+    expect(headers[1]).toContain("Library settings");
+  });
+
+  it("does not render empty categories", async () => {
+    const wrapper = mountModal({
+      dirty: { plays: [{ path: "a.ds", kind: "modified" }], sidecars: [], other: [], count: 1 },
+    });
+    await flushPromises();
+    const headers = wrapper.findAll("h4").map((h) => h.text());
+    expect(headers.length).toBe(1);
+    expect(headers[0]).toContain("Plays");
+  });
+
+  it("commit-all opens the prompt with all paths queued, then emits on submit", async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    const commitAllBtn = wrapper.findAll("button").find((b) => b.text().includes("Commit all changes"));
+    expect(commitAllBtn).toBeTruthy();
+    await commitAllBtn!.trigger("click");
+    await flushPromises();
+
+    // Prompt stub should now be open.
+    const prompt = wrapper.findComponent(promptModalStub as any);
+    expect(prompt.props("open")).toBe(true);
+
+    prompt.vm.$emit("submit", "Library cleanup commit");
+    await flushPromises();
+
+    const emitted = wrapper.emitted("commit");
+    expect(emitted, "commit event should fire").toBeTruthy();
+    expect(emitted![0]).toEqual([
+      ["act-one.ds", "act-two.ds", ".downstage/dictionary.txt"],
+      "Library cleanup commit",
+    ]);
+  });
+
+  it("per-section commit only includes that section's paths", async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    // First "Commit all" button is the Plays section header button.
+    const sectionCommit = wrapper.findAll("button").find((b) => b.text().trim().startsWith("Commit all"));
+    expect(sectionCommit).toBeTruthy();
+    await sectionCommit!.trigger("click");
+    await flushPromises();
+
+    const prompt = wrapper.findComponent(promptModalStub as any);
+    expect(prompt.props("open")).toBe(true);
+    prompt.vm.$emit("submit", "Update plays");
+    await flushPromises();
+
+    expect(wrapper.emitted("commit")![0]).toEqual([
+      ["act-one.ds", "act-two.ds"],
+      "Update plays",
+    ]);
+  });
+
+  it("discard buttons require confirmation before emitting", async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    // happy-dom doesn't ship window.confirm; install a fake so spyOn works.
+    const originalConfirm = (window as unknown as { confirm?: unknown }).confirm;
+    const fake = vi.fn().mockReturnValue(false);
+    (window as unknown as { confirm: (msg?: string) => boolean }).confirm = fake;
+
+    const sectionDiscard = wrapper.findAll("button").find((b) => b.text().trim().startsWith("Discard all"));
+    await sectionDiscard!.trigger("click");
+    expect(wrapper.emitted("discard")).toBeFalsy();
+
+    fake.mockReturnValue(true);
+    await sectionDiscard!.trigger("click");
+    expect(wrapper.emitted("discard")![0]).toEqual([["act-one.ds", "act-two.ds"]]);
+
+    (window as unknown as { confirm?: unknown }).confirm = originalConfirm;
+  });
+
+  it("commit-all is disabled when the library is clean", async () => {
+    const wrapper = mountModal({
+      dirty: { plays: [], sidecars: [], other: [], count: 0 },
+    });
+    await flushPromises();
+    const commitAllBtn = wrapper.findAll("button").find((b) => b.text().includes("Commit all changes"));
+    expect(commitAllBtn!.attributes("disabled")).toBeDefined();
+  });
+
+  it("emits close on Close button", async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    const closeBtn = wrapper.findAll("button").find((b) => b.text().trim() === "Close");
+    await closeBtn!.trigger("click");
+    expect(wrapper.emitted("close")).toBeTruthy();
+  });
+
+  it("emits refresh on Refresh button", async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    const refresh = wrapper.findAll("button").find((b) => b.text().includes("Refresh"));
+    await refresh!.trigger("click");
+    expect(wrapper.emitted("refresh")).toBeTruthy();
+  });
+});

--- a/web/src/__tests__/desktop/reviewChangesModal.test.ts
+++ b/web/src/__tests__/desktop/reviewChangesModal.test.ts
@@ -21,6 +21,13 @@ const promptModalStub = {
   template: '<div v-if="open" data-testid="prompt-stub"></div>',
 };
 
+const confirmModalStub = {
+  name: "ConfirmModal",
+  props: ["open", "title", "message", "confirmLabel", "destructive"],
+  emits: ["close", "confirm"],
+  template: '<div v-if="open" data-testid="confirm-stub"></div>',
+};
+
 function makeDirty(): LibraryDirty {
   return {
     plays: [
@@ -47,6 +54,7 @@ function mountModal(props: Partial<{ open: boolean; dirty: LibraryDirty | null; 
       stubs: {
         BaseModal: baseModalStub,
         PromptModal: promptModalStub,
+        ConfirmModal: confirmModalStub,
       },
     },
   });
@@ -116,23 +124,33 @@ describe("ReviewChangesModal", () => {
     ]);
   });
 
-  it("discard buttons require confirmation before emitting", async () => {
+  it("discard buttons open a styled confirm modal and emit only on confirm", async () => {
     const wrapper = mountModal();
     await flushPromises();
-    // happy-dom doesn't ship window.confirm; install a fake so spyOn works.
-    const originalConfirm = (window as unknown as { confirm?: unknown }).confirm;
-    const fake = vi.fn().mockReturnValue(false);
-    (window as unknown as { confirm: (msg?: string) => boolean }).confirm = fake;
 
+    // Section "Discard all" should open the confirm modal — but not emit yet.
     const sectionDiscard = wrapper.findAll("button").find((b) => b.text().trim().startsWith("Discard all"));
     await sectionDiscard!.trigger("click");
+    await flushPromises();
     expect(wrapper.emitted("discard")).toBeFalsy();
 
-    fake.mockReturnValue(true);
-    await sectionDiscard!.trigger("click");
-    expect(wrapper.emitted("discard")![0]).toEqual([["act-one.ds", "act-two.ds"]]);
+    const confirmStub = wrapper.findComponent(confirmModalStub as any);
+    expect(confirmStub.props("open")).toBe(true);
+    // `destructive` is bound as a bare attribute, which the stub receives
+    // as "". Just confirm the prop was passed at all.
+    expect(confirmStub.props()).toHaveProperty("destructive");
 
-    (window as unknown as { confirm?: unknown }).confirm = originalConfirm;
+    // Closing the modal cancels — no emit.
+    confirmStub.vm.$emit("close");
+    await flushPromises();
+    expect(wrapper.emitted("discard")).toBeFalsy();
+
+    // Re-open and confirm — the paths flow through.
+    await sectionDiscard!.trigger("click");
+    await flushPromises();
+    confirmStub.vm.$emit("confirm");
+    await flushPromises();
+    expect(wrapper.emitted("discard")![0]).toEqual([["act-one.ds", "act-two.ds"]]);
   });
 
   it("commit-all is disabled when the library is clean", async () => {

--- a/web/src/__tests__/desktop/workspace.test.ts
+++ b/web/src/__tests__/desktop/workspace.test.ts
@@ -164,6 +164,20 @@ function createEnv(initial?: Partial<StubEnv>): StubEnv {
     getSpellAllowlist: () => record("getSpellAllowlist", async () => []),
     addSpellAllowlistWord: () => record("addSpellAllowlistWord", async () => true),
     removeSpellAllowlistWord: () => record("removeSpellAllowlistWord", async () => true),
+    getLibraryDirty: () => record("getLibraryDirty", async () => ({
+      plays: [],
+      sidecars: [],
+      other: [],
+      count: 0,
+    })),
+    commitPaths: (paths: string[], msg: string) =>
+      record(`commitPaths:${paths.join(",")}:${msg}`, async () => {}),
+    discardPaths: (paths: string[]) =>
+      record(`discardPaths:${paths.join(",")}`, async () => {}),
+    deleteLibraryFile: (p: string) =>
+      record(`deleteLibraryFile:${p}`, async () => {}),
+    restoreLibraryFile: (p: string) =>
+      record(`restoreLibraryFile:${p}`, async () => {}),
   });
 
   return state;
@@ -1223,6 +1237,127 @@ describe("Workspace", () => {
       // should no longer be in the sidebar list.
       expect(ws.libraryFiles.value.map((f) => f.path)).not.toContain("gone.ds");
       expect(ws.libraryFiles.value.map((f) => f.path)).toContain("alive.ds");
+    });
+  });
+
+  // --- A2: library-wide dirty surface (deleteFile / restoreFile /
+  // commitDirtyPaths / discardDirtyPaths / refreshLibraryDirty) ---
+
+  describe("library dirty surface", () => {
+    it("refreshLibraryDirty calls the env method and stores the result", async () => {
+      stubLocalStorage();
+      const env = createEnv({ _openReturn: "/p/x" });
+      env.getLibraryDirty = async () => ({
+        plays: [{ path: "act.ds", kind: "modified" }],
+        sidecars: [],
+        other: [],
+        count: 1,
+      });
+      const ws = new Workspace(env);
+      await ws.init();
+      await ws.refreshLibraryDirty();
+
+      expect(ws.state.libraryDirty?.count).toBe(1);
+      expect(ws.state.libraryDirty?.plays[0].path).toBe("act.ds");
+    });
+
+    it("deletedFiles computed exposes only deleted-kind plays", async () => {
+      stubLocalStorage();
+      const env = createEnv({ _openReturn: "/p/x" });
+      env.getLibraryDirty = async () => ({
+        plays: [
+          { path: "alive.ds", kind: "modified" },
+          { path: "gone1.ds", kind: "deleted" },
+          { path: "gone2.ds", kind: "deleted" },
+        ],
+        sidecars: [],
+        other: [],
+        count: 3,
+      });
+      const ws = new Workspace(env);
+      await ws.init();
+      await ws.refreshLibraryDirty();
+
+      const paths = ws.deletedFiles.value.map((p) => p.path);
+      expect(paths).toEqual(["gone1.ds", "gone2.ds"]);
+    });
+
+    it("deleteFile clears activeFile when the deleted path was active", async () => {
+      stubLocalStorage();
+      const env = createEnv({
+        _files: [
+          { path: "doomed.ds", name: "doomed.ds", updatedAt: "" },
+          { path: "other.ds", name: "other.ds", updatedAt: "" },
+        ],
+        _contents: { "doomed.ds": "x", "other.ds": "y" },
+      });
+      const ws = new Workspace(env);
+      await ws.init();
+      await ws.selectFile("doomed.ds");
+      expect(ws.state.activeFile).toBe("doomed.ds");
+
+      // Stub env.deleteLibraryFile to also drop the file from the
+      // fake filesystem so the post-delete tree refresh is realistic.
+      const originalDelete = env.deleteLibraryFile;
+      env.deleteLibraryFile = async (p: string) => {
+        env._files = env._files.filter((f) => f.path !== p);
+        return originalDelete(p);
+      };
+
+      await ws.deleteFile("doomed.ds");
+
+      expect(ws.state.activeFile).toBeNull();
+      expect(ws.libraryFiles.value.map((f) => f.path)).not.toContain("doomed.ds");
+    });
+
+    it("deleteFile leaves activeFile alone when a different path is deleted", async () => {
+      stubLocalStorage();
+      const env = createEnv({
+        _files: [
+          { path: "stay.ds", name: "stay.ds", updatedAt: "" },
+          { path: "other.ds", name: "other.ds", updatedAt: "" },
+        ],
+        _contents: { "stay.ds": "a", "other.ds": "b" },
+      });
+      const ws = new Workspace(env);
+      await ws.init();
+      await ws.selectFile("stay.ds");
+
+      const originalDelete = env.deleteLibraryFile;
+      env.deleteLibraryFile = async (p: string) => {
+        env._files = env._files.filter((f) => f.path !== p);
+        return originalDelete(p);
+      };
+
+      await ws.deleteFile("other.ds");
+
+      expect(ws.state.activeFile).toBe("stay.ds");
+    });
+
+    it("commitDirtyPaths forwards to env and refreshes dirty state", async () => {
+      stubLocalStorage();
+      const env = createEnv({ _openReturn: "/p/x" });
+      const seen: { paths: string[]; msg: string }[] = [];
+      env.commitPaths = async (paths: string[], msg: string) => {
+        seen.push({ paths, msg });
+      };
+      const ws = new Workspace(env);
+      await ws.init();
+      await ws.commitDirtyPaths(["a.ds", "b.ds"], "cleanup");
+
+      expect(seen).toEqual([{ paths: ["a.ds", "b.ds"], msg: "cleanup" }]);
+    });
+
+    it("discardDirtyPaths forwards to env and refreshes tree + dirty", async () => {
+      stubLocalStorage();
+      const env = createEnv({ _openReturn: "/p/x" });
+      const seen: string[][] = [];
+      env.discardPaths = async (paths: string[]) => { seen.push(paths); };
+      const ws = new Workspace(env);
+      await ws.init();
+      await ws.discardDirtyPaths(["bad.ds"]);
+
+      expect(seen).toEqual([["bad.ds"]]);
     });
   });
 });

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -557,10 +557,10 @@ defineExpose({
   <div class="flex-1 flex flex-col overflow-hidden bg-[var(--color-page-bg)]">
     <div class="px-4 py-2 border-b border-border bg-[var(--color-toolbar-bg)] flex items-center justify-between gap-2">
         <div class="flex items-center gap-1.5 overflow-x-auto no-scrollbar">
-            <!-- Leading host actions. Desktop puts the sidebar/project
+            <!-- Leading host actions. Desktop puts the sidebar/library
                  toggle here; web leaves it empty. Keeping it as a slot
                  means the shared editor doesn't know about host-level
-                 concepts like projects. -->
+                 concepts like libraries. -->
             <template v-if="$slots.leadingActions">
               <slot name="leadingActions" />
               <div class="w-px h-4 bg-black/10 dark:bg-white/10 mx-1"></div>

--- a/web/src/desktop-app.ts
+++ b/web/src/desktop-app.ts
@@ -79,7 +79,11 @@ function normalizeLibraryNode(node: unknown): LibraryNode {
     children?: unknown;
     updatedAt?: unknown;
   } | null;
-  const kind: "folder" | "file" = current?.kind === "folder" ? "folder" : "file";
+  const rawKind = current?.kind;
+  let kind: "folder" | "file" | "deleted-file";
+  if (rawKind === "folder") kind = "folder";
+  else if (rawKind === "deleted-file") kind = "deleted-file";
+  else kind = "file";
   return {
     path: String(current?.path ?? ""),
     name: String(current?.name ?? ""),
@@ -280,6 +284,44 @@ class WailsBridge implements DesktopCapabilities {
       untracked: !!raw?.untracked,
       missing: !!raw?.missing,
     };
+  }
+
+  async getLibraryDirty() {
+    const raw = await App.GetLibraryDirty();
+    type Kind = "untracked" | "modified" | "deleted";
+    const normalizePath = (entry: unknown): { path: string; kind: Kind } => {
+      const e = entry as { path?: unknown; kind?: unknown } | null;
+      const rawKind = e?.kind;
+      const kind: Kind =
+        rawKind === "untracked" || rawKind === "modified" || rawKind === "deleted"
+          ? rawKind
+          : "modified";
+      return { path: String(e?.path ?? ""), kind };
+    };
+    const normList = (arr: unknown): { path: string; kind: Kind }[] =>
+      Array.isArray(arr) ? arr.map(normalizePath) : [];
+    return {
+      plays: normList(raw?.plays),
+      sidecars: normList(raw?.sidecars),
+      other: normList(raw?.other),
+      count: typeof raw?.count === "number" ? raw.count : 0,
+    };
+  }
+
+  async commitPaths(paths: string[], message: string): Promise<void> {
+    await App.CommitPaths(paths, message);
+  }
+
+  async discardPaths(paths: string[]): Promise<void> {
+    await App.DiscardPaths(paths);
+  }
+
+  async deleteLibraryFile(path: string): Promise<void> {
+    await App.DeleteLibraryFile(path);
+  }
+
+  async restoreLibraryFile(path: string): Promise<void> {
+    await App.RestoreLibraryFile(path);
   }
 
   async getCurrentLibrary(): Promise<string> {

--- a/web/src/desktop/CommandPalette.vue
+++ b/web/src/desktop/CommandPalette.vue
@@ -2,6 +2,7 @@
 import { computed, nextTick, ref, watch } from 'vue';
 import type { CommandMeta, DesktopCapabilities, LibraryFile } from './types';
 import { dispatchCommand } from './dispatcher-registry';
+import { displayFileName, displayFilePath } from './naming';
 
 // Command palette overlay. Consumes the Go-declared catalog (labels,
 // accelerators, categories) through env.getCommands so there's no
@@ -60,8 +61,8 @@ const rows = computed<Row[]>(() => {
   if (props.mode === 'file') {
     return props.libraryFiles.map<Row>((f) => ({
       key: `file:${f.path}`,
-      label: f.name,
-      secondary: f.path !== f.name ? f.path : 'File',
+      label: displayFileName(f.name),
+      secondary: f.path !== f.name ? displayFilePath(f.path) : 'File',
       disabled: false,
       run: () => emit('select-file', f.path),
     }));

--- a/web/src/desktop/ConfirmModal.vue
+++ b/web/src/desktop/ConfirmModal.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import BaseModal from '../components/shared/BaseModal.vue';
+
+// Styled replacement for `window.confirm`. Used by delete / permanent-delete
+// / discard flows so the Wails app doesn't surface an unstyled native dialog.
+
+const props = withDefaults(
+  defineProps<{
+    open: boolean;
+    title: string;
+    message: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    destructive?: boolean;
+  }>(),
+  { confirmLabel: 'Confirm', cancelLabel: 'Cancel', destructive: false },
+);
+
+const emit = defineEmits<{
+  (e: 'close'): void;
+  (e: 'confirm'): void;
+}>();
+
+function onConfirm() {
+  emit('confirm');
+}
+</script>
+
+<template>
+  <BaseModal :open="open" :title="title" @close="emit('close')">
+    <div class="flex flex-col gap-5 py-1">
+      <p class="text-sm text-text-main leading-relaxed whitespace-pre-line">{{ message }}</p>
+      <div class="flex justify-end gap-2 pt-1">
+        <button
+          type="button"
+          class="rounded-md border border-border px-3 py-1.5 text-sm font-bold text-text-main transition-colors hover:bg-black/5 dark:hover:bg-white/5"
+          @click="emit('close')"
+        >
+          {{ cancelLabel }}
+        </button>
+        <button
+          type="button"
+          :class="[
+            'rounded-md px-3 py-1.5 text-sm font-bold transition-colors',
+            destructive
+              ? 'bg-red-600 text-white hover:bg-red-500'
+              : 'bg-brass-500 text-ember-950 hover:bg-brass-400',
+          ]"
+          @click="onConfirm"
+        >
+          {{ confirmLabel }}
+        </button>
+      </div>
+    </div>
+  </BaseModal>
+</template>

--- a/web/src/desktop/LibraryTree.vue
+++ b/web/src/desktop/LibraryTree.vue
@@ -4,6 +4,7 @@ import { FolderPlus, Edit3, Trash2, Undo2 } from 'lucide-vue-next';
 import type { Workspace } from './workspace';
 import type { DirtyPath, LibraryNode } from './types';
 import LibraryTreeNode from './LibraryTreeNode.vue';
+import { displayFileName, displayFilePath, normalizeFileRename } from './naming';
 
 const props = defineProps<{
   workspace: Workspace;
@@ -90,7 +91,9 @@ function toggleExpand(path: string) {
 
 async function startRename(node: LibraryNode) {
   renamingPath.value = node.path;
-  renameValue.value = node.name;
+  // Show only the base name in the rename input; the .ds extension is
+  // re-applied in commitRename. Folders keep their full name.
+  renameValue.value = node.kind === 'file' ? displayFileName(node.name) : node.name;
   contextMenu.value = null;
   await nextTick();
   renameInput.value?.focus();
@@ -98,9 +101,11 @@ async function startRename(node: LibraryNode) {
 }
 
 async function commitRename(node: LibraryNode) {
-  const newName = renameValue.value.trim();
+  const raw = renameValue.value.trim();
   renamingPath.value = null;
-  if (!newName || newName === node.name) return;
+  if (!raw) return;
+  const newName = node.kind === 'file' ? normalizeFileRename(raw) : raw;
+  if (newName === node.name) return;
   try {
     const newPath = await props.workspace.renameEntry(node.path, newName);
     if (node.kind === 'file') emit('select-file', newPath);
@@ -292,7 +297,7 @@ async function onDrop(event: DragEvent, targetPath: string) {
           @contextmenu.prevent="openDeletedMenu($event, dp)"
         >
           <Undo2 class="w-3 h-3 shrink-0 opacity-60" />
-          <span class="truncate">{{ dp.path }}</span>
+          <span class="truncate">{{ displayFilePath(dp.path) }}</span>
         </button>
       </div>
     </div>

--- a/web/src/desktop/LibraryTree.vue
+++ b/web/src/desktop/LibraryTree.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { computed, nextTick, ref } from 'vue';
-import { FolderPlus, Edit3 } from 'lucide-vue-next';
+import { FolderPlus, Edit3, Trash2, Undo2 } from 'lucide-vue-next';
 import type { Workspace } from './workspace';
-import type { LibraryNode } from './types';
+import type { DirtyPath, LibraryNode } from './types';
 import LibraryTreeNode from './LibraryTreeNode.vue';
 
 const props = defineProps<{
@@ -14,6 +14,9 @@ const emit = defineEmits<{
   (e: 'error', message: string): void;
   (e: 'info', message: string): void;
   (e: 'request-new-folder', parentPath: string): void;
+  (e: 'request-delete-file', path: string): void;
+  (e: 'request-restore-file', path: string): void;
+  (e: 'request-permanent-delete', path: string): void;
 }>();
 
 const renamingPath = ref<string | null>(null);
@@ -26,8 +29,46 @@ const contextMenu = ref<{
   y: number;
 } | null>(null);
 
+const deletedMenu = ref<{ path: string; name: string; x: number; y: number } | null>(null);
+
 const draggedPath = ref<string | null>(null);
 const dropTarget = ref<string | null>(null);
+
+const deletedFiles = computed(() => props.workspace.deletedFiles.value);
+
+function fileName(path: string): string {
+  return path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path;
+}
+
+function openDeletedMenu(event: MouseEvent, dp: DirtyPath) {
+  event.preventDefault();
+  deletedMenu.value = { path: dp.path, name: fileName(dp.path), x: event.clientX, y: event.clientY };
+}
+
+function closeDeletedMenu() {
+  deletedMenu.value = null;
+}
+
+function contextDeleteFile() {
+  if (!contextMenu.value) return;
+  const path = contextMenu.value.node.path;
+  closeContextMenu();
+  emit('request-delete-file', path);
+}
+
+function menuRestore() {
+  if (!deletedMenu.value) return;
+  const path = deletedMenu.value.path;
+  closeDeletedMenu();
+  emit('request-restore-file', path);
+}
+
+function menuPermanentDelete() {
+  if (!deletedMenu.value) return;
+  const path = deletedMenu.value.path;
+  closeDeletedMenu();
+  emit('request-permanent-delete', path);
+}
 
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -141,7 +182,7 @@ async function onDrop(event: DragEvent, targetPath: string) {
 </script>
 
 <template>
-  <div class="flex-1 overflow-y-auto p-2 custom-scrollbar border-b border-border" @click="closeContextMenu">
+  <div class="flex-1 overflow-y-auto p-2 custom-scrollbar border-b border-border" @click="() => { closeContextMenu(); closeDeletedMenu(); }">
     <div
       class="flex items-center justify-between px-2 pb-2 rounded transition-colors"
       :class="dropTarget === '' ? 'bg-brass-500/10 ring-1 ring-brass-500/30' : ''"
@@ -221,6 +262,61 @@ async function onDrop(event: DragEvent, targetPath: string) {
         @click="() => { const n = contextMenu!.node; closeContextMenu(); startRename(n); }"
       >
         <Edit3 class="w-3.5 h-3.5" /> Rename
+      </button>
+      <button
+        v-if="contextMenu.node.kind === 'file'"
+        type="button"
+        class="w-full text-left px-3 py-1.5 text-xs hover:bg-red-500/10 text-red-600 dark:text-red-400 inline-flex items-center gap-2"
+        @click="contextDeleteFile"
+      >
+        <Trash2 class="w-3.5 h-3.5" /> Delete…
+      </button>
+    </div>
+
+    <div
+      v-if="deletedFiles.length > 0"
+      class="mt-4 pt-2 border-t border-border"
+    >
+      <div class="flex items-center px-2 pb-2">
+        <span class="text-[10px] uppercase tracking-[0.2em] text-text-muted font-bold">
+          Deleted ({{ deletedFiles.length }})
+        </span>
+      </div>
+      <div class="space-y-0.5">
+        <button
+          v-for="dp in deletedFiles"
+          :key="dp.path"
+          type="button"
+          class="w-full text-left px-2 py-1 rounded text-xs flex items-center gap-2 text-text-muted line-through italic opacity-70 hover:opacity-100 hover:bg-black/5 dark:hover:bg-white/5"
+          :title="`Deleted: ${dp.path} — right-click to restore`"
+          @contextmenu.prevent="openDeletedMenu($event, dp)"
+        >
+          <Undo2 class="w-3 h-3 shrink-0 opacity-60" />
+          <span class="truncate">{{ dp.path }}</span>
+        </button>
+      </div>
+    </div>
+
+    <div
+      v-if="deletedMenu"
+      class="fixed z-50 min-w-[200px] rounded-md border border-border bg-[var(--color-page-surface)] shadow-lg py-1"
+      :style="{ left: deletedMenu.x + 'px', top: deletedMenu.y + 'px' }"
+      @click.stop
+    >
+      <button
+        type="button"
+        class="w-full text-left px-3 py-1.5 text-xs hover:bg-brass-500/10 text-text-main inline-flex items-center gap-2"
+        @click="menuRestore"
+      >
+        <Undo2 class="w-3.5 h-3.5" /> Restore from last version
+      </button>
+      <div class="my-1 border-t border-border" />
+      <button
+        type="button"
+        class="w-full text-left px-3 py-1.5 text-xs hover:bg-red-500/10 text-red-600 dark:text-red-400 inline-flex items-center gap-2"
+        @click="menuPermanentDelete"
+      >
+        <Trash2 class="w-3.5 h-3.5" /> Permanently delete
       </button>
     </div>
   </div>

--- a/web/src/desktop/LibraryTreeNode.vue
+++ b/web/src/desktop/LibraryTreeNode.vue
@@ -4,10 +4,12 @@ export default { name: 'LibraryTreeNode' };
 </script>
 
 <script setup lang="ts">
+import { computed } from 'vue';
 import {
   ChevronDown, ChevronRight, FileText, Folder, FolderOpen,
 } from 'lucide-vue-next';
 import type { LibraryNode } from './types';
+import { displayFileName } from './naming';
 
 // Recursive tree-row renderer for LibraryTree.vue. Presentational —
 // all state (rename target, drop target, expanded set) lives in the
@@ -53,6 +55,10 @@ function onRowClick(e: MouseEvent) {
   if (props.node.kind === 'folder') emit('toggleExpand', props.node.path);
   else emit('selectFile', props.node);
 }
+
+const displayName = computed(() =>
+  props.node.kind === 'file' ? displayFileName(props.node.name) : props.node.name,
+);
 </script>
 
 <template>
@@ -111,7 +117,7 @@ function onRowClick(e: MouseEvent) {
         @blur="emit('commitRename', node)"
         @click.stop
       />
-      <span v-else class="truncate">{{ node.name }}</span>
+      <span v-else class="truncate">{{ displayName }}</span>
     </div>
 
     <div

--- a/web/src/desktop/ReviewChangesModal.vue
+++ b/web/src/desktop/ReviewChangesModal.vue
@@ -128,10 +128,10 @@ function fileName(path: string): string {
 </script>
 
 <template>
-  <BaseModal :open="open" title="Review Library Changes" @close="emit('close')">
-    <div class="flex flex-col gap-4 min-w-[480px] max-w-[640px]">
-      <div class="flex items-center justify-between">
-        <p class="text-xs text-text-muted">
+  <BaseModal :open="open" title="Review Library Changes" size="lg" @close="emit('close')">
+    <div class="flex flex-col gap-4">
+      <div class="flex items-start justify-between gap-3">
+        <p class="text-xs text-text-muted flex-1 min-w-0">
           <span v-if="totalCount === 0">Library is clean — no uncommitted changes.</span>
           <span v-else>
             {{ totalCount }} uncommitted change{{ totalCount === 1 ? '' : 's' }} across your library.
@@ -140,7 +140,7 @@ function fileName(path: string): string {
         </p>
         <button
           type="button"
-          class="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 text-xs text-text-main hover:bg-black/5 dark:hover:bg-white/5 disabled:opacity-50"
+          class="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 text-xs text-text-main hover:bg-black/5 dark:hover:bg-white/5 disabled:opacity-50 shrink-0"
           :disabled="busy"
           @click="emit('refresh')"
         >

--- a/web/src/desktop/ReviewChangesModal.vue
+++ b/web/src/desktop/ReviewChangesModal.vue
@@ -1,0 +1,225 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { Check, GitCommit, RefreshCw, Trash2 } from 'lucide-vue-next';
+import BaseModal from '../components/shared/BaseModal.vue';
+import PromptModal from './PromptModal.vue';
+import type { DirtyPath, LibraryDirty } from './types';
+
+// Surfaces library-wide uncommitted changes — sibling-file edits, untracked
+// new files, deleted-tracked files, sidecar (.downstage/*) drift — and lets
+// the user commit or discard them in bulk. The canonical path for sibling
+// reconciliation; SnapshotFile stays single-path and intentionally does NOT
+// pick these up.
+
+const props = defineProps<{
+  open: boolean;
+  dirty: LibraryDirty | null;
+  busy: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'close'): void;
+  (e: 'commit', paths: string[], message: string): void;
+  (e: 'discard', paths: string[]): void;
+  (e: 'refresh'): void;
+}>();
+
+const promptOpen = ref(false);
+const pendingCommitPaths = ref<string[]>([]);
+const promptInitial = ref('');
+
+const sections = computed(() => {
+  const d = props.dirty;
+  if (!d) return [];
+  return [
+    { id: 'plays', label: 'Plays', items: d.plays },
+    { id: 'sidecars', label: 'Library settings — auto-managed by Downstage', items: d.sidecars },
+    { id: 'other', label: 'Other', items: d.other },
+  ].filter((s) => s.items.length > 0);
+});
+
+const totalCount = computed(() => props.dirty?.count ?? 0);
+
+function kindLabel(kind: DirtyPath['kind']): string {
+  if (kind === 'untracked') return 'new';
+  if (kind === 'deleted') return 'deleted';
+  return 'modified';
+}
+
+function kindClass(kind: DirtyPath['kind']): string {
+  if (kind === 'untracked') return 'text-emerald-600 dark:text-emerald-400';
+  if (kind === 'deleted') return 'text-red-600 dark:text-red-400';
+  return 'text-amber-600 dark:text-amber-400';
+}
+
+function openCommitPrompt(paths: string[], initial: string) {
+  pendingCommitPaths.value = paths;
+  promptInitial.value = initial;
+  promptOpen.value = true;
+}
+
+function submitCommit(message: string) {
+  const paths = pendingCommitPaths.value;
+  promptOpen.value = false;
+  pendingCommitPaths.value = [];
+  if (paths.length > 0) emit('commit', paths, message);
+}
+
+function commitRow(dp: DirtyPath) {
+  const verb = dp.kind === 'deleted' ? 'Delete' : dp.kind === 'untracked' ? 'Add' : 'Update';
+  openCommitPrompt([dp.path], `${verb} ${fileName(dp.path)}`);
+}
+
+function commitSection(sectionId: string, items: DirtyPath[]) {
+  const paths = items.map((i) => i.path);
+  let initial = 'Library cleanup';
+  if (sectionId === 'sidecars') initial = 'Update library settings';
+  else if (sectionId === 'plays') initial = `Commit ${items.length} script change${items.length === 1 ? '' : 's'}`;
+  openCommitPrompt(paths, initial);
+}
+
+function commitAll() {
+  if (!props.dirty) return;
+  const paths = [
+    ...props.dirty.plays.map((p) => p.path),
+    ...props.dirty.sidecars.map((p) => p.path),
+    ...props.dirty.other.map((p) => p.path),
+  ];
+  if (paths.length === 0) return;
+  openCommitPrompt(paths, 'Library cleanup');
+}
+
+function discardRow(dp: DirtyPath) {
+  if (!confirm(`Discard changes to ${dp.path}? This cannot be undone.`)) return;
+  emit('discard', [dp.path]);
+}
+
+function discardSection(items: DirtyPath[]) {
+  if (items.length === 0) return;
+  if (!confirm(`Discard ${items.length} change${items.length === 1 ? '' : 's'}? This cannot be undone.`)) return;
+  emit('discard', items.map((i) => i.path));
+}
+
+function fileName(path: string): string {
+  return path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path;
+}
+</script>
+
+<template>
+  <BaseModal :open="open" title="Review Library Changes" @close="emit('close')">
+    <div class="flex flex-col gap-4 min-w-[480px] max-w-[640px]">
+      <div class="flex items-center justify-between">
+        <p class="text-xs text-text-muted">
+          <span v-if="totalCount === 0">Library is clean — no uncommitted changes.</span>
+          <span v-else>
+            {{ totalCount }} uncommitted change{{ totalCount === 1 ? '' : 's' }} across your library.
+            Snapshots only commit the active file; this is where sibling and out-of-band changes get reconciled.
+          </span>
+        </p>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 text-xs text-text-main hover:bg-black/5 dark:hover:bg-white/5 disabled:opacity-50"
+          :disabled="busy"
+          @click="emit('refresh')"
+        >
+          <RefreshCw class="w-3 h-3" /> Refresh
+        </button>
+      </div>
+
+      <div
+        v-for="section in sections"
+        :key="section.id"
+        class="flex flex-col gap-1.5 rounded-md border border-border p-3"
+      >
+        <div class="flex items-center justify-between">
+          <h4 class="text-[10px] uppercase tracking-[0.15em] font-bold text-text-muted">
+            {{ section.label }} ({{ section.items.length }})
+          </h4>
+          <div class="flex gap-1.5">
+            <button
+              type="button"
+              class="inline-flex items-center gap-1 rounded border border-border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-text-main hover:bg-brass-500/10 disabled:opacity-50"
+              :disabled="busy"
+              @click="commitSection(section.id, section.items)"
+            >
+              <GitCommit class="w-3 h-3" /> Commit all
+            </button>
+            <button
+              type="button"
+              class="inline-flex items-center gap-1 rounded border border-border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-text-muted hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50"
+              :disabled="busy"
+              @click="discardSection(section.items)"
+            >
+              <Trash2 class="w-3 h-3" /> Discard all
+            </button>
+          </div>
+        </div>
+        <ul class="flex flex-col gap-0.5">
+          <li
+            v-for="item in section.items"
+            :key="item.path"
+            class="flex items-center justify-between gap-2 text-xs py-1 px-2 rounded hover:bg-black/5 dark:hover:bg-white/5"
+          >
+            <span class="flex items-center gap-2 truncate flex-1">
+              <span
+                class="text-[9px] uppercase tracking-wide font-bold w-16 shrink-0"
+                :class="kindClass(item.kind)"
+              >
+                {{ kindLabel(item.kind) }}
+              </span>
+              <span class="truncate text-text-main" :title="item.path">{{ item.path }}</span>
+            </span>
+            <div class="flex gap-1 shrink-0">
+              <button
+                type="button"
+                class="rounded p-1 text-text-muted hover:bg-brass-500/10 hover:text-brass-500 disabled:opacity-50"
+                title="Commit this change"
+                :disabled="busy"
+                @click="commitRow(item)"
+              >
+                <Check class="w-3 h-3" />
+              </button>
+              <button
+                type="button"
+                class="rounded p-1 text-text-muted hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50"
+                title="Discard this change"
+                :disabled="busy"
+                @click="discardRow(item)"
+              >
+                <Trash2 class="w-3 h-3" />
+              </button>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="flex justify-end gap-2 pt-1 border-t border-border">
+        <button
+          type="button"
+          class="rounded-md border border-border px-3 py-1.5 text-sm font-bold text-text-main hover:bg-black/5 dark:hover:bg-white/5"
+          @click="emit('close')"
+        >
+          Close
+        </button>
+        <button
+          type="button"
+          class="rounded-md bg-brass-500 px-3 py-1.5 text-sm font-bold text-ember-950 hover:bg-brass-400 disabled:opacity-50"
+          :disabled="busy || totalCount === 0"
+          @click="commitAll"
+        >
+          Commit all changes…
+        </button>
+      </div>
+    </div>
+  </BaseModal>
+
+  <PromptModal
+    :open="promptOpen"
+    title="Commit Changes"
+    label="Commit message"
+    :initial-value="promptInitial"
+    submit-label="Commit"
+    @close="promptOpen = false; pendingCommitPaths = []"
+    @submit="submitCommit"
+  />
+</template>

--- a/web/src/desktop/ReviewChangesModal.vue
+++ b/web/src/desktop/ReviewChangesModal.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue';
 import { Check, GitCommit, RefreshCw, Trash2 } from 'lucide-vue-next';
 import BaseModal from '../components/shared/BaseModal.vue';
 import PromptModal from './PromptModal.vue';
+import ConfirmModal from './ConfirmModal.vue';
 import type { DirtyPath, LibraryDirty } from './types';
 
 // Surfaces library-wide uncommitted changes — sibling-file edits, untracked
@@ -27,6 +28,11 @@ const emit = defineEmits<{
 const promptOpen = ref(false);
 const pendingCommitPaths = ref<string[]>([]);
 const promptInitial = ref('');
+
+const discardConfirmOpen = ref(false);
+const pendingDiscardPaths = ref<string[]>([]);
+const discardConfirmTitle = ref('');
+const discardConfirmMessage = ref('');
 
 const sections = computed(() => {
   const d = props.dirty;
@@ -90,14 +96,30 @@ function commitAll() {
 }
 
 function discardRow(dp: DirtyPath) {
-  if (!confirm(`Discard changes to ${dp.path}? This cannot be undone.`)) return;
-  emit('discard', [dp.path]);
+  pendingDiscardPaths.value = [dp.path];
+  discardConfirmTitle.value = 'Discard change?';
+  discardConfirmMessage.value = `Discard changes to ${dp.path}? This cannot be undone.`;
+  discardConfirmOpen.value = true;
 }
 
 function discardSection(items: DirtyPath[]) {
   if (items.length === 0) return;
-  if (!confirm(`Discard ${items.length} change${items.length === 1 ? '' : 's'}? This cannot be undone.`)) return;
-  emit('discard', items.map((i) => i.path));
+  pendingDiscardPaths.value = items.map((i) => i.path);
+  discardConfirmTitle.value = 'Discard changes?';
+  discardConfirmMessage.value = `Discard ${items.length} change${items.length === 1 ? '' : 's'}? This cannot be undone.`;
+  discardConfirmOpen.value = true;
+}
+
+function confirmDiscard() {
+  const paths = pendingDiscardPaths.value;
+  discardConfirmOpen.value = false;
+  pendingDiscardPaths.value = [];
+  if (paths.length > 0) emit('discard', paths);
+}
+
+function cancelDiscard() {
+  discardConfirmOpen.value = false;
+  pendingDiscardPaths.value = [];
 }
 
 function fileName(path: string): string {
@@ -221,5 +243,15 @@ function fileName(path: string): string {
     submit-label="Commit"
     @close="promptOpen = false; pendingCommitPaths = []"
     @submit="submitCommit"
+  />
+
+  <ConfirmModal
+    :open="discardConfirmOpen"
+    :title="discardConfirmTitle"
+    :message="discardConfirmMessage"
+    confirm-label="Discard"
+    destructive
+    @close="cancelDiscard"
+    @confirm="confirmDiscard"
   />
 </template>

--- a/web/src/desktop/StatusBar.vue
+++ b/web/src/desktop/StatusBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { FolderOpen } from 'lucide-vue-next';
+import { FolderOpen, GitMerge } from 'lucide-vue-next';
 import type { FileGitStatus } from './types';
 
 // StatusBar is the desktop app's single bottom chrome strip. It carries:
@@ -22,10 +22,15 @@ const props = defineProps<{
   gitStatus: FileGitStatus | null;
   hasLibrary: boolean;
   hasActiveFile: boolean;
+  // Library-wide uncommitted-change count. Distinct from per-file
+  // gitStatus.dirty (which only covers the active file). When > 0, a
+  // sidebar-adjacent affordance prompts the user to open Review Changes.
+  libraryDirtyCount: number;
 }>();
 
 defineEmits<{
   (e: 'revealLibrary'): void;
+  (e: 'reviewLibraryChanges'): void;
 }>();
 
 // formatRelativeTime renders a compact human-readable duration for the
@@ -110,6 +115,17 @@ const libraryButtonTitle = computed(() => {
     >
       {{ wordCount.toLocaleString() }} words
     </span>
+
+    <button
+      v-if="libraryDirtyCount > 0"
+      type="button"
+      class="inline-flex items-center gap-1.5 px-1.5 py-0.5 rounded text-amber-700 dark:text-amber-300 hover:bg-amber-500/15 focus:outline-none focus:bg-amber-500/15 transition-colors"
+      :title="`Library has ${libraryDirtyCount} uncommitted change${libraryDirtyCount === 1 ? '' : 's'} — click to review`"
+      @click="$emit('reviewLibraryChanges')"
+    >
+      <GitMerge class="w-3 h-3 shrink-0" />
+      <span class="font-bold">{{ libraryDirtyCount }} uncommitted</span>
+    </button>
 
     <span v-if="gitStatus && hasActiveFile" class="inline-flex items-center gap-1.5">
       <span

--- a/web/src/desktop/commands.ts
+++ b/web/src/desktop/commands.ts
@@ -43,6 +43,11 @@ export interface CommandContext {
     openNewFolderPrompt: (parentPath?: string) => void;
     openExportDialog: () => void;
     openSaveVersionPrompt: () => void;
+    openReviewChanges: () => void;
+    // Confirm-and-delete the active library file. Implemented in the host
+    // so the confirm-prompt UX (BaseModal vs native confirm) stays in one
+    // place; commands.ts just opens it.
+    requestDeleteActiveFile: () => void;
   };
 }
 
@@ -233,6 +238,15 @@ export function createCommandHandlers(ctx: CommandContext): Array<[string, Handl
     ["insert.scene", { handler: () => editor.applyFormat("scene"), isEnabled: hasActiveFileEditable }],
     ["insert.song", { handler: () => editor.applyFormat("song"), isEnabled: hasActiveFileEditable }],
     ["insert.pageBreak", { handler: () => editor.applyFormat("page-break"), isEnabled: hasActiveFileEditable }],
+
+    ["library.delete", {
+      handler: () => ui.requestDeleteActiveFile(),
+      isEnabled: hasActiveFileEditable,
+    }],
+    ["library.reviewChanges", {
+      handler: () => ui.openReviewChanges(),
+      isEnabled: () => (workspace.state.libraryDirty?.count ?? 0) > 0,
+    }],
 
     ["help.toggle", { handler: () => toggleDrawerTab("help"), isEnabled: hasActiveFile }],
     ["help.github", { handler: () => env.openURL("https://github.com/jscaltreto/downstage") }],

--- a/web/src/desktop/naming.ts
+++ b/web/src/desktop/naming.ts
@@ -1,0 +1,35 @@
+// Library files are .ds-only by design. The extension is implementation
+// detail — writers think of "Act One", not "Act One.ds" — and showing it
+// in the rename input invites a footgun (delete the extension, file
+// disappears from the library since it no longer matches the .ds filter).
+//
+// These helpers strip .ds for display and re-append it on write. Folders
+// are passed through untouched; callers must only invoke the file-name
+// helpers when the entry is a file.
+
+const DS_RE = /\.ds$/i;
+
+export function displayFileName(name: string): string {
+  return name.replace(DS_RE, '');
+}
+
+export function displayFilePath(path: string): string {
+  if (!path.includes('/') && !path.includes('\\')) {
+    return displayFileName(path);
+  }
+  const idx = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+  const dir = path.slice(0, idx + 1);
+  const base = path.slice(idx + 1);
+  return dir + displayFileName(base);
+}
+
+// Normalize whatever the user typed in a rename input back to a real .ds
+// filename. We only strip a trailing `.ds` the user happened to type (so
+// "Act One" and "Act One.ds" both land at "Act One.ds"); other dots are
+// preserved verbatim. Stripping aggressively would munge legitimate
+// names like "Act 2.1".
+export function normalizeFileRename(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return '';
+  return `${trimmed.replace(DS_RE, '')}.ds`;
+}

--- a/web/src/desktop/types.ts
+++ b/web/src/desktop/types.ts
@@ -9,9 +9,23 @@ export interface LibraryFile {
 export interface LibraryNode {
   path: string;
   name: string;
-  kind: 'folder' | 'file';
+  kind: 'folder' | 'file' | 'deleted-file';
   children?: LibraryNode[];
   updatedAt?: string;
+}
+
+export type DirtyKind = 'untracked' | 'modified' | 'deleted';
+
+export interface DirtyPath {
+  path: string;
+  kind: DirtyKind;
+}
+
+export interface LibraryDirty {
+  plays: DirtyPath[];
+  sidecars: DirtyPath[];
+  other: DirtyPath[];
+  count: number;
 }
 
 export interface Revision {
@@ -56,6 +70,11 @@ export interface LibraryEnv {
   hideRevision(hash: string): Promise<void>;
   unhideRevision(hash: string): Promise<void>;
   getFileGitStatus(path: string): Promise<FileGitStatus>;
+  getLibraryDirty(): Promise<LibraryDirty>;
+  commitPaths(paths: string[], message: string): Promise<void>;
+  discardPaths(paths: string[]): Promise<void>;
+  deleteLibraryFile(path: string): Promise<void>;
+  restoreLibraryFile(path: string): Promise<void>;
   getCurrentLibrary(): Promise<string>;
   getLastActiveFile(): Promise<string>;
   setActiveLibraryFile(rel: string): Promise<void>;

--- a/web/src/desktop/workspace.ts
+++ b/web/src/desktop/workspace.ts
@@ -1,5 +1,5 @@
 import { computed, reactive, type ComputedRef } from "vue";
-import type { DesktopCapabilities, FileGitStatus, LibraryFile, LibraryNode, Revision } from "./types";
+import type { DesktopCapabilities, DirtyPath, FileGitStatus, LibraryDirty, LibraryFile, LibraryNode, Revision } from "./types";
 
 export type DrawerDock = 'bottom' | 'right';
 
@@ -28,7 +28,16 @@ export interface WorkspaceState {
   hiddenRevisionHashes: Set<string>;
   showHidden: boolean;
   externalFile: { absPath: string; content: string } | null;
+  // Library-wide dirty state (sibling files / out-of-band edits / deleted
+  // tracked files). Distinct from gitStatus, which is per-active-file.
+  libraryDirty: LibraryDirty | null;
 }
+
+// How often to re-poll worktree status while the window is focused. 30s
+// trades off responsiveness for cost; window-focus also triggers an
+// immediate refresh, so unfocused-then-refocused is instant. fsnotify
+// would obsolete this; deferred.
+export const LIBRARY_DIRTY_POLL_MS = 30_000;
 
 const dirtyReconcileMs = 2000;
 
@@ -54,11 +63,13 @@ export class Workspace {
   public state: WorkspaceState;
   public libraryFiles: ComputedRef<LibraryFile[]>;
   public visibleRevisions!: ComputedRef<Revision[]>;
+  public deletedFiles!: ComputedRef<DirtyPath[]>;
 
   private hydrated = false;
   private dirtyReconcileTimer: ReturnType<typeof setTimeout> | null = null;
   private sidebarPersistTimer: ReturnType<typeof setTimeout> | null = null;
   private drawerWidthPersistTimer: ReturnType<typeof setTimeout> | null = null;
+  private libraryDirtyPollTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(private env: DesktopCapabilities) {
     this.state = reactive<WorkspaceState>({
@@ -86,9 +97,15 @@ export class Workspace {
       hiddenRevisionHashes: new Set<string>(),
       showHidden: false,
       externalFile: null,
+      libraryDirty: null,
     });
 
     this.libraryFiles = computed(() => flattenLibraryTree(this.state.libraryTree));
+    this.deletedFiles = computed(() => {
+      const d = this.state.libraryDirty;
+      if (!d) return [];
+      return d.plays.filter((p) => p.kind === "deleted");
+    });
     this.visibleRevisions = computed(() => {
       if (this.state.showHidden) return this.state.revisions;
       if (this.state.hiddenRevisionHashes.size === 0) {
@@ -263,6 +280,69 @@ export class Workspace {
     const path = await this.env.createLibraryFile(name, content);
     this.state.libraryTree = await this.env.getLibraryTree();
     return path;
+  }
+
+  // --- library-wide dirty surface (sibling/out-of-band reconciliation) ---
+
+  async refreshLibraryDirty(): Promise<void> {
+    if (!this.state.libraryPath) {
+      this.state.libraryDirty = null;
+      return;
+    }
+    try {
+      this.state.libraryDirty = await this.env.getLibraryDirty();
+    } catch {
+      this.state.libraryDirty = null;
+    }
+  }
+
+  startLibraryDirtyPolling(): void {
+    if (this.libraryDirtyPollTimer !== null) return;
+    this.libraryDirtyPollTimer = setInterval(() => {
+      void this.refreshLibraryDirty();
+    }, LIBRARY_DIRTY_POLL_MS);
+  }
+
+  stopLibraryDirtyPolling(): void {
+    if (this.libraryDirtyPollTimer === null) return;
+    clearInterval(this.libraryDirtyPollTimer);
+    this.libraryDirtyPollTimer = null;
+  }
+
+  // Deleting the active file leaves the editor pointing at nothing.
+  // Caller (AppDesktop) is responsible for the flushSave-before-delete
+  // dance and for opening a replacement file via selectLibraryFile after
+  // this call returns. We retarget activeFile to null here so the editor
+  // stops trying to read the dead path during the gap.
+  async deleteFile(path: string): Promise<void> {
+    const wasActive = this.state.activeFile === path;
+    await this.env.deleteLibraryFile(path);
+    if (wasActive) {
+      this.state.activeFile = null;
+      this.state.gitStatus = null;
+      this.state.revisions = [];
+      this.clearRevisionView();
+      this.cancelDirtyReconcile();
+    }
+    this.state.libraryTree = await this.env.getLibraryTree();
+    await this.refreshLibraryDirty();
+  }
+
+  async restoreFile(path: string): Promise<void> {
+    await this.env.restoreLibraryFile(path);
+    this.state.libraryTree = await this.env.getLibraryTree();
+    await this.refreshLibraryDirty();
+  }
+
+  async commitDirtyPaths(paths: string[], message: string): Promise<void> {
+    await this.env.commitPaths(paths, message);
+    await this.refreshLibraryDirty();
+  }
+
+  async discardDirtyPaths(paths: string[]): Promise<void> {
+    await this.env.discardPaths(paths);
+    this.state.libraryTree = await this.env.getLibraryTree();
+    await this.refreshLibraryDirty();
   }
 
   async snapshotFile(message: string) {
@@ -528,6 +608,12 @@ function clampDrawerRightWidth(px: number): number {
   return Math.max(minDrawerRightWidth, Math.min(maxDrawerRightWidth, Math.round(px)));
 }
 
+// flattenLibraryTree returns only live library files. Deleted-tracked
+// files are NEVER included — they belong to a separate UI surface
+// (LibraryTree's "Deleted" section) and including them here would let
+// the palette file-pick, navigate.nextFile cycling, and other consumers
+// try to open dead paths. Anyone adding a navigation feature: if the
+// list of openable files matters, this function is the source of truth.
 export function flattenLibraryTree(nodes: readonly LibraryNode[]): LibraryFile[] {
   const out: LibraryFile[] = [];
   const walk = (ns: readonly LibraryNode[]) => {
@@ -536,6 +622,7 @@ export function flattenLibraryTree(nodes: readonly LibraryNode[]): LibraryFile[]
         if (n.children) walk(n.children);
         continue;
       }
+      if (n.kind === "deleted-file") continue;
       out.push({
         path: n.path,
         name: n.name,

--- a/web/src/desktop/workspace.ts
+++ b/web/src/desktop/workspace.ts
@@ -294,6 +294,15 @@ export class Workspace {
     } catch {
       this.state.libraryDirty = null;
     }
+    // The live tree must stay in sync with the dirty surface. Without
+    // this, an out-of-band `rm` shows up in the Deleted section *and*
+    // still appears as a live file in the tree until something else
+    // refreshes it.
+    try {
+      this.state.libraryTree = await this.env.getLibraryTree();
+    } catch {
+      // leave the previous tree in place if the walk fails
+    }
   }
 
   startLibraryDirtyPolling(): void {
@@ -336,6 +345,9 @@ export class Workspace {
 
   async commitDirtyPaths(paths: string[], message: string): Promise<void> {
     await this.env.commitPaths(paths, message);
+    // refreshLibraryDirty refreshes the tree too — that picks up the
+    // case where commitPaths includes a deletion (permanent-delete from
+    // the Deleted section).
     await this.refreshLibraryDirty();
   }
 

--- a/web/src/wailsjs/go/desktop/App.d.ts
+++ b/web/src/wailsjs/go/desktop/App.d.ts
@@ -15,13 +15,19 @@ export function ChangeLibraryLocation():Promise<string>;
 
 export function CodeActions(arg1:string,arg2:number,arg3:number,arg4:Array<string>):Promise<desktop.codeActionsResultJSON>;
 
+export function CommitPaths(arg1:Array<string>,arg2:string):Promise<void>;
+
 export function Completion(arg1:string,arg2:number,arg3:number):Promise<protocol.CompletionList>;
 
 export function CreateLibraryFile(arg1:string,arg2:string):Promise<string>;
 
 export function CreateLibraryFolder(arg1:string):Promise<void>;
 
+export function DeleteLibraryFile(arg1:string):Promise<void>;
+
 export function Diagnostics(arg1:string):Promise<Array<desktop.diagnosticJSON>>;
+
+export function DiscardPaths(arg1:Array<string>):Promise<void>;
 
 export function DocumentSymbols(arg1:string):Promise<desktop.documentSymbolsResultJSON>;
 
@@ -34,6 +40,8 @@ export function GetFileGitStatus(arg1:string):Promise<desktop.FileGitStatus>;
 export function GetHiddenRevisions():Promise<Array<string>>;
 
 export function GetLastActiveFile():Promise<string>;
+
+export function GetLibraryDirty():Promise<desktop.LibraryDirty>;
 
 export function GetLibraryTree():Promise<Array<desktop.LibraryNode>>;
 
@@ -68,6 +76,8 @@ export function RenameLibraryEntry(arg1:string,arg2:string):Promise<string>;
 export function RenderHTML(arg1:string,arg2:string):Promise<string>;
 
 export function RenderPDF(arg1:string,arg2:desktop.PdfExportOptions):Promise<string>;
+
+export function RestoreLibraryFile(arg1:string):Promise<void>;
 
 export function RevealLibraryInExplorer():Promise<void>;
 

--- a/web/src/wailsjs/go/desktop/App.js
+++ b/web/src/wailsjs/go/desktop/App.js
@@ -22,6 +22,10 @@ export function CodeActions(arg1, arg2, arg3, arg4) {
   return window['go']['desktop']['App']['CodeActions'](arg1, arg2, arg3, arg4);
 }
 
+export function CommitPaths(arg1, arg2) {
+  return window['go']['desktop']['App']['CommitPaths'](arg1, arg2);
+}
+
 export function Completion(arg1, arg2, arg3) {
   return window['go']['desktop']['App']['Completion'](arg1, arg2, arg3);
 }
@@ -34,8 +38,16 @@ export function CreateLibraryFolder(arg1) {
   return window['go']['desktop']['App']['CreateLibraryFolder'](arg1);
 }
 
+export function DeleteLibraryFile(arg1) {
+  return window['go']['desktop']['App']['DeleteLibraryFile'](arg1);
+}
+
 export function Diagnostics(arg1) {
   return window['go']['desktop']['App']['Diagnostics'](arg1);
+}
+
+export function DiscardPaths(arg1) {
+  return window['go']['desktop']['App']['DiscardPaths'](arg1);
 }
 
 export function DocumentSymbols(arg1) {
@@ -60,6 +72,10 @@ export function GetHiddenRevisions() {
 
 export function GetLastActiveFile() {
   return window['go']['desktop']['App']['GetLastActiveFile']();
+}
+
+export function GetLibraryDirty() {
+  return window['go']['desktop']['App']['GetLibraryDirty']();
 }
 
 export function GetLibraryTree() {
@@ -128,6 +144,10 @@ export function RenderHTML(arg1, arg2) {
 
 export function RenderPDF(arg1, arg2) {
   return window['go']['desktop']['App']['RenderPDF'](arg1, arg2);
+}
+
+export function RestoreLibraryFile(arg1) {
+  return window['go']['desktop']['App']['RestoreLibraryFile'](arg1);
 }
 
 export function RevealLibraryInExplorer() {

--- a/web/src/wailsjs/go/models.ts
+++ b/web/src/wailsjs/go/models.ts
@@ -20,6 +20,20 @@ export namespace desktop {
 	        this.paletteHidden = source["paletteHidden"];
 	    }
 	}
+	export class DirtyPath {
+	    path: string;
+	    kind: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new DirtyPath(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.path = source["path"];
+	        this.kind = source["kind"];
+	    }
+	}
 	export class ExternalFileResult {
 	    content: string;
 	    insideLibrary: boolean;
@@ -69,6 +83,42 @@ export namespace desktop {
 	        this.untracked = source["untracked"];
 	        this.missing = source["missing"];
 	    }
+	}
+	export class LibraryDirty {
+	    plays: DirtyPath[];
+	    sidecars: DirtyPath[];
+	    other: DirtyPath[];
+	    count: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new LibraryDirty(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.plays = this.convertValues(source["plays"], DirtyPath);
+	        this.sidecars = this.convertValues(source["sidecars"], DirtyPath);
+	        this.other = this.convertValues(source["other"], DirtyPath);
+	        this.count = source["count"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
 	}
 	export class LibraryNode {
 	    path: string;


### PR DESCRIPTION
## Summary

Closes the three sidebar/git-status gaps from issue #189 (Track A2-α). Plan-reviewed via `/plan-review`; Codex converged at round 2 (LGTM) on the revised plan.

| Item | What it does |
|------|--------------|
| **Delete from sidebar** | Right-click "Delete…" on a `.ds` file. `flushSave` + retarget active file if needed. |
| **Restore deleted-tracked files** | Flat "Deleted" section below the live tree. Right-click → Restore from last version / Permanently delete. |
| **Library-wide dirty surface** | Status bar shows "N uncommitted" when sibling/untracked/sidecar changes accumulate; click opens **Review Changes** modal with grouped sections (Plays / Library settings / Other), per-row + batch Commit/Discard. |

## Design highlights

- **`SnapshotFile` stays single-path.** The Review Changes pane is the explicit affordance for sibling reconciliation — preserves the "save this version of this file" intent.
- **Generic batch helpers**, not delete-specific specials: `CommitPaths(paths, msg)` (Add for paths-on-disk, Remove for paths-deleted, single commit), `DiscardPaths(paths)` (per-kind dispatch).
- **30s periodic poll while focused** + immediate refresh on window focus + after every local mutation. No fsnotify (cross-platform dep cost didn't pencil out for v1).
- **Sidecars surface explicitly**, labeled "Library settings — auto-managed by Downstage". Blanket-hiding `.downstage/*` would have broken A2-β's `revision-names.json` by construction.
- **`flattenLibraryTree` excludes deleted-file kind** so palette file-pick and `navigate.nextFile` can't open dead paths (code comment locks the contract).
- **Restore precondition-blocked on Modified files** — forces explicit Discard, no silent overwrite.

## Test plan

- [x] `go test ./internal/desktop/ -race` clean (13 new tests covering categorization, batch commit shape, per-kind discard dispatch, delete/restore preconditions)
- [x] `npm --prefix web run test` — 211 pass (14 new for A2: 6 workspace, 8 ReviewChangesModal)
- [x] `make desktop-build` clean

Manual smoke (on the built binary):
- [x] Right-click → Delete… a `.ds` file in the sidebar. File disappears; if it was active, editor flips to next file (or empties). Git log shows a "Delete `<name>`" commit.
- [x] `rm` a `.ds` file from a terminal. Within 30s (or on focus): row appears in the Deleted section. Right-click → Restore from last version. File returns at HEAD content. No extra commit.
- [x] `sed` edit a sibling file + `touch` a new `.ds` from a terminal. Status bar shows "2 uncommitted". Click → modal opens with the two changes under Plays. Commit-all → message prompt → commit. Indicator clears.
- [x] From the Deleted section: right-click → Permanently delete. Confirm dialog with explicit language. Row disappears; git log shows the deletion commit.

## Out of scope (per approved plan)

- A2-β (rename existing versions) — separate follow-up PR; sidecar JSON in `.downstage/revision-names.json`
- Pagination (no >100-revision fixture)
- Scroll-sync polish (no reported issue)
- fsnotify (revisit only if periodic poll proves insufficient)

Refs #189