### PR TITLE
feat(web): structured Help drawer (Track B of #189)

### DIFF
--- a/internal/desktop/commands.go
+++ b/internal/desktop/commands.go
@@ -146,7 +146,7 @@ func Commands() []Command {
 		{ID: CmdLibraryReviewChanges, Label: "Review Library Changes…", Category: CategoryFile},
 		{ID: CmdLibraryCommitChanges, Label: "Commit Library Changes", Category: CategoryFile, PaletteHidden: true},
 
-		{ID: CmdHelpToggle, Label: "View Help", Category: CategoryHelp, Accelerator: "cmdorctrl+shift+/", MenuPath: []string{"Help"}},
+		{ID: CmdHelpToggle, Label: "View Help", Category: CategoryHelp, Accelerator: "cmdorctrl+?", MenuPath: []string{"Help"}},
 		{ID: CmdHelpGitHub, Label: "GitHub", Category: CategoryHelp, MenuPath: []string{"Help"}, BeforeSeparator: true},
 		{ID: CmdHelpDocs, Label: "Documentation", Category: CategoryHelp, MenuPath: []string{"Help"}},
 		{ID: CmdHelpAbout, Label: "About Downstage Write…", Category: CategoryHelp, MenuPath: []string{"Help"}, BeforeSeparator: true},

--- a/web/e2e/workbench.spec.ts
+++ b/web/e2e/workbench.spec.ts
@@ -29,8 +29,10 @@ test.describe("workbench", () => {
 
     const drawer = editor.drawer;
     await expect(drawer).toContainText("Workbench Smoke");
-    await expect(drawer).toContainText("ACT I");
-    await expect(drawer).toContainText("SCENE 1");
+    // Outline renders symbol display names in title case ("Act I", "Scene 1")
+    // regardless of the source heading's case in the .ds file.
+    await expect(drawer).toContainText(/Act I/i);
+    await expect(drawer).toContainText(/Scene 1/i);
   });
 
   test("Stats tab shows manuscript counts", async ({ page }) => {
@@ -98,7 +100,7 @@ test.describe("workbench", () => {
     await expect(editor.editor).toContainText("apple apple apple");
   });
 
-  test("Help tab renders the Writing/Tools/Shortcuts sections", async ({ page }) => {
+  test("Help tab renders the sectioned help nav", async ({ page }) => {
     const editor = new EditorPage(page);
     await editor.gotoReady();
     await editor.welcomeStartButton.click();
@@ -106,11 +108,16 @@ test.describe("workbench", () => {
     await editor.openDrawer("help");
 
     const drawer = editor.drawer;
-    await expect(drawer.getByRole("button", { name: "Writing" })).toBeVisible();
-    await expect(drawer.getByRole("button", { name: "Tools" })).toBeVisible();
-    await expect(drawer.getByRole("button", { name: "Shortcuts" })).toBeVisible();
+    // Section nav is a tablist; the inner buttons carry role="tab".
+    // Web host filters out desktop-only sections (Versions, Library,
+    // Settings). The four cross-host sections must render.
+    const nav = drawer.getByRole("tablist", { name: "Help sections" });
+    await expect(nav.getByRole("tab", { name: "Getting Started" })).toBeVisible();
+    await expect(nav.getByRole("tab", { name: "Writing" })).toBeVisible();
+    await expect(nav.getByRole("tab", { name: "Export" })).toBeVisible();
+    await expect(nav.getByRole("tab", { name: "Shortcuts" })).toBeVisible();
 
-    await drawer.getByRole("button", { name: "Shortcuts" }).click();
+    await nav.getByRole("tab", { name: "Shortcuts" }).click();
     await expect(drawer).toContainText(/Bold|Italic|Find/);
   });
 

--- a/web/src/AppDesktop.vue
+++ b/web/src/AppDesktop.vue
@@ -14,6 +14,9 @@ import { CommandDispatcher } from './desktop/command-dispatcher';
 import { createCommandHandlers, type CommandContext } from './desktop/commands';
 import { registerDispatcher } from './desktop/dispatcher-registry';
 import type { WorkbenchTab } from './components/shared/workbench-tabs';
+import type { ShortcutEntry } from './components/shared/help-sections';
+import { formatAccelerator } from './core/accelerators';
+import { isMac } from './core/platform';
 import type { SearchMode } from './core/engine';
 import ToastManager from './components/shared/ToastManager.vue';
 import Editor from './components/shared/Editor.vue';
@@ -47,8 +50,35 @@ const isV1Document = ref(false);
 const cursor = ref<{ line: number; col: number }>({ line: 1, col: 1 });
 const wordCount = ref(0);
 
+// Help drawer's Shortcuts section consumes the command catalog the
+// native menu was built from. Loaded once on mount; renders a loading
+// state until then. The bridge call is async, can fail in dev
+// (Wails runtime not present), and the help pane is non-critical so
+// errors only console-log.
+const helpShortcuts = ref<ShortcutEntry[]>([]);
+const helpShortcutsLoading = ref(true);
+
 function errorMessage(error: unknown): string {
   return String((error as { message?: unknown } | null)?.message ?? error);
+}
+
+async function loadHelpShortcuts(): Promise<void> {
+  try {
+    const cmds = await props.env.getCommands();
+    helpShortcuts.value = cmds
+      .filter((c) => !c.paletteHidden && !!c.accelerator)
+      .map<ShortcutEntry>((c) => ({
+        id: c.id,
+        label: c.label,
+        keys: formatAccelerator(c.accelerator ?? '', { isMac }),
+        group: c.category,
+      }));
+  } catch (err) {
+    console.error('Failed to load command catalog for help drawer:', err);
+    helpShortcuts.value = [];
+  } finally {
+    helpShortcutsLoading.value = false;
+  }
 }
 
 let sidebarDragStartX = 0;
@@ -431,6 +461,8 @@ const editorDocumentKey = computed(() => {
 onMounted(async () => {
   await store.init();
   await workspace.init();
+
+  void loadHelpShortcuts();
 
   if (workspace.state.libraryPath && workspace.libraryFiles.value.length > 0) {
     const lastFile = await props.env.getLastActiveFile();
@@ -942,6 +974,9 @@ watch(activeContent, (newContent) => {
               :remove-spell-allowlist-word="removeSpellAllowlistWord"
               :drawer-dock="workspace.state.drawerDock"
               :drawer-right-width="workspace.state.drawerRightWidth"
+              :help-host="'desktop'"
+              :help-shortcuts="helpShortcuts"
+              :help-shortcuts-loading="helpShortcutsLoading"
               @migration-state-change="isV1Document = $event"
               @open-spellcheck-settings="() => dispatcher?.dispatch('file.settings.spellcheck')"
               @update:cursor="cursor = $event"

--- a/web/src/AppWeb.vue
+++ b/web/src/AppWeb.vue
@@ -13,7 +13,24 @@ import ToastManager from './components/shared/ToastManager.vue';
 import Editor from './components/shared/Editor.vue';
 import WelcomeModal from './components/shared/WelcomeModal.vue';
 import type { WorkbenchTab } from './components/shared/workbench-tabs';
+import type { ShortcutEntry } from './components/shared/help-sections';
+import { shortcuts } from './core/platform';
+import { helpLinks } from './core/help-links';
 import type { SearchMode } from './core/engine';
+
+// Web-side shortcut list for the Help drawer. These are the keys the
+// CodeMirror engine binds (`engine.ts`) — desktop has many more via its
+// native menu, but in the browser these are the ones the user can
+// actually press.
+const webHelpShortcuts: ShortcutEntry[] = [
+  { id: 'format.bold',         label: shortcuts.bold.label,        keys: shortcuts.bold.keys,        group: 'format' },
+  { id: 'format.italic',       label: shortcuts.italic.label,      keys: shortcuts.italic.keys,      group: 'format' },
+  { id: 'format.underline',    label: shortcuts.underline.label,   keys: shortcuts.underline.keys,   group: 'format' },
+  { id: 'edit.find',           label: shortcuts.find.label,        keys: shortcuts.find.keys,        group: 'edit' },
+  { id: 'edit.findReplace',    label: shortcuts.findReplace.label, keys: shortcuts.findReplace.keys, group: 'edit' },
+  { id: 'view.togglePreview',  label: shortcuts.preview.label,     keys: shortcuts.preview.keys,     group: 'view' },
+  { id: 'help.toggle',         label: shortcuts.help.label,        keys: shortcuts.help.keys,        group: 'help' },
+];
 
 const props = defineProps<{
   env: EditorEnv;
@@ -461,7 +478,7 @@ watch(activeContent, (newContent) => {
         </h1>
         <button
           class="flex items-center gap-1.5 text-xs px-3 py-1 rounded-full border border-black/10 dark:border-white/10 bg-black/5 dark:bg-white/5 text-text-muted hover:bg-black/10 dark:hover:bg-white/10 hover:text-text-main transition-colors font-medium"
-          @click="env.openURL('https://www.getdownstage.com/syntax/')"
+          @click="env.openURL(helpLinks.syntax)"
         >
           <ExternalLink class="w-3 h-3" /> <span class="hidden md:inline">Syntax Guide</span>
         </button>
@@ -502,6 +519,8 @@ watch(activeContent, (newContent) => {
         :add-spell-allowlist-word="addSpellAllowlistWord"
         :remove-spell-allowlist-word="removeSpellAllowlistWord"
         :bind-engine-accelerators="true"
+        :help-host="'web'"
+        :help-shortcuts="webHelpShortcuts"
         @migration-state-change="isV1Document = $event"
       />
     </main>

--- a/web/src/__tests__/accelerators.test.ts
+++ b/web/src/__tests__/accelerators.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { formatAccelerator } from "../core/accelerators";
+
+describe("formatAccelerator", () => {
+  it("returns empty string for empty input", () => {
+    expect(formatAccelerator("")).toBe("");
+    expect(formatAccelerator("+++")).toBe("");
+  });
+
+  describe("mac formatting", () => {
+    it("renders cmdorctrl as ⌘ and joins symbols with no separator", () => {
+      expect(formatAccelerator("cmdorctrl+b", { isMac: true })).toBe("⌘B");
+      expect(formatAccelerator("cmdorctrl+shift+s", { isMac: true })).toBe("⌘⇧S");
+    });
+
+    it("renders optionoralt as ⌥", () => {
+      expect(formatAccelerator("cmdorctrl+optionoralt+f", { isMac: true })).toBe(
+        "⌘⌥F",
+      );
+    });
+
+    it("handles punctuation single-char keys", () => {
+      expect(formatAccelerator("cmdorctrl+shift+/", { isMac: true })).toBe("⌘⇧/");
+      expect(formatAccelerator("cmdorctrl+\\", { isMac: true })).toBe("⌘\\");
+      expect(formatAccelerator("cmdorctrl+,", { isMac: true })).toBe("⌘,");
+    });
+
+    it("renders named keys with mac glyphs", () => {
+      expect(formatAccelerator("cmdorctrl+enter", { isMac: true })).toBe("⌘⏎");
+      expect(formatAccelerator("escape", { isMac: true })).toBe("Esc");
+    });
+  });
+
+  describe("non-mac formatting", () => {
+    it("renders cmdorctrl as Ctrl and joins with +", () => {
+      expect(formatAccelerator("cmdorctrl+b", { isMac: false })).toBe("Ctrl+B");
+      expect(formatAccelerator("cmdorctrl+shift+s", { isMac: false })).toBe(
+        "Ctrl+Shift+S",
+      );
+    });
+
+    it("renders optionoralt as Alt", () => {
+      expect(formatAccelerator("cmdorctrl+optionoralt+f", { isMac: false })).toBe(
+        "Ctrl+Alt+F",
+      );
+    });
+
+    it("handles punctuation single-char keys", () => {
+      expect(formatAccelerator("cmdorctrl+shift+/", { isMac: false })).toBe(
+        "Ctrl+Shift+/",
+      );
+      expect(formatAccelerator("cmdorctrl+\\", { isMac: false })).toBe("Ctrl+\\");
+      expect(formatAccelerator("cmdorctrl+,", { isMac: false })).toBe("Ctrl+,");
+    });
+
+    it("renders named keys with word labels", () => {
+      expect(formatAccelerator("cmdorctrl+enter", { isMac: false })).toBe(
+        "Ctrl+Enter",
+      );
+      expect(formatAccelerator("escape", { isMac: false })).toBe("Esc");
+    });
+  });
+
+  it("uppercases single-letter passthrough keys", () => {
+    expect(formatAccelerator("z", { isMac: true })).toBe("Z");
+    expect(formatAccelerator("cmdorctrl+shift+z", { isMac: false })).toBe(
+      "Ctrl+Shift+Z",
+    );
+  });
+
+  it("title-cases multi-char passthrough keys (e.g. function keys)", () => {
+    expect(formatAccelerator("F1", { isMac: false })).toBe("F1");
+    expect(formatAccelerator("home", { isMac: false })).toBe("Home");
+  });
+
+  // Coverage net: every accelerator the desktop catalog emits today
+  // must render to a non-empty string. Update this list when commands.go
+  // gains new accelerators.
+  it("renders every accelerator the desktop catalog currently emits", () => {
+    const desktopAccelerators = [
+      "cmdorctrl+n",
+      "cmdorctrl+o",
+      "cmdorctrl+s",
+      "cmdorctrl+shift+s",
+      "cmdorctrl+e",
+      "cmdorctrl+,",
+      "cmdorctrl+q",
+      "cmdorctrl+z",
+      "cmdorctrl+shift+z",
+      "cmdorctrl+x",
+      "cmdorctrl+c",
+      "cmdorctrl+v",
+      "cmdorctrl+a",
+      "cmdorctrl+f",
+      "cmdorctrl+optionoralt+f",
+      "cmdorctrl+k",
+      "cmdorctrl+\\",
+      "cmdorctrl+shift+b",
+      "cmdorctrl+b",
+      "cmdorctrl+i",
+      "cmdorctrl+u",
+      "cmdorctrl+shift+x",
+      "cmdorctrl+shift+/",
+    ];
+    for (const accel of desktopAccelerators) {
+      expect(formatAccelerator(accel, { isMac: true })).not.toBe("");
+      expect(formatAccelerator(accel, { isMac: false })).not.toBe("");
+    }
+  });
+});

--- a/web/src/__tests__/shared/HelpTab.test.ts
+++ b/web/src/__tests__/shared/HelpTab.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import HelpTab from "../../components/shared/HelpTab.vue";
+import { sectionsForHost } from "../../components/shared/help-sections";
+
+describe("HelpTab", () => {
+  it("desktop host shows every desktop-eligible section", async () => {
+    const wrapper = mount(HelpTab, {
+      props: {
+        openLink: async () => {},
+        host: "desktop",
+        shortcuts: [],
+        shortcutsLoading: false,
+      },
+    });
+    await flushPromises();
+    const tabs = wrapper.findAll('[role="tab"]');
+    const expected = sectionsForHost("desktop");
+    expect(tabs).toHaveLength(expected.length);
+    expect(tabs.map((t) => t.attributes("title"))).toEqual(expected.map((s) => s.label));
+  });
+
+  it("web host hides desktop-only sections", async () => {
+    const wrapper = mount(HelpTab, {
+      props: {
+        openLink: async () => {},
+        host: "web",
+      },
+    });
+    await flushPromises();
+    const tabs = wrapper.findAll('[role="tab"]');
+    const expected = sectionsForHost("web");
+    expect(tabs).toHaveLength(expected.length);
+    expect(tabs.map((t) => t.attributes("title"))).toEqual(expected.map((s) => s.label));
+    // The three sections we deliberately filter on web
+    const titles = tabs.map((t) => t.attributes("title"));
+    expect(titles).not.toContain("Versions");
+    expect(titles).not.toContain("Library");
+    expect(titles).not.toContain("Settings");
+  });
+
+  it("marks the default section as selected on mount", () => {
+    const wrapper = mount(HelpTab, {
+      props: { openLink: async () => {}, host: "desktop", shortcuts: [], shortcutsLoading: false },
+    });
+    const selected = wrapper.findAll('[role="tab"]').filter((t) =>
+      t.attributes("aria-selected") === "true",
+    );
+    expect(selected).toHaveLength(1);
+    expect(selected[0].attributes("title")).toBe("Getting Started");
+  });
+
+  it("switches active section when a tab is clicked", async () => {
+    const wrapper = mount(HelpTab, {
+      props: { openLink: async () => {}, host: "desktop", shortcuts: [], shortcutsLoading: false },
+    });
+    const shortcutsTab = wrapper
+      .findAll('[role="tab"]')
+      .find((t) => t.attributes("title") === "Shortcuts");
+    expect(shortcutsTab).toBeDefined();
+    await shortcutsTab!.trigger("click");
+    expect(shortcutsTab!.attributes("aria-selected")).toBe("true");
+  });
+
+  it("falls back to the first visible section if active becomes invalid after host change", async () => {
+    // Start on desktop, switch to Versions (desktop-only), then re-mount as
+    // web — the original activeSection ("versions") is no longer visible
+    // and should fall back to the first web-visible section.
+    const wrapper = mount(HelpTab, {
+      props: { openLink: async () => {}, host: "desktop", shortcuts: [], shortcutsLoading: false },
+    });
+    const versionsTab = wrapper
+      .findAll('[role="tab"]')
+      .find((t) => t.attributes("title") === "Versions");
+    await versionsTab!.trigger("click");
+    expect(versionsTab!.attributes("aria-selected")).toBe("true");
+
+    await wrapper.setProps({ host: "web" });
+    await flushPromises();
+
+    const selected = wrapper.findAll('[role="tab"]').filter((t) =>
+      t.attributes("aria-selected") === "true",
+    );
+    expect(selected).toHaveLength(1);
+    // First visible web section is Getting Started.
+    expect(selected[0].attributes("title")).toBe("Getting Started");
+  });
+});

--- a/web/src/__tests__/shared/ShortcutsSection.test.ts
+++ b/web/src/__tests__/shared/ShortcutsSection.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import ShortcutsSection from "../../components/shared/help/ShortcutsSection.vue";
+import type { ShortcutEntry } from "../../components/shared/help-sections";
+
+const noop = async () => {};
+
+describe("ShortcutsSection", () => {
+  it("shows the loading placeholder when loading=true", () => {
+    const wrapper = mount(ShortcutsSection, {
+      props: {
+        openLink: noop,
+        host: "desktop",
+        shortcuts: [],
+        loading: true,
+      },
+    });
+    expect(wrapper.text()).toContain("Loading shortcuts");
+    expect(wrapper.findAll("kbd")).toHaveLength(0);
+  });
+
+  it("shows the fallback notice when loading=false and no shortcuts", () => {
+    const wrapper = mount(ShortcutsSection, {
+      props: {
+        openLink: noop,
+        host: "desktop",
+        shortcuts: [],
+        loading: false,
+      },
+    });
+    expect(wrapper.text()).toContain("Shortcut list unavailable");
+  });
+
+  it("renders grouped shortcuts when a populated list is provided", () => {
+    const shortcuts: ShortcutEntry[] = [
+      { id: "file.save", label: "Save", keys: "Ctrl+S", group: "file" },
+      { id: "file.open", label: "Open…", keys: "Ctrl+O", group: "file" },
+      { id: "format.bold", label: "Bold", keys: "Ctrl+B", group: "format" },
+      { id: "help.toggle", label: "Help", keys: "Ctrl+Shift+/", group: "help" },
+    ];
+    const wrapper = mount(ShortcutsSection, {
+      props: {
+        openLink: noop,
+        host: "desktop",
+        shortcuts,
+        loading: false,
+      },
+    });
+    // group headers
+    const headers = wrapper.findAll("h3").map((h) => h.text());
+    expect(headers).toEqual(["File", "Format", "Help"]);
+    // every shortcut row renders the keys in a <kbd>
+    const kbds = wrapper.findAll("kbd").map((k) => k.text());
+    expect(kbds).toEqual(["Ctrl+S", "Ctrl+O", "Ctrl+B", "Ctrl+Shift+/"]);
+  });
+
+  it("uses different intro copy per host", () => {
+    const desktop = mount(ShortcutsSection, {
+      props: { openLink: noop, host: "desktop", shortcuts: [], loading: false },
+    });
+    expect(desktop.text()).toContain("mirror the native menu");
+
+    const web = mount(ShortcutsSection, {
+      props: { openLink: noop, host: "web", shortcuts: [], loading: false },
+    });
+    expect(web.text()).toContain("browser editor");
+  });
+});

--- a/web/src/__tests__/shared/help-sections.test.ts
+++ b/web/src/__tests__/shared/help-sections.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultHelpSection,
+  helpSections,
+  sectionsForHost,
+  shortcutGroupOrder,
+  sortShortcuts,
+  type HelpSectionId,
+  type ShortcutEntry,
+} from "../../components/shared/help-sections";
+
+describe("helpSections registry", () => {
+  it("exports exactly seven sections in the documented order", () => {
+    const ids = helpSections.map((s) => s.id);
+    expect(ids).toEqual<HelpSectionId[]>([
+      "getting-started",
+      "writing",
+      "versions",
+      "library",
+      "export",
+      "shortcuts",
+      "settings",
+    ]);
+  });
+
+  it("every section has a non-empty label, an icon, and a component", () => {
+    for (const section of helpSections) {
+      expect(section.label).not.toBe("");
+      expect(section.icon).toBeTruthy();
+      expect(section.component).toBeTruthy();
+    }
+  });
+
+  it("default section is one of the registered IDs", () => {
+    expect(helpSections.map((s) => s.id)).toContain(defaultHelpSection);
+  });
+
+  it("every section advertises at least one host", () => {
+    for (const section of helpSections) {
+      expect(section.hosts.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("sectionsForHost", () => {
+  it("desktop sees the full set", () => {
+    expect(sectionsForHost("desktop").map((s) => s.id)).toEqual<HelpSectionId[]>([
+      "getting-started",
+      "writing",
+      "versions",
+      "library",
+      "export",
+      "shortcuts",
+      "settings",
+    ]);
+  });
+
+  it("web hides desktop-only sections (versions, library, settings)", () => {
+    expect(sectionsForHost("web").map((s) => s.id)).toEqual<HelpSectionId[]>([
+      "getting-started",
+      "writing",
+      "export",
+      "shortcuts",
+    ]);
+  });
+
+  it("the default section is visible to both hosts", () => {
+    expect(sectionsForHost("desktop").map((s) => s.id)).toContain(defaultHelpSection);
+    expect(sectionsForHost("web").map((s) => s.id)).toContain(defaultHelpSection);
+  });
+});
+
+describe("sortShortcuts", () => {
+  function entry(id: string, group: string): ShortcutEntry {
+    return { id, label: id, keys: "X", group };
+  }
+
+  it("orders entries by shortcutGroupOrder, preserving within-group input order", () => {
+    const input: ShortcutEntry[] = [
+      entry("help.toggle", "help"),
+      entry("file.save", "file"),
+      entry("format.bold", "format"),
+      entry("file.open", "file"),
+      entry("edit.find", "edit"),
+    ];
+    const sorted = sortShortcuts(input);
+    expect(sorted.map((s) => s.id)).toEqual([
+      "file.save",
+      "file.open",
+      "format.bold",
+      "help.toggle",
+      "edit.find",
+    ].sort((a, b) => {
+      // Verify against the documented ordering manually:
+      // file (save, open) → edit → format → help
+      const order = ["file.save", "file.open", "edit.find", "format.bold", "help.toggle"];
+      return order.indexOf(a) - order.indexOf(b);
+    }));
+  });
+
+  it("places unknown-group entries last", () => {
+    const input: ShortcutEntry[] = [
+      entry("custom.x", "mystery"),
+      entry("file.save", "file"),
+    ];
+    const sorted = sortShortcuts(input);
+    expect(sorted.map((s) => s.id)).toEqual(["file.save", "custom.x"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input: ShortcutEntry[] = [
+      entry("help.toggle", "help"),
+      entry("file.save", "file"),
+    ];
+    const before = [...input];
+    sortShortcuts(input);
+    expect(input).toEqual(before);
+  });
+});
+
+describe("shortcutGroupOrder", () => {
+  it("matches the native menu's left-to-right layout", () => {
+    expect(shortcutGroupOrder).toEqual([
+      "file",
+      "edit",
+      "view",
+      "navigate",
+      "insert",
+      "format",
+      "help",
+    ]);
+  });
+});

--- a/web/src/components/shared/Editor.vue
+++ b/web/src/components/shared/Editor.vue
@@ -22,6 +22,7 @@ import FindReplaceTab from './FindReplaceTab.vue';
 import OutlineTab from './OutlineTab.vue';
 import StatsTab from './StatsTab.vue';
 import HelpTab from './HelpTab.vue';
+import type { HelpHost, ShortcutEntry } from './help-sections';
 import { shortcuts as sc } from '../../core/platform';
 
 const props = withDefaults(
@@ -73,6 +74,13 @@ const props = withDefaults(
     // Wails-registered native menu fires the same actions at the OS
     // level — binding here too would either double-fire or be dead code.
     bindEngineAccelerators?: boolean;
+    // Host hint for the help drawer. Desktop = full sectioned help with
+    // the native-menu shortcut catalog; web = same sections, web-flavored
+    // prose, smaller shortcut list. Defaults to 'web' so existing test
+    // mounts and the web host keep working without passing it explicitly.
+    helpHost?: HelpHost;
+    helpShortcuts?: ShortcutEntry[];
+    helpShortcutsLoading?: boolean;
     getSpellAllowlist: () => string[];
     addSpellAllowlistWord: (word: string) => Promise<boolean>;
     removeSpellAllowlistWord: (word: string) => Promise<boolean>;
@@ -88,6 +96,9 @@ const props = withDefaults(
     drawerDock: 'bottom',
     drawerRightWidth: 360,
     bindEngineAccelerators: false,
+    helpHost: 'web',
+    helpShortcuts: () => [],
+    helpShortcutsLoading: false,
   },
 );
 
@@ -747,7 +758,12 @@ defineExpose({
                     <StatsTab :stats="manuscriptStats" :loading="manuscriptStatsLoading" />
                 </template>
                 <template #help>
-                    <HelpTab :open-link="props.env.openURL" />
+                    <HelpTab
+                        :open-link="props.env.openURL"
+                        :host="props.helpHost"
+                        :shortcuts="props.helpShortcuts"
+                        :shortcuts-loading="props.helpShortcutsLoading"
+                    />
                 </template>
             </WorkbenchDrawer>
         </div>

--- a/web/src/components/shared/HelpTab.vue
+++ b/web/src/components/shared/HelpTab.vue
@@ -1,164 +1,91 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import {
-  Type, Layout, Keyboard, ExternalLink,
-  Eye, ListTree, BarChart3, AlertTriangle, Search, SpellCheck, ScrollText,
-} from 'lucide-vue-next';
-import type { Component } from 'vue';
-import { shortcuts as sc } from '../../core/platform';
+  defaultHelpSection,
+  sectionsForHost,
+  type HelpHost,
+  type HelpSectionId,
+  type ShortcutEntry,
+} from './help-sections';
 
-const { openLink } = defineProps<{
-  openLink: (url: string) => Promise<void>;
-}>();
+const props = withDefaults(
+  defineProps<{
+    openLink: (url: string) => Promise<void>;
+    host?: HelpHost;
+    shortcuts?: ShortcutEntry[];
+    shortcutsLoading?: boolean;
+  }>(),
+  {
+    host: 'web',
+    shortcuts: () => [],
+    shortcutsLoading: false,
+  },
+);
 
-type HelpSection = 'syntax' | 'tools' | 'shortcuts';
-const activeSection = ref<HelpSection>('syntax');
-const sections: { id: HelpSection; icon: Component; label: string }[] = [
-  { id: 'syntax', icon: Type, label: 'Writing' },
-  { id: 'tools', icon: Layout, label: 'Tools' },
-  { id: 'shortcuts', icon: Keyboard, label: 'Shortcuts' },
-];
+const visibleSections = computed(() => sectionsForHost(props.host));
 
-const shortcutList = [
-  sc.bold, sc.italic, sc.underline,
-  sc.find, sc.findReplace,
-  sc.preview, sc.help,
-];
+const activeSection = ref<HelpSectionId>(defaultHelpSection);
 
-const tools: { icon: Component; name: string; desc: string }[] = [
-  { icon: Eye, name: 'Preview', desc: 'See the printed page beside your script.' },
-  { icon: ListTree, name: 'Outline', desc: 'Jump between acts, scenes, and characters.' },
-  { icon: BarChart3, name: 'Stats', desc: 'See word count, runtime estimate, and who speaks most.' },
-  { icon: AlertTriangle, name: 'Issues', desc: 'Catch typos, structural errors, and formatting mistakes.' },
-  { icon: Search, name: 'Find & Replace', desc: 'Search for a word or phrase, then replace it once or everywhere.' },
-  { icon: SpellCheck, name: 'Spell Check', desc: 'Underline misspellings and add names or terms to this script’s allowlist.' },
-  { icon: ScrollText, name: 'Manuscript / Acting Edition', desc: 'Switch between standard manuscript and a compact acting-edition layout.' },
-];
+// Keep activeSection valid against the current host's visible set. The
+// host prop can change (component re-mount in a new host) or the
+// registry can grow/shrink; in both cases fall back to the first
+// visible section so the content pane never goes blank.
+watch(
+  [visibleSections, activeSection],
+  ([visible, id]) => {
+    if (!visible.some((s) => s.id === id)) {
+      activeSection.value = visible[0]?.id ?? defaultHelpSection;
+    }
+  },
+  { immediate: true },
+);
+
+const currentSection = computed(() =>
+  visibleSections.value.find((s) => s.id === activeSection.value)
+    ?? visibleSections.value[0],
+);
 </script>
 
 <template>
-  <div class="flex h-full flex-col overflow-hidden">
-    <div class="flex items-center gap-1 border-b border-border px-4 py-1.5">
-      <button
-        v-for="section in sections"
-        :key="section.id"
-        class="flex items-center gap-1.5 rounded px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-[0.14em] transition-colors"
-        :class="activeSection === section.id
-          ? 'bg-brass-500/15 text-accent'
-          : 'text-text-muted hover:text-text-main hover:bg-black/5 dark:hover:bg-white/5'"
-        @click="activeSection = section.id"
+  <div class="flex h-full min-h-0 flex-col overflow-hidden @container">
+    <!-- Wide layout: left rail + content. Narrow (right-docked drawer at
+         ~360px): icon-only top strip + content. The @container threshold
+         mirrors HelpTab's pre-existing breakpoint usage. -->
+    <div class="flex min-h-0 flex-1 flex-col overflow-hidden @md:flex-row">
+      <nav
+        class="flex shrink-0 overflow-x-auto border-b border-border bg-[var(--color-toolbar-bg)]
+               @md:w-36 @md:flex-col @md:overflow-x-visible @md:overflow-y-auto @md:border-b-0 @md:border-r @md:py-2"
+        role="tablist"
+        aria-label="Help sections"
       >
-        <component :is="section.icon" class="h-3 w-3" />
-        {{ section.label }}
-      </button>
-    </div>
-
-    <!-- `@container` opts this scroll region into Tailwind v4 container
-         queries so the Writing-tab card grid tracks the drawer's width
-         (not the viewport). In the right-docked drawer at its default
-         360px the cards stack in one column; they spread to 2/3 cols
-         as the drawer widens or when docked at the bottom of the
-         editor pane. -->
-    <div class="@container flex-1 overflow-y-auto px-4 py-3">
-      <div v-if="activeSection === 'syntax'" class="space-y-3">
-        <p class="text-xs text-text-muted">
-          Downstage scripts are plain text. Write naturally. Structure does the work.
-        </p>
-        <dl class="grid gap-3 @md:grid-cols-2 @2xl:grid-cols-3">
-          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Title Page</dt>
-            <dd>
-              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code># My Play
-Subtitle: A Play in One Act
-Author: Your Name
-Draft: First</code></pre>
-            </dd>
-          </div>
-          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Dialogue</dt>
-            <dd>
-              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>ALICE
-I know this looks reckless.
-
-BOB
-(laughing)
-You always say that.</code></pre>
-            </dd>
-          </div>
-          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Stage Directions</dt>
-            <dd>
-              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>&gt; The lights cut to black.
-
-&gt; ALICE crosses to the bench
-&gt; and sits.</code></pre>
-            </dd>
-          </div>
-          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Acts &amp; Scenes</dt>
-            <dd>
-              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>## ACT I
-### SCENE 1</code></pre>
-            </dd>
-          </div>
-          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Formatting</dt>
-            <dd>
-              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>**bold**  *italic*
-_underline_  ~strikethrough~</code></pre>
-            </dd>
-          </div>
-          <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
-            <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Page Breaks &amp; Comments</dt>
-            <dd>
-              <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>===
-
-// Note to self: fix this</code></pre>
-            </dd>
-          </div>
-        </dl>
-        <p class="text-xs text-text-muted">
-          You don't need a title page to start. Just dialogue works too. See the
-          <button
-            class="font-bold text-brass-500 underline decoration-brass-500/40 underline-offset-2 hover:text-brass-400"
-            @click="openLink('https://www.getdownstage.com/syntax/')"
-          >
-            full Syntax Guide
-            <ExternalLink class="mb-0.5 inline h-3 w-3" />
-          </button>
-          for the full reference.
-        </p>
-      </div>
-
-      <div v-if="activeSection === 'tools'" class="space-y-1.5">
-        <p class="mb-2 text-xs text-text-muted">
-          All of these are in the toolbar above the editor.
-        </p>
-        <div
-          v-for="t in tools"
-          :key="t.name"
-          class="flex items-center gap-2.5 rounded-md bg-black/[0.03] px-3 py-2 dark:bg-white/[0.03]"
+        <button
+          v-for="section in visibleSections"
+          :key="section.id"
+          type="button"
+          role="tab"
+          :aria-selected="activeSection === section.id"
+          :title="section.label"
+          :aria-label="section.label"
+          class="flex items-center gap-2 px-2.5 py-2 text-[10px] font-bold uppercase tracking-[0.14em] transition-colors
+                 @md:justify-start @md:rounded-none @md:px-3 @md:py-1.5 @md:text-xs"
+          :class="activeSection === section.id
+            ? 'bg-brass-500/15 text-accent'
+            : 'text-text-muted hover:bg-black/5 hover:text-text-main dark:hover:bg-white/5'"
+          @click="activeSection = section.id"
         >
-          <component :is="t.icon" class="h-3.5 w-3.5 shrink-0 text-text-muted" />
-          <span>
-            <span class="text-xs font-bold text-text-main">{{ t.name }}</span>
-            <span class="ml-2 text-xs text-text-muted">{{ t.desc }}</span>
-          </span>
-        </div>
-      </div>
+          <component :is="section.icon" class="h-3.5 w-3.5 shrink-0" />
+          <span class="hidden normal-case tracking-normal @md:inline">{{ section.label }}</span>
+        </button>
+      </nav>
 
-      <div v-if="activeSection === 'shortcuts'" class="space-y-1.5">
-        <p class="mb-2 text-xs text-text-muted">
-          These are the keyboard shortcuts. Everything else lives in the toolbar.
-        </p>
-        <div
-          v-for="s in shortcutList"
-          :key="s.label"
-          class="flex items-center justify-between rounded-md bg-black/[0.03] px-3 py-2 dark:bg-white/[0.03]"
-        >
-          <span class="text-xs text-text-main">{{ s.label }}</span>
-          <kbd class="rounded border border-border bg-[var(--color-page-surface)] px-1.5 py-0.5 text-[10px] font-mono font-bold text-text-muted shadow-sm">{{ s.keys }}</kbd>
-        </div>
+      <div class="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+        <component
+          :is="currentSection.component"
+          :open-link="props.openLink"
+          :host="props.host"
+          :shortcuts="props.shortcuts"
+          :loading="props.shortcutsLoading"
+        />
       </div>
     </div>
   </div>

--- a/web/src/components/shared/WelcomeModal.vue
+++ b/web/src/components/shared/WelcomeModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import BaseModal from './BaseModal.vue';
 import { AlertTriangle, BookOpen, Download, HelpCircle } from 'lucide-vue-next';
+import { helpLinks } from '../../core/help-links';
 
 defineProps<{
   open: boolean;
@@ -63,7 +64,7 @@ const emit = defineEmits<{
               button in the toolbar for syntax, shortcuts, and editor features — or view the
               <a
                 class="font-bold text-brass-500 underline decoration-brass-500/40 underline-offset-2 hover:text-brass-400"
-                href="https://www.getdownstage.com/syntax/"
+                :href="helpLinks.syntax"
                 target="_blank"
                 rel="noreferrer"
               >

--- a/web/src/components/shared/help-sections.ts
+++ b/web/src/components/shared/help-sections.ts
@@ -1,0 +1,145 @@
+// Registry for the Help drawer's section navigator. Lives next to
+// HelpTab.vue as a sibling TS module (mirrors workbench-tabs.ts) so
+// pure-TS consumers can import the types without going through the
+// Vue SFC shim.
+
+import { defineAsyncComponent, type Component } from "vue";
+import type { LucideIcon } from "lucide-vue-next";
+import {
+  Sparkles, Type, History, FolderTree, Download, Keyboard, Settings as SettingsIcon,
+} from "lucide-vue-next";
+
+export type HelpHost = "desktop" | "web";
+
+export type HelpSectionId =
+  | "getting-started"
+  | "writing"
+  | "versions"
+  | "library"
+  | "export"
+  | "shortcuts"
+  | "settings";
+
+export interface HelpSection {
+  id: HelpSectionId;
+  label: string;
+  icon: LucideIcon;
+  component: Component;
+  // Hosts that render this section. Web hides sections whose only
+  // content is "this is a desktop feature" — they don't earn their
+  // tab slot on a build that can't use the feature.
+  hosts: ReadonlyArray<HelpHost>;
+}
+
+export interface ShortcutEntry {
+  id: string;
+  label: string;
+  keys: string;
+  group: string;
+}
+
+// Order matches the native menu (`internal/desktop/commands.go`) — file,
+// edit, view, navigate, insert, format, help. Library/Help-section
+// entries with unknown categories sort last (Number.MAX_SAFE_INTEGER
+// fallback in sortShortcuts).
+export const shortcutGroupOrder: ReadonlyArray<string> = [
+  "file",
+  "edit",
+  "view",
+  "navigate",
+  "insert",
+  "format",
+  "help",
+];
+
+// User-facing labels for the group headers. Same keys as
+// shortcutGroupOrder; missing keys fall through to a title-cased
+// default in the ShortcutsSection renderer.
+export const shortcutGroupLabel: Readonly<Record<string, string>> = {
+  file: "File",
+  edit: "Edit",
+  view: "View",
+  navigate: "Navigate",
+  insert: "Insert",
+  format: "Format",
+  help: "Help",
+};
+
+// Stable sort: first by group order, then preserve incoming order
+// within a group (the catalog already orders things the way the menu
+// presents them). Returns a new array; does not mutate input.
+export function sortShortcuts(entries: ShortcutEntry[]): ShortcutEntry[] {
+  const groupIndex = new Map<string, number>();
+  shortcutGroupOrder.forEach((g, i) => groupIndex.set(g, i));
+  const unknownRank = Number.MAX_SAFE_INTEGER;
+  return entries
+    .map((entry, originalIndex) => ({ entry, originalIndex }))
+    .sort((a, b) => {
+      const ga = groupIndex.get(a.entry.group) ?? unknownRank;
+      const gb = groupIndex.get(b.entry.group) ?? unknownRank;
+      if (ga !== gb) return ga - gb;
+      return a.originalIndex - b.originalIndex;
+    })
+    .map(({ entry }) => entry);
+}
+
+// Async-imported so the desktop-only-feature sections don't bloat the
+// web bundle on first paint. Vite resolves these paths at build time
+// against the help/ folder.
+export const helpSections: ReadonlyArray<HelpSection> = [
+  {
+    id: "getting-started",
+    label: "Getting Started",
+    icon: Sparkles,
+    component: defineAsyncComponent(() => import("./help/GettingStartedSection.vue")),
+    hosts: ["desktop", "web"],
+  },
+  {
+    id: "writing",
+    label: "Writing",
+    icon: Type,
+    component: defineAsyncComponent(() => import("./help/WritingSection.vue")),
+    hosts: ["desktop", "web"],
+  },
+  {
+    id: "versions",
+    label: "Versions",
+    icon: History,
+    component: defineAsyncComponent(() => import("./help/VersionsSection.vue")),
+    hosts: ["desktop"],
+  },
+  {
+    id: "library",
+    label: "Library",
+    icon: FolderTree,
+    component: defineAsyncComponent(() => import("./help/LibrarySection.vue")),
+    hosts: ["desktop"],
+  },
+  {
+    id: "export",
+    label: "Export",
+    icon: Download,
+    component: defineAsyncComponent(() => import("./help/ExportSection.vue")),
+    hosts: ["desktop", "web"],
+  },
+  {
+    id: "shortcuts",
+    label: "Shortcuts",
+    icon: Keyboard,
+    component: defineAsyncComponent(() => import("./help/ShortcutsSection.vue")),
+    hosts: ["desktop", "web"],
+  },
+  {
+    id: "settings",
+    label: "Settings",
+    icon: SettingsIcon,
+    component: defineAsyncComponent(() => import("./help/SettingsSection.vue")),
+    hosts: ["desktop"],
+  },
+];
+
+export function sectionsForHost(host: HelpHost): HelpSection[] {
+  return helpSections.filter((s) => s.hosts.includes(host));
+}
+
+export const defaultHelpSection: HelpSectionId = "getting-started";

--- a/web/src/components/shared/help/ExportSection.vue
+++ b/web/src/components/shared/help/ExportSection.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import type { HelpHost } from '../help-sections';
+
+defineProps<{
+  openLink: (url: string) => Promise<void>;
+  host: HelpHost;
+}>();
+</script>
+
+<template>
+  <div class="space-y-4 text-xs leading-relaxed text-text-muted">
+    <section class="space-y-2">
+      <h2 class="text-xs font-bold uppercase tracking-[0.14em] text-text-main">PDF export</h2>
+      <p v-if="host === 'desktop'">
+        Choose <strong class="text-text-main">File → Export → PDF…</strong> or press
+        <kbd class="rounded border border-border px-1 font-mono text-[10px]">Ctrl/⌘&shy;E</kbd> to open the export
+        dialog. Pick a page size (US Letter or A4), a layout (single-sided
+        manuscript or folded booklet), and a style (Manuscript or Acting
+        Edition). Your last choices are remembered, so re-exporting after a
+        small edit takes a single keystroke.
+      </p>
+      <p v-else>
+        Click <strong class="text-text-main">Export to PDF</strong> in the toolbar
+        to render the script in the browser. Pick a page size and style; the PDF
+        downloads to wherever your browser normally puts downloads.
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Manuscript vs. Acting Edition</h3>
+      <p>
+        <strong class="text-text-main">Manuscript</strong> is the full-page
+        layout you would send to a literary manager or include in a submission.
+        Generous margins, dialogue centered on the page.
+      </p>
+      <p>
+        <strong class="text-text-main">Acting Edition</strong> is the compact
+        layout you would hand to a cast. Tighter line spacing and character
+        cues in the margin, designed to be read from a music stand.
+      </p>
+    </section>
+
+    <section v-if="host === 'desktop'" class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Booklet layout</h3>
+      <p>
+        Booklet mode prints two reading pages on each physical sheet, in the
+        order needed to fold the stack in half and bind it down the spine. The
+        gutter (the extra space along the inner edge) is adjustable in the
+        export dialog, so the binding does not eat into your inner margin.
+      </p>
+    </section>
+
+    <section v-if="host === 'desktop'" class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Exporting the .ds source</h3>
+      <p>
+        Choose <strong class="text-text-main">File → Export → Downstage File…</strong>
+        to save a copy of the raw <code class="rounded bg-black/5 px-1 dark:bg-white/5">.ds</code> text file. Use this
+        to send the source to a collaborator who also uses Downstage, or to keep
+        a snapshot of the script outside your library folder.
+      </p>
+    </section>
+
+    <p class="text-text-muted/80">
+      The exported PDF uses the same renderer as the live preview. What you see
+      in the preview pane is what lands on the page.
+    </p>
+  </div>
+</template>

--- a/web/src/components/shared/help/GettingStartedSection.vue
+++ b/web/src/components/shared/help/GettingStartedSection.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { ExternalLink } from 'lucide-vue-next';
+import type { HelpHost } from '../help-sections';
+import { helpLinks } from '../../../core/help-links';
+
+defineProps<{
+  openLink: (url: string) => Promise<void>;
+  host: HelpHost;
+}>();
+</script>
+
+<template>
+  <div class="space-y-4 text-xs leading-relaxed text-text-muted">
+    <section class="space-y-2">
+      <h2 class="text-xs font-bold uppercase tracking-[0.14em] text-text-main">Welcome to Downstage</h2>
+      <p>
+        Downstage is a plain-text writing tool for plays and musicals. A script is
+        just a text file. Acts, scenes, dialogue, and stage directions follow a
+        handful of conventions you can learn in a few minutes.
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">The editor</h3>
+      <p>
+        The large text area on the left is where you write. Type the way you'd
+        type any document. The preview on the right updates to show the page as it
+        will print. To give the script your full attention, hide the preview with
+        the eye icon or
+        <kbd class="rounded border border-border px-1 font-mono text-[10px]">Ctrl/⌘\</kbd>.
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Where your work lives</h3>
+      <p v-if="host === 'desktop'">
+        Downstage Write reads from a <em>library folder</em> on your disk. The
+        file list on the left shows every <code class="rounded bg-black/5 px-1 dark:bg-white/5">.ds</code> file inside.
+        Saved versions of each file are kept in a hidden
+        <code class="rounded bg-black/5 px-1 dark:bg-white/5">.downstage/</code> folder next to your scripts. Your work
+        stays on your machine, in files you can read and back up yourself.
+      </p>
+      <p v-else>
+        The browser editor keeps drafts in your browser's local storage. That's
+        fine for a quick page, but anything that clears site data (incognito
+        windows, browser cleanups) will wipe them. For real work, install
+        <strong class="text-text-main">Downstage Write</strong>, the desktop app.
+        Same editor, but your scripts live in a folder on your disk, with saved
+        versions kept alongside them.
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Where to look next</h3>
+      <ul class="ml-4 list-disc space-y-1">
+        <li><strong class="text-text-main">Writing</strong>. A cheat sheet for dialogue, stage directions, and headings.</li>
+        <li v-if="host === 'desktop'"><strong class="text-text-main">Versions</strong>. How to save named snapshots of a script and roll back to one.</li>
+        <li v-if="host === 'desktop'"><strong class="text-text-main">Library</strong>. Organizing files into folders and opening scripts from elsewhere on disk.</li>
+        <li><strong class="text-text-main">Export</strong>. PDF for readings and submissions, <code class="rounded bg-black/5 px-1 dark:bg-white/5">.ds</code> for handing the source to another Downstage user.</li>
+        <li><strong class="text-text-main">Shortcuts</strong>. Every keyboard shortcut in one list.</li>
+      </ul>
+    </section>
+
+    <p>
+      The full syntax reference lives at
+      <button
+        class="font-bold text-brass-500 underline decoration-brass-500/40 underline-offset-2 hover:text-brass-400"
+        @click="openLink(helpLinks.syntax)"
+      >
+        getdownstage.com/syntax
+        <ExternalLink class="mb-0.5 inline h-3 w-3" />
+      </button>.
+    </p>
+  </div>
+</template>

--- a/web/src/components/shared/help/GettingStartedSection.vue
+++ b/web/src/components/shared/help/GettingStartedSection.vue
@@ -41,9 +41,10 @@ defineProps<{
         stays on your machine, in files you can read and back up yourself.
       </p>
       <p v-else>
-        The browser editor keeps drafts in your browser's local storage. That's
-        fine for a quick page, but anything that clears site data (incognito
-        windows, browser cleanups) will wipe them. For real work, install
+        The browser editor keeps drafts in your browser's local storage. Good
+        for trying things out or jotting a scene, but anything that clears
+        site data (incognito windows, browser cleanups) will wipe them. For
+        a script you plan to keep, install
         <strong class="text-text-main">Downstage Write</strong>, the desktop app.
         Same editor, but your scripts live in a folder on your disk, with saved
         versions kept alongside them.

--- a/web/src/components/shared/help/LibrarySection.vue
+++ b/web/src/components/shared/help/LibrarySection.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import type { HelpHost } from '../help-sections';
+
+defineProps<{
+  openLink: (url: string) => Promise<void>;
+  host: HelpHost;
+}>();
+</script>
+
+<template>
+  <div class="space-y-4 text-xs leading-relaxed text-text-muted">
+    <section class="space-y-2">
+      <h2 class="text-xs font-bold uppercase tracking-[0.14em] text-text-main">The library folder</h2>
+      <p>
+        Your library is a single folder on your disk. Every
+        <code class="rounded bg-black/5 px-1 dark:bg-white/5">.ds</code> file inside it appears in the file list on
+        the left. The first time you open Downstage Write, it asks you to pick
+        that folder. Point it at a folder of scripts you already have, or create
+        an empty one and start fresh. You can switch to a different library later
+        from <strong class="text-text-main">Settings → Library</strong>.
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Folders and organization</h3>
+      <p>
+        Right-click a folder in the file list to add a sub-folder inside it.
+        Drag a script onto a folder to move it there. Right-click a script to
+        rename it. A folder disappears from the list once its last file moves
+        out.
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Opening scripts from outside your library</h3>
+      <p>
+        Choose <strong class="text-text-main">File → Open…</strong> to read a
+        <code class="rounded bg-black/5 px-1 dark:bg-white/5">.ds</code> file from anywhere on disk, useful when a
+        collaborator emails you a script. Files opened this way are read-only.
+        Click <strong class="text-text-main">Add to Library</strong> in the banner
+        across the top of the editor to copy the script into your library so you
+        can edit it.
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">The hidden .downstage folder</h3>
+      <p>
+        Downstage keeps version history and per-script spellcheck words in a
+        hidden <code class="rounded bg-black/5 px-1 dark:bg-white/5">.downstage/</code> folder inside your library.
+        Leave it alone. The app reads and writes it for you.
+      </p>
+    </section>
+  </div>
+</template>

--- a/web/src/components/shared/help/LibrarySection.vue
+++ b/web/src/components/shared/help/LibrarySection.vue
@@ -26,8 +26,39 @@ defineProps<{
       <p>
         Right-click a folder in the file list to add a sub-folder inside it.
         Drag a script onto a folder to move it there. Right-click a script to
-        rename it. A folder disappears from the list once its last file moves
-        out.
+        rename it or delete it. A folder disappears from the list once its
+        last file moves out.
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Deleting and restoring scripts</h3>
+      <p>
+        Right-click a script and choose <strong class="text-text-main">Delete…</strong>
+        to remove it from your library. Deleted scripts move to a
+        <strong class="text-text-main">Deleted</strong> section at the bottom
+        of the file list, shown with strikethrough. Right-click any row there
+        to <strong class="text-text-main">Restore from last version</strong>
+        (the file comes back at its most recent saved state) or
+        <strong class="text-text-main">Permanently delete</strong> (gone for
+        good, can't be undone from inside the app).
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Review Library Changes</h3>
+      <p>
+        When other files in your library have changes that haven't been
+        snapshotted yet, the status bar at the bottom of the window shows
+        <strong class="text-text-main">N uncommitted</strong> in amber. Click
+        it to open <strong class="text-text-main">Review Library Changes</strong>,
+        which groups the drift into <em>Plays</em> (your scripts),
+        <em>Library settings</em> (Downstage's own bookkeeping), and
+        <em>Other</em>. Commit or discard rows individually, or use
+        <strong class="text-text-main">Commit all</strong> /
+        <strong class="text-text-main">Discard all</strong> per section.
+        This is also where scripts that were edited outside Downstage show
+        up so you can fold them into history.
       </p>
     </section>
 

--- a/web/src/components/shared/help/SettingsSection.vue
+++ b/web/src/components/shared/help/SettingsSection.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import type { HelpHost } from '../help-sections';
+
+defineProps<{
+  openLink: (url: string) => Promise<void>;
+  host: HelpHost;
+}>();
+</script>
+
+<template>
+  <div class="space-y-4 text-xs leading-relaxed text-text-muted">
+    <section class="space-y-2">
+      <h2 class="text-xs font-bold uppercase tracking-[0.14em] text-text-main">Settings</h2>
+      <p>
+        Open <strong class="text-text-main">File → Settings…</strong> (or press
+        <kbd class="rounded border border-border px-1 font-mono text-[10px]">Ctrl/⌘&shy;,</kbd>) to open the
+        preferences window. It has four tabs.
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Library</h3>
+      <p>
+        Shows which folder is currently your library. Click
+        <strong class="text-text-main">Change…</strong> to point Downstage at a
+        different folder; the editor reloads and opens the first script in the
+        new library. This is the only place to switch libraries.
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Appearance</h3>
+      <p>
+        Switch between the light and dark themes. Your choice is saved with the
+        rest of your preferences and persists across restarts.
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Export</h3>
+      <p>
+        Defaults for the PDF export dialog: page size, style, layout, and
+        booklet gutter. These set what the dialog opens with. You can still
+        change any of them on a single export without changing the defaults.
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Spellcheck</h3>
+      <p>
+        Turn spellcheck on or off, and review the dictionary of words you've
+        added for the current script. Words you added by right-clicking and
+        choosing <em>Add to Dictionary</em> appear here, and you can remove any
+        you no longer want.
+      </p>
+    </section>
+
+    <p>
+      Quick toggles like showing the preview or the sidebar don't live in
+      Settings. They have their own buttons in the toolbar and on the sidebar
+      header.
+    </p>
+  </div>
+</template>

--- a/web/src/components/shared/help/ShortcutsSection.vue
+++ b/web/src/components/shared/help/ShortcutsSection.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Loader2 } from 'lucide-vue-next';
+import type { HelpHost, ShortcutEntry } from '../help-sections';
+import { shortcutGroupLabel, shortcutGroupOrder, sortShortcuts } from '../help-sections';
+
+const { shortcuts, loading = false } = defineProps<{
+  openLink: (url: string) => Promise<void>;
+  host: HelpHost;
+  shortcuts: ShortcutEntry[];
+  loading?: boolean;
+}>();
+
+const grouped = computed(() => {
+  const sorted = sortShortcuts([...shortcuts]);
+  const groups = new Map<string, ShortcutEntry[]>();
+  for (const entry of sorted) {
+    const bucket = groups.get(entry.group);
+    if (bucket) bucket.push(entry);
+    else groups.set(entry.group, [entry]);
+  }
+  const orderedKeys = [
+    ...shortcutGroupOrder.filter((g) => groups.has(g)),
+    ...Array.from(groups.keys()).filter((g) => !shortcutGroupOrder.includes(g)),
+  ];
+  return orderedKeys.map((key) => ({
+    key,
+    label: shortcutGroupLabel[key] ?? titleCase(key),
+    entries: groups.get(key) ?? [],
+  }));
+});
+
+function titleCase(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+</script>
+
+<template>
+  <div class="space-y-3">
+    <p class="text-xs text-text-muted">
+      <template v-if="host === 'desktop'">
+        These shortcuts mirror the native menu. Pressing the keys does the same thing as choosing the menu item.
+      </template>
+      <template v-else>
+        These shortcuts work in the browser editor. The desktop app adds many more.
+      </template>
+    </p>
+
+    <div
+      v-if="loading"
+      class="flex items-center gap-2 rounded-md bg-black/[0.03] px-3 py-3 text-xs text-text-muted dark:bg-white/[0.03]"
+    >
+      <Loader2 class="h-3.5 w-3.5 animate-spin" />
+      Loading shortcuts…
+    </div>
+
+    <div
+      v-else-if="grouped.length === 0"
+      class="rounded-md border border-dashed border-border px-3 py-3 text-xs text-text-muted"
+    >
+      Shortcut list unavailable.
+    </div>
+
+    <template v-else>
+      <section v-for="g in grouped" :key="g.key" class="space-y-1.5">
+        <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">{{ g.label }}</h3>
+        <div
+          v-for="s in g.entries"
+          :key="s.id"
+          class="flex items-center justify-between gap-3 rounded-md bg-black/[0.03] px-3 py-2 dark:bg-white/[0.03]"
+        >
+          <span class="text-xs text-text-main">{{ s.label }}</span>
+          <kbd class="rounded border border-border bg-[var(--color-page-surface)] px-1.5 py-0.5 text-[10px] font-mono font-bold text-text-muted shadow-sm">{{ s.keys }}</kbd>
+        </div>
+      </section>
+    </template>
+  </div>
+</template>

--- a/web/src/components/shared/help/VersionsSection.vue
+++ b/web/src/components/shared/help/VersionsSection.vue
@@ -29,7 +29,10 @@ defineProps<{
       </p>
       <p>
         The autosave that runs as you type does <em>not</em> create a version.
-        Versions are only made when you ask for one.
+        Versions are only made when you ask for one. To snapshot changes
+        across several files at once (for example after editing scripts
+        outside the app), use <strong class="text-text-main">Review Library
+        Changes</strong> from the status bar — see the Library section.
       </p>
     </section>
 

--- a/web/src/components/shared/help/VersionsSection.vue
+++ b/web/src/components/shared/help/VersionsSection.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import type { HelpHost } from '../help-sections';
+
+defineProps<{
+  openLink: (url: string) => Promise<void>;
+  host: HelpHost;
+}>();
+</script>
+
+<template>
+  <div class="space-y-4 text-xs leading-relaxed text-text-muted">
+    <section class="space-y-2">
+      <h2 class="text-xs font-bold uppercase tracking-[0.14em] text-text-main">What versions are</h2>
+      <p>
+        A version is a named snapshot of one script at a point in time. Save one
+        before a big rewrite, and you can come back to it later. Each script has
+        its own history. Saving a version for one file does not touch any other
+        file in your library.
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Save a version</h3>
+      <p>
+        Choose <strong class="text-text-main">File → Save Version…</strong> or
+        press <kbd class="rounded border border-border px-1 font-mono text-[10px]">Ctrl/⌘&shy;⇧S</kbd>.
+        Downstage asks for a short label so you can recognize it later. Something
+        like "end of act II rewrite" or "before cutting the duet" works well.
+      </p>
+      <p>
+        The autosave that runs as you type does <em>not</em> create a version.
+        Versions are only made when you ask for one.
+      </p>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Browse and compare</h3>
+      <p>
+        Open the <strong class="text-text-main">Versions</strong> list from the
+        sidebar header to see every saved snapshot of the current script. Click a
+        row to open that snapshot in the editor (read-only, so you can't edit
+        history by accident). The menu on the right of each row lets you:
+      </p>
+      <ul class="ml-4 list-disc space-y-1">
+        <li><strong class="text-text-main">Compare with current</strong>. Show this snapshot side by side with what's in the editor now.</li>
+        <li><strong class="text-text-main">Compare with another version</strong>. Pick a second row to compare against.</li>
+        <li><strong class="text-text-main">Restore</strong>. Replace the live script with this snapshot. Downstage saves a version of the current state first, so the work you're about to overwrite is not lost.</li>
+        <li><strong class="text-text-main">Hide</strong>. Collapse a noisy version out of the list. It is still saved. Unhide it from the filter menu at the top of the panel.</li>
+      </ul>
+    </section>
+
+    <section class="space-y-2">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Where versions are stored</h3>
+      <p>
+        Versions live in a hidden
+        <code class="rounded bg-black/5 px-1 dark:bg-white/5">.downstage/</code> folder inside your library. Under the
+        hood it's a standard Git repository, so if you're comfortable with Git you
+        can back it up to GitHub or another remote from a terminal. Built-in sync
+        is on the roadmap.
+      </p>
+    </section>
+  </div>
+</template>

--- a/web/src/components/shared/help/WritingSection.vue
+++ b/web/src/components/shared/help/WritingSection.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { ExternalLink, Bold, Italic, Underline, MessageSquare, ChevronRight, GalleryVerticalEnd, GalleryVertical, Music, FilePlus2, Eye, ListTree, BarChart3, AlertTriangle, Search, SpellCheck, ScrollText } from 'lucide-vue-next';
+import type { Component } from 'vue';
+import { helpLinks } from '../../../core/help-links';
+
+defineProps<{
+  openLink: (url: string) => Promise<void>;
+}>();
+
+const formatTools: { icon: Component; name: string; desc: string }[] = [
+  { icon: Bold, name: 'Bold', desc: 'Wrap the selection in **double stars**.' },
+  { icon: Italic, name: 'Italic', desc: 'Wrap the selection in *single stars*.' },
+  { icon: Underline, name: 'Underline', desc: 'Wrap the selection in _underscores_.' },
+  { icon: MessageSquare, name: 'Dialogue', desc: 'Start a new speech with a CHARACTER cue above your cursor.' },
+  { icon: ChevronRight, name: 'Stage Direction', desc: 'Add `>` to the start of the line to mark it as a stage direction.' },
+  { icon: GalleryVerticalEnd, name: 'Act Heading', desc: 'Insert `## ACT N` to begin a new act.' },
+  { icon: GalleryVertical, name: 'Scene Heading', desc: 'Insert `### SCENE N` to begin a new scene.' },
+  { icon: Music, name: 'Song Block', desc: 'Wrap lyrics in `SONG` / `SONG END` so they render as a song.' },
+  { icon: FilePlus2, name: 'Page Break', desc: 'Insert `===` to force a new page in the printed manuscript.' },
+];
+
+const workbenchTools: { icon: Component; name: string; desc: string }[] = [
+  { icon: Eye, name: 'Preview', desc: 'Show or hide the rendered page beside your script.' },
+  { icon: ListTree, name: 'Outline', desc: 'Jump to any act, scene, or character in the script.' },
+  { icon: BarChart3, name: 'Stats', desc: 'Word count, estimated running time, and lines per character.' },
+  { icon: AlertTriangle, name: 'Issues', desc: 'Flags typos, broken structure, and formatting mistakes as you write.' },
+  { icon: Search, name: 'Find & Replace', desc: 'Search for a phrase and replace it one match at a time or all at once.' },
+  { icon: SpellCheck, name: 'Spell Check', desc: 'Underlines misspellings. Right-click to add a character name to this script\'s dictionary.' },
+  { icon: ScrollText, name: 'Manuscript / Acting Edition', desc: 'Switch the preview between the full-page manuscript and the compact acting edition.' },
+];
+</script>
+
+<template>
+  <div class="space-y-4">
+    <p class="text-xs text-text-muted">
+      A Downstage script is plain text. Type the way a script reads, and the
+      structure falls out of a few conventions.
+    </p>
+
+    <dl class="grid gap-3 @md:grid-cols-2 @2xl:grid-cols-3">
+      <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+        <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Title Page</dt>
+        <dd>
+          <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code># My Play
+Subtitle: A Play in One Act
+Author: Your Name
+Draft: First</code></pre>
+        </dd>
+      </div>
+      <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+        <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Dialogue</dt>
+        <dd>
+          <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>ALICE
+I know this looks reckless.
+
+BOB
+(laughing)
+You always say that.</code></pre>
+        </dd>
+      </div>
+      <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+        <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Stage Directions</dt>
+        <dd>
+          <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>&gt; The lights cut to black.
+
+&gt; ALICE crosses to the bench
+&gt; and sits.</code></pre>
+        </dd>
+      </div>
+      <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+        <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Acts &amp; Scenes</dt>
+        <dd>
+          <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>## ACT I
+### SCENE 1</code></pre>
+        </dd>
+      </div>
+      <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+        <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Formatting</dt>
+        <dd>
+          <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>**bold**  *italic*
+_underline_  ~strikethrough~</code></pre>
+        </dd>
+      </div>
+      <div class="rounded-lg border border-border bg-black/5 p-3 dark:bg-white/5">
+        <dt class="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-text-main">Page Breaks &amp; Comments</dt>
+        <dd>
+          <pre class="overflow-x-auto text-xs leading-relaxed text-text-muted"><code>===
+
+// Note to self: fix this</code></pre>
+        </dd>
+      </div>
+    </dl>
+
+    <p class="text-xs text-text-muted">
+      A title page is optional. A file containing nothing but dialogue is a
+      valid script. For the full reference, read the
+      <button
+        class="font-bold text-brass-500 underline decoration-brass-500/40 underline-offset-2 hover:text-brass-400"
+        @click="openLink(helpLinks.syntax)"
+      >
+        Syntax Guide
+        <ExternalLink class="mb-0.5 inline h-3 w-3" />
+      </button>.
+    </p>
+
+    <section class="space-y-2 border-t border-border pt-3">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Formatting buttons</h3>
+      <div
+        v-for="t in formatTools"
+        :key="t.name"
+        class="flex items-center gap-2.5 rounded-md bg-black/[0.03] px-3 py-2 dark:bg-white/[0.03]"
+      >
+        <component :is="t.icon" class="h-3.5 w-3.5 shrink-0 text-text-muted" />
+        <span>
+          <span class="text-xs font-bold text-text-main">{{ t.name }}</span>
+          <span class="ml-2 text-xs text-text-muted">{{ t.desc }}</span>
+        </span>
+      </div>
+    </section>
+
+    <section class="space-y-2 border-t border-border pt-3">
+      <h3 class="text-[10px] font-bold uppercase tracking-[0.14em] text-text-main">Workbench</h3>
+      <div
+        v-for="t in workbenchTools"
+        :key="t.name"
+        class="flex items-center gap-2.5 rounded-md bg-black/[0.03] px-3 py-2 dark:bg-white/[0.03]"
+      >
+        <component :is="t.icon" class="h-3.5 w-3.5 shrink-0 text-text-muted" />
+        <span>
+          <span class="text-xs font-bold text-text-main">{{ t.name }}</span>
+          <span class="ml-2 text-xs text-text-muted">{{ t.desc }}</span>
+        </span>
+      </div>
+    </section>
+  </div>
+</template>

--- a/web/src/core/accelerators.ts
+++ b/web/src/core/accelerators.ts
@@ -1,0 +1,96 @@
+// Format the menu-catalog accelerator strings emitted by
+// `internal/desktop/commands.go` (e.g. `cmdorctrl+shift+/`,
+// `cmdorctrl+optionoralt+f`) into the user-facing keystroke string used
+// in toolbars, palettes, and the help drawer (`⌘⇧/` on macOS,
+// `Ctrl+Shift+/` elsewhere).
+//
+// Leaf module: must not import from `platform.ts`. `platform.ts` imports
+// this module to derive its own `shortcuts` map, so any reverse
+// dependency would create a cycle.
+
+export interface FormatAcceleratorOptions {
+  isMac?: boolean;
+}
+
+const MAC_SYMBOL: Record<string, string> = {
+  cmdorctrl: "⌘",
+  shift: "⇧",
+  optionoralt: "⌥",
+  option: "⌥",
+  alt: "⌥",
+  ctrl: "⌃",
+  control: "⌃",
+  enter: "⏎",
+  return: "⏎",
+  escape: "Esc",
+  esc: "Esc",
+  tab: "⇥",
+  space: "Space",
+  arrowup: "↑",
+  arrowdown: "↓",
+  arrowleft: "←",
+  arrowright: "→",
+  backspace: "⌫",
+  delete: "⌦",
+};
+
+const NON_MAC_LABEL: Record<string, string> = {
+  cmdorctrl: "Ctrl",
+  shift: "Shift",
+  optionoralt: "Alt",
+  option: "Alt",
+  alt: "Alt",
+  ctrl: "Ctrl",
+  control: "Ctrl",
+  enter: "Enter",
+  return: "Enter",
+  escape: "Esc",
+  esc: "Esc",
+  tab: "Tab",
+  space: "Space",
+  arrowup: "Up",
+  arrowdown: "Down",
+  arrowleft: "Left",
+  arrowright: "Right",
+  backspace: "Backspace",
+  delete: "Delete",
+};
+
+// Guarded so Vitest / SSR / any Node import path doesn't blow up on
+// missing `navigator`. Matches the existing pattern in
+// `core/platform.ts`.
+const defaultIsMac =
+  typeof navigator !== "undefined" &&
+  /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+
+export function formatAccelerator(
+  raw: string,
+  opts: FormatAcceleratorOptions = {},
+): string {
+  if (!raw) return "";
+  const isMac = opts.isMac ?? defaultIsMac;
+  const parts = raw
+    .split("+")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+  if (parts.length === 0) return "";
+
+  const rendered = parts.map((part) => renderPart(part, isMac));
+  return isMac ? rendered.join("") : rendered.join("+");
+}
+
+function renderPart(part: string, isMac: boolean): string {
+  const lookup = part.toLowerCase();
+  const table = isMac ? MAC_SYMBOL : NON_MAC_LABEL;
+  if (lookup in table) {
+    return table[lookup];
+  }
+  // Single-character keys (letters, digits, punctuation): uppercase
+  // on both platforms so `b` and `/` render as `B` and `/`.
+  if (part.length === 1) {
+    return part.toUpperCase();
+  }
+  // Multi-char passthrough (function keys F1-F12, named keys we
+  // haven't mapped). Capitalize first letter for readability.
+  return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+}

--- a/web/src/core/engine.ts
+++ b/web/src/core/engine.ts
@@ -152,7 +152,7 @@ export class Engine {
           { key: "Mod-i", preventDefault: true, run: () => { acc.applyFormat("italic"); return true; } },
           { key: "Mod-u", preventDefault: true, run: () => { acc.applyFormat("underline"); return true; } },
           { key: "Mod-\\", preventDefault: true, run: () => { acc.togglePreview(); return true; } },
-          { key: "Mod-Shift-/", preventDefault: true, run: () => { acc.toggleHelp(); return true; } },
+          { key: "Mod-?", preventDefault: true, run: () => { acc.toggleHelp(); return true; } },
         ])
       : keymap.of([]);
 

--- a/web/src/core/help-links.ts
+++ b/web/src/core/help-links.ts
@@ -1,0 +1,10 @@
+// Single source of truth for the external URLs the help surface points
+// at. Sites that opened these as inline string literals
+// (AppWeb.vue, WelcomeModal.vue, HelpTab.vue, desktop/commands.ts) now
+// read from here so a URL change lands in one diff, not five.
+
+export const helpLinks = {
+  syntax: "https://www.getdownstage.com/syntax/",
+  docs: "https://getdownstage.com/docs",
+  github: "https://github.com/jscaltreto/downstage",
+} as const;

--- a/web/src/core/platform.ts
+++ b/web/src/core/platform.ts
@@ -1,10 +1,8 @@
+import { formatAccelerator } from "./accelerators";
+
 export const isMac =
   typeof navigator !== "undefined" &&
   /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
-
-const mod = isMac ? "\u2318" : "Ctrl";
-const shift = isMac ? "\u21E7" : "Shift";
-const alt = isMac ? "\u2325" : "Alt";
 
 export interface Shortcut {
   label: string;
@@ -12,16 +10,17 @@ export interface Shortcut {
   tooltip: string;
 }
 
-function formatKeys(parts: string[]): string {
-  return isMac ? parts.join("") : parts.join("+");
+function shortcut(label: string, raw: string, tooltipLabel?: string): Shortcut {
+  const keys = formatAccelerator(raw, { isMac });
+  return { label, keys, tooltip: `${tooltipLabel ?? label} (${keys})` };
 }
 
 export const shortcuts: Record<string, Shortcut> = {
-  bold:        { label: "Bold",                keys: formatKeys([mod, "B"]),        tooltip: `Bold (${formatKeys([mod, "B"])})` },
-  italic:      { label: "Italic",              keys: formatKeys([mod, "I"]),        tooltip: `Italic (${formatKeys([mod, "I"])})` },
-  underline:   { label: "Underline",           keys: formatKeys([mod, "U"]),        tooltip: `Underline (${formatKeys([mod, "U"])})` },
-  find:        { label: "Find",                keys: formatKeys([mod, "F"]),        tooltip: `Find (${formatKeys([mod, "F"])})` },
-  findReplace: { label: "Find & Replace",      keys: formatKeys([mod, alt, "F"]),   tooltip: `Find & Replace (${formatKeys([mod, alt, "F"])})` },
-  preview:     { label: "Show / Hide Preview", keys: formatKeys([mod, "\\"]),       tooltip: `Toggle Preview (${formatKeys([mod, "\\"])})` },
-  help:        { label: "Help",                keys: formatKeys([mod, shift, "/"]), tooltip: `Help (${formatKeys([mod, shift, "/"])})` },
+  bold:        shortcut("Bold",                "cmdorctrl+b"),
+  italic:      shortcut("Italic",              "cmdorctrl+i"),
+  underline:   shortcut("Underline",           "cmdorctrl+u"),
+  find:        shortcut("Find",                "cmdorctrl+f"),
+  findReplace: shortcut("Find & Replace",      "cmdorctrl+optionoralt+f"),
+  preview:     shortcut("Show / Hide Preview", "cmdorctrl+\\", "Toggle Preview"),
+  help:        shortcut("Help",                "cmdorctrl+shift+/"),
 };

--- a/web/src/desktop/commands.ts
+++ b/web/src/desktop/commands.ts
@@ -249,7 +249,7 @@ export function createCommandHandlers(ctx: CommandContext): Array<[string, Handl
       isEnabled: () => (workspace.state.libraryDirty?.count ?? 0) > 0,
     }],
 
-    ["help.toggle", { handler: () => toggleDrawerTab("help"), isEnabled: hasActiveFile }],
+    ["help.toggle", { handler: () => toggleDrawerTab("help") }],
     ["help.github", { handler: () => env.openURL(helpLinks.github) }],
     ["help.docs", { handler: () => env.openURL(helpLinks.docs) }],
     ["help.about", { handler: () => env.showAboutDialog() }],

--- a/web/src/desktop/commands.ts
+++ b/web/src/desktop/commands.ts
@@ -4,6 +4,7 @@ import type { Workspace } from "./workspace";
 import type { DesktopCapabilities } from "./types";
 import type { HandlerEntry } from "./command-dispatcher";
 import type { WorkbenchTab } from "../components/shared/workbench-tabs";
+import { helpLinks } from "../core/help-links";
 import type { SearchMode } from "../core/engine";
 
 export interface CommandContext {
@@ -249,8 +250,8 @@ export function createCommandHandlers(ctx: CommandContext): Array<[string, Handl
     }],
 
     ["help.toggle", { handler: () => toggleDrawerTab("help"), isEnabled: hasActiveFile }],
-    ["help.github", { handler: () => env.openURL("https://github.com/jscaltreto/downstage") }],
-    ["help.docs", { handler: () => env.openURL("https://getdownstage.com/docs") }],
+    ["help.github", { handler: () => env.openURL(helpLinks.github) }],
+    ["help.docs", { handler: () => env.openURL(helpLinks.docs) }],
     ["help.about", { handler: () => env.showAboutDialog() }],
   ];
 }


### PR DESCRIPTION
## Summary

- Rebuild the Help drawer from its three-section stub (Writing / Tools / Shortcuts) into a registry-driven, sectioned interface: Getting Started, Writing, Versions, Library, Export, Shortcuts, Settings. Versions/Library/Settings are filtered out on the web host since the underlying features don't exist there.
- Desktop shortcuts are sourced from `env.getCommands()` so the list stays in lockstep with the native menu; a shared `core/accelerators.ts` formats catalog tokens (`cmdorctrl+shift+/`) into the mac or non-mac display form, and `core/platform.ts` now delegates to it. Web ships a static seven-entry list.
- New `core/help-links.ts` centralises the three external URLs (`syntax`, `docs`, `github`) that were previously hard-coded inline in `AppWeb.vue`, `WelcomeModal.vue`, and `desktop/commands.ts`.
- Library and Versions copy reflect Track A2 (#216): right-click Delete…, the Deleted section with Restore / Permanently delete, and the library-wide Review Library Changes modal reached from the status bar.

Closes Track B of #189. Section components are lazy-loaded via `defineAsyncComponent` so desktop-only panes stay out of the initial web chunk. Entry points (toolbar HelpCircle button, `Cmd-Shift-/`) are unchanged.

## Test plan

- [x] `npm run typecheck` (in `web/`) — clean.
- [x] `npm run test -- --run` — 256/256 passing. New tests: `accelerators.test.ts`, `help-sections.test.ts`, `HelpTab.test.ts`, `ShortcutsSection.test.ts`.
- [ ] Manual desktop smoke: `make desktop-build`, run binary, `Cmd-Shift-/`, click through every section in both bottom-dock and right-dock at 360px and 480px. Confirm external-link buttons open via Wails `openURL`, Shortcuts section lists every native-menu accelerator, no console errors on tab switching.
- [ ] Manual web smoke: `npm run dev -w web`, `Cmd-Shift-/`, confirm only the four cross-host sections render and copy reads correctly.